### PR TITLE
(SERVER-155/SERVER-260) Update submodules and eliminate duplicated code

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -81,9 +81,6 @@ class Puppet::Server::PuppetConfig
     end
     Puppet.push_context({:current_environment => configured_environment},
                         "Update current environment from puppet master's configuration")
-
-    require 'puppet/util/instrumentation'
-    Puppet::Util::Instrumentation.init
   end
 
   def self.configure_indirector_routes

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -33,7 +33,7 @@ class Puppet::Server::PuppetConfig
 
     Puppet.info("Puppet settings initialized; run mode: #{Puppet.run_mode.name}")
 
-    reset_environment_context()
+    Puppet::ApplicationSupport.push_application_context(master_run_mode)
 
     Puppet.settings.use :main, :master, :ssl, :metrics
 
@@ -43,56 +43,7 @@ class Puppet::Server::PuppetConfig
 
     Puppet::Node.indirection.cache_class = Puppet[:node_cache_terminus]
 
-    configure_indirector_routes()
+    Puppet::ApplicationSupport.configure_indirector_routes("master")
 
   end
-
-  private
-  def self.reset_environment_context
-    # The following lines were copied for the most part from the run() method
-    # in the Puppet::Application class from .../lib/puppet/application.rb
-    # in core Ruby Puppet code.  The logic in the Puppet::Application class is
-    # executed by the core Ruby Puppet master during its initialization.
-    #
-    # The call to Puppet.base_context is needed in order for the modulepath
-    # settings just implicitly reprocessed for master run mode to be
-    # reset onto the Environment objects that later Ruby Puppet requests
-    # will use (e.g., for agent pluginsyncs).
-    #
-    # It would be better for the logic below to be put in a location where
-    # both the core Ruby Puppet and Puppet Server masters can use the same
-    # implementation.  A separate ticket, PE-4356, was filed to cover this
-    # follow-on work.
-
-    Puppet.push_context(Puppet.base_context(Puppet.settings),
-                        "Update for application settings (Puppet Server).")
-    # This use of configured environment is correct, this is used to establish
-    # the defaults for an application that does not override, or where an override
-    # has not been made from the command line.
-    #
-    configured_environment_name = Puppet[:environment]
-    configured_environment =
-        Puppet.lookup(:environments).get(configured_environment_name)
-    configured_environment =
-        configured_environment.override_from_commandline(Puppet.settings)
-
-    if configured_environment.nil?
-      fail(Puppet::Environments::EnvironmentNotFound, configured_environment_name)
-    end
-    Puppet.push_context({:current_environment => configured_environment},
-                        "Update current environment from puppet master's configuration")
-  end
-
-  def self.configure_indirector_routes
-    # The following lines were copied for the most part from the
-    # configure_indirector_routes() method in the Puppet::Application class from
-    # .../lib/puppet/application.rb in core Ruby Puppet code.
-    route_file = Puppet[:route_file]
-    if Puppet::FileSystem.exist?(route_file)
-      routes = YAML.load_file(route_file)
-      application_routes = routes["master"]
-      Puppet::Indirector.configure_routes(application_routes) if application_routes
-    end
-  end
-
 end


### PR DESCRIPTION
This PR addresses two tickets, both of which required small enough changes and complemented each other well enough that I felt it was better to open one PR to address both.

This PR updates the submodules to the latest commit on the master branch of each repo, addressing SERVER-260. It also eliminates duplicated code by calling into the new functions in `Puppet::ApplicationSupport` added by @KevinCorcoran, a change which required the submodule updates. 