### PR TITLE
(SERVER-85) Sync CA CRL to Host CRL at startup

### DIFF
--- a/dev-resources/puppetlabs/services/master/master_service_test/conf/puppet.conf
+++ b/dev-resources/puppetlabs/services/master/master_service_test/conf/puppet.conf
@@ -8,6 +8,7 @@ cakey = target/master-service-test/ca/ca_key.pem
 cacert = target/master-service-test/ca/ca_crt.pem
 localcacert = target/master-service-test/ca/ca.pem
 cacrl = target/master-service-test/ca/ca_crl.pem
+hostcrl = target/master-service-test/ca/crl.pem
 
 hostpubkey = target/master-service-test/public_keys/localhost.pem
 hostprivkey = target/master-service-test/private_keys/localhost.pem

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -41,12 +41,21 @@ If you enable Puppet Server's certificate authority service, it uses the `cacert
 ### [`cacrl`](https://docs.puppetlabs.com/references/latest/configuration.html#cacrl)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
-[webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-crl-path` as the CRL for authenticating clients via SSL. If at least one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set, Puppet Server will *not* use a CRL to validate clients via SSL.
+[webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
+file at `ssl-crl-path` as the CRL for authenticating clients via SSL. If at least
+one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set,
+Puppet Server will *not* use a CRL to validate clients via SSL.
 
 If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses
-the CRL file defined for the `cacrl` setting in puppet.conf. (In a Ruby Puppet master on the WEBrick server, the CRL would be determined by the `ca` and `hostcrl` settings, but Puppet Server ignores both of these settings.)
+the CRL file defined for the `hostcrl` setting---and not the file defined for
+the `cacrl` setting--in puppet.conf. At start time, Puppet Server copies the
+file for the `cacrl` setting, if one exists, over to the location in the
+`hostcrl` setting.
 
-Any CRL file updates from the Puppet Server certificate authority---such as revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl` setting in puppet.conf to determine the location of the CRL. This is true regardless of the `ssl-` settings in webserver.conf.
+Any CRL file updates from the Puppet Server certificate authority---such as
+revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl`
+setting in puppet.conf to determine the location of the CRL. This is true
+regardless of the `ssl-` settings in webserver.conf.
 
 ### [`capass`](https://docs.puppetlabs.com/references/latest/configuration.html#capass)
 
@@ -81,7 +90,22 @@ location of the server host certificate to generate.
 
 ### [`hostcrl`](https://docs.puppetlabs.com/references/latest/configuration.html#hostcrl)
 
-Puppet Server does not use this setting.  See [`cacrl`](#cacrl) for more details.
+If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
+[webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
+file at `ssl-crl-path` as the CRL for authenticating clients via SSL. If at least
+one of the `ssl-` settings in webserver.conf is set but `ssl-crl-path` is not set,
+Puppet Server will *not* use a CRL to validate clients via SSL.
+
+If none of the `ssl-` settings in webserver.conf are set, Puppet Server uses
+the CRL file defined for the `hostcrl` setting---and not the file defined for
+the `cacrl` setting--in puppet.conf. At start time, Puppet Server copies the
+file for the `cacrl` setting, if one exists, over to the location in the
+`hostcrl` setting.
+
+Any CRL file updates from the Puppet Server certificate authority---such as
+revocations performed via the `certificate_status` HTTP endpoint---use the `cacrl`
+setting in puppet.conf to determine the location of the CRL. This is true
+regardless of the `ssl-` settings in webserver.conf.
 
 ### [`hostprivkey`](https://docs.puppetlabs.com/references/latest/configuration.html#hostprivkey)
 

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -27,6 +27,7 @@
   {:certdir        schema/Str
    :dns-alt-names  schema/Str
    :hostcert       schema/Str
+   :hostcrl        schema/Str
    :hostprivkey    schema/Str
    :hostpubkey     schema/Str
    :localcacert    schema/Str
@@ -583,9 +584,9 @@
              (throw (partial-state-error "master" found missing))))))))
 
 (schema/defn ^:always-validate retrieve-ca-cert!
-  "Given configuration settings and CA settings, ensure a local copy of the CA
-  cert is available on disk.  cacert is the base CA cert file to copy from and
-  localcacert is where that the CA cert file should be copied to."
+  "Ensure a local copy of the CA cert is available on disk.  cacert is the base
+  CA cert file to copy from and localcacert is where the CA cert file should be
+  copied to."
   ([cacert :- schema/Str
     localcacert :- schema/Str]
    (if (fs/exists? cacert)
@@ -600,6 +601,16 @@
                      "be found and no file at :cacert ("
                      cacert
                      ") to copy it from")))))))
+
+(schema/defn ^:always-validate retrieve-ca-crl!
+  "Ensure a local copy of the CA CRL, if one exists, is available on disk.
+  cacrl is the base CRL file to copy from and localcacrl is where the CRL file
+  should be copied to."
+  ([cacrl :- schema/Str
+    localcacrl :- schema/Str]
+    (when (fs/exists? cacrl)
+      (ks/mkdirs! (fs/parent localcacrl))
+      (fs/copy cacrl localcacrl))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Autosign

--- a/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_disabled_service.clj
@@ -15,4 +15,8 @@
 
   (retrieve-ca-cert!
     [this localcacert]
-    (log/info "CA disabled; ignoring retrieval of CA cert")))
+    (log/info "CA disabled; ignoring retrieval of CA cert"))
+
+  (retrieve-ca-crl!
+    [this localcacrl]
+    (log/info "CA disabled; ignoring retrieval of CA CRL")))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -31,4 +31,9 @@
   (retrieve-ca-cert!
     [this localcacert]
     (ca/retrieve-ca-cert! (get-in-config [:puppet-server :cacert])
-                          localcacert)))
+                          localcacert))
+
+  (retrieve-ca-crl!
+    [this localcacrl]
+    (ca/retrieve-ca-crl! (get-in-config [:puppet-server :cacrl])
+                         localcacrl)))

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -28,6 +28,7 @@
     :certname
     :csrdir
     :hostcert
+    :hostcrl
     :hostprivkey
     :hostpubkey
     :localcacert
@@ -104,11 +105,11 @@
 (defn init-webserver!
   "Initialize Jetty with paths to the master's SSL certs."
   [override-webserver-settings! webserver-settings puppet-config]
-  (let [{:keys [hostcert cacert cacrl hostprivkey]} puppet-config
+  (let [{:keys [hostcert cacert hostcrl hostprivkey]} puppet-config
         overrides {:ssl-cert     hostcert
                    :ssl-key      hostprivkey
                    :ssl-ca-cert  cacert
-                   :ssl-crl-path cacrl}]
+                   :ssl-crl-path hostcrl}]
     (if (some #((key %) webserver-settings) overrides)
       (log/info
         "Not overriding webserver settings with values from core Puppet")

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -9,7 +9,7 @@
   [[:WebroutingService add-ring-handler get-route]
    [:PuppetServerConfigService get-config]
    [:RequestHandlerService handle-request]
-   [:CaService initialize-master-ssl! retrieve-ca-cert!]]
+   [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl!]]
   (init
    [this context]
    (core/validate-memory-requirements!)
@@ -17,9 +17,11 @@
          config      (get-config)
          certname    (get-in config [:puppet-server :certname])
          localcacert (get-in config [:puppet-server :localcacert])
+         hostcrl     (get-in config [:puppet-server :hostcrl])
          settings    (ca/config->master-settings config)]
 
      (retrieve-ca-cert! localcacert)
+     (retrieve-ca-crl! hostcrl)
      (initialize-master-ssl! settings certname)
 
      (log/info "Master Service adding a ring handler")

--- a/src/clj/puppetlabs/services/protocols/ca.clj
+++ b/src/clj/puppetlabs/services/protocols/ca.clj
@@ -3,4 +3,5 @@
 (defprotocol CaService
   "Describes the functionality of the CA service."
   (initialize-master-ssl! [this master-settings certname])
-  (retrieve-ca-cert! [this master-settings]))
+  (retrieve-ca-cert! [this localcacert])
+  (retrieve-ca-crl! [this localcacrl]))

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -18,6 +18,7 @@
        {:certdir        (str ssldir "/certs")
         :dns-alt-names  ""
         :hostcert       (str ssldir "/certs/" hostname ".pem")
+        :hostcrl        (str ssldir "/certs/crl.pem")
         :hostprivkey    (str ssldir "/private_keys/" hostname ".pem")
         :hostpubkey     (str ssldir "/public_keys/" hostname ".pem")
         :localcacert    (str ssldir "/certs/ca.pem")

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -44,7 +44,7 @@
                                (reset! settings-passed settings))
         puppet-config        {:hostcert    "thehostcert"
                               :cacert      "thecacert"
-                              :cacrl       "thecacrl"
+                              :hostcrl     "thehostcrl"
                               :hostprivkey "thehostprivkey"}
         init-webserver-fn    (fn [webserver-settings]
                                (reset! settings-passed nil)
@@ -55,7 +55,7 @@
         webserver-ssl-config {:ssl-cert     "thehostcert"
                               :ssl-key      "thehostprivkey"
                               :ssl-ca-cert  "thecacert"
-                              :ssl-crl-path "thecacrl"}]
+                              :ssl-crl-path "thehostcrl"}]
 
     (testing (str "no call made to override default webserver settings if "
                   "full ssl cert configuration already in webserver settings")

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -61,6 +61,7 @@
                   (test-path! "cacert" "target/master-service-test/ca/ca_crt.pem")
                   (test-path! "localcacert" "target/master-service-test/ca/ca.pem")
                   (test-path! "cacrl" "target/master-service-test/ca/ca_crl.pem")
+                  (test-path! "hostcrl" "target/master-service-test/ca/crl.pem")
                   (test-path! "hostpubkey" "target/master-service-test/public_keys/localhost.pem")
                   (test-path! "hostprivkey" "target/master-service-test/private_keys/localhost.pem")
                   (test-path! "hostcert" "target/master-service-test/certs/localhost.pem")


### PR DESCRIPTION
This commit changes the master to, at each startup, copy the file
pointed at by the Puppet `cacrl` setting, if it exists, over to the
file pointed at by the Puppet `hostcrl` setting.

This commit also changes the `override-webserver-setting!` logic to
use the file at the `hostcrl` setting rather than the one at the `cacrl`
setting to determine which file the webserver uses to validate
certificates for connecting clients.  This was done based on the fact
that a "standalone" master -- one hosted without a corresponding active
CA in the same container -- would have used the `hostcrl` setting under
the Ruby master.  With the logic in place to copy the `cacrl` to the
`hostcrl` when a real CA is in place, the latest CRL, when the master
and CA are running in the same container, should now be in place at
service startup.