### PR TITLE
(SERVER-269) Passthrough binary payload properly for master requests

### DIFF
--- a/dev-resources/puppetlabs/services/jruby/request_handler_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/jruby/request_handler_test/puppet.conf
@@ -1,0 +1,2 @@
+[main]
+certname = localhost

--- a/spec/puppet-server-lib/puppet/jvm/handler_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/handler_spec.rb
@@ -1,0 +1,38 @@
+require 'puppet/server/network/http/handler'
+
+class TestHandler
+  include Puppet::Server::Network::HTTP::Handler
+end
+
+describe Puppet::Server::Network::HTTP::Handler do
+  context "body" do
+    it "should return a string body untouched" do
+      body_string = "12345"
+      handler = TestHandler.new()
+      result = handler.body({"body" => body_string})
+      expect(result).to be_a String
+      expect(result).to eq body_string
+    end
+
+    it "should return an InputStream body back as a string" do
+      bytes = Java::byte[3].new
+      bytes[0] = -128
+      bytes[1] = -127
+      bytes[2] = -126
+      bytes_as_stream = Java::Java::io::ByteArrayInputStream.new(bytes)
+      handler = TestHandler.new()
+      result = handler.body({"body" => bytes_as_stream})
+      expect(result).to be_a String
+      result_as_bytes = result.bytes.to_a
+      expect(result_as_bytes[0]).to eq 128
+      expect(result_as_bytes[1]).to eq 129
+      expect(result_as_bytes[2]).to eq 130
+    end
+
+    it "should return a nil body back as nil" do
+      handler = TestHandler.new()
+      result = handler.body({"body" => nil})
+      expect(result).to be_nil
+    end
+  end
+end

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -41,7 +41,9 @@
     ;; the actual payload is "binary".  Coercing this to
     ;; "application/octet-stream" for now as this is synonymous with "binary".
     ;; This should be removed when/if Puppet agents start using an appropriate
-    ;; Content-Type to describe the input payload.
+    ;; Content-Type to describe the input payload - see PUP-3812 for the core
+    ;; Puppet work and SERVER-294 for the related Puppet Server work that
+    ;; would be done.
     (compojure/PUT "/file_bucket_file/*" request
                    (request-handler (assoc request
                                            :content-type

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -33,8 +33,20 @@
                    (request-handler request))
     (compojure/GET "/file_bucket_file/*" request
                    (request-handler request))
+
+    ;; TODO: file_bucket_file request PUTs from Puppet agents currently use a
+    ;; Content-Type of 'text/plain', which, per HTTP specification, would imply
+    ;; a default character encoding of ISO-8859-1 or US-ASCII be used to decode
+    ;; the data.  This would be incorrect to do in this case, however, because
+    ;; the actual payload is "binary".  Coercing this to
+    ;; "application/octet-stream" for now as this is synonymous with "binary".
+    ;; This should be removed when/if Puppet agents start using an appropriate
+    ;; Content-Type to describe the input payload.
     (compojure/PUT "/file_bucket_file/*" request
-                   (request-handler request))
+                   (request-handler (assoc request
+                                           :content-type
+                                           "application/octet-stream")))
+
     (compojure/HEAD "/file_bucket_file/*" request
                    (request-handler request))
     (compojure/GET "/catalog/*" request

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -1,16 +1,12 @@
 (ns puppetlabs.services.request-handler.request-handler-core
-  (:import (java.security.cert X509Certificate)
-           (java.util HashMap)
+  (:import (java.util HashMap)
            (java.io StringReader)
-           (com.puppetlabs.puppetserver JRubyPuppetResponse)
-           (org.apache.commons.io IOUtils))
+           (com.puppetlabs.puppetserver JRubyPuppetResponse))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [clojure.walk :as walk]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.certificate-authority.core :as ssl]
             [ring.middleware.params :as ring-params]
-            [ring.middleware.nested-params :as ring-nested-params]
             [ring.util.codec :as ring-codec]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]))

--- a/src/ruby/puppet-server-lib/puppet/server/network/http/handler.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/network/http/handler.rb
@@ -3,6 +3,8 @@ require 'puppet/server/network/http'
 require 'puppet/network/http/handler'
 require 'puppet/server/certificate'
 
+java_import java.io.InputStream
+
 module Puppet::Server::Network::HTTP::Handler
   include Puppet::Network::HTTP::Handler
 
@@ -32,7 +34,12 @@ module Puppet::Server::Network::HTTP::Handler
   end
 
   def body(request)
-    request["body"]
+    body = request["body"]
+    if body.java_kind_of?(InputStream)
+      body.to_io.read()
+    else
+      body
+    end
   end
 
   def params(request)

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -1,0 +1,94 @@
+(ns puppetlabs.services.jruby.request-handler-test
+  (:import (java.io ByteArrayInputStream)
+           (java.security MessageDigest)
+           (javax.xml.bind.annotation.adapters HexBinaryAdapter)
+           (org.apache.commons.io IOUtils))
+  (:require [clojure.string :as string]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all]
+            [me.raynes.fs :as fs]
+            [schema.test :as schema-test]
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.http.client.sync :as http-client]))
+
+(def test-resources-dir
+  "./dev-resources/puppetlabs/services/jruby/request_handler_test")
+
+(use-fixtures :once
+              schema-test/validate-schemas
+              (jruby-testutils/with-puppet-conf (fs/file test-resources-dir
+                                                         "puppet.conf")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Utilities
+
+(def ca-cert
+  (bootstrap/pem-file "certs" "ca.pem"))
+
+(def localhost-cert
+  (bootstrap/pem-file "certs" "localhost.pem"))
+
+(def localhost-key
+  (bootstrap/pem-file "private_keys" "localhost.pem"))
+
+(def ssl-request-options
+  {:ssl-cert    localhost-cert
+   :ssl-key     localhost-key
+   :ssl-ca-cert ca-cert})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Tests
+
+(deftest ^:integration file-bucket-test
+  (testing "that a file bucket upload with *binary*, non-UTF-8, content is
+            successful (SERVER-269)"
+    (let [bucket-dir (str bootstrap/master-var-dir "/bucket")]
+      (fs/delete-dir bucket-dir)
+      (bootstrap/with-puppetserver-running app {}
+       (try
+         (let [raw-byte-arr            (byte-array [(byte -128)
+                                                    (byte -127)
+                                                    (byte -126)])
+               expected-md5            (-> (HexBinaryAdapter.)
+                                           (.marshal (->
+                                                       (MessageDigest/getInstance
+                                                         "MD5")
+                                                       (.digest raw-byte-arr)))
+                                           (string/lower-case))
+               expected-bucket-file    (string/join
+                                         "/"
+                                         [bucket-dir
+                                          (string/join "/"
+                                                       (subs expected-md5 0 8))
+                                          expected-md5
+                                          "contents"])
+               ;; The 'text/plain' content-type mimics what a Puppet agent
+               ;; sends to a master for a file-bucket PUT.  Ideally, this
+               ;; should be "application/octet-stream" but including this at
+               ;; present would result in a Puppet Ruby error - Puppet Client
+               ;; sent a mime-type (application/octet-stream) that doesn't
+               ;; correspond to a format we support.
+               options                 (merge ssl-request-options
+                                              {:body (ByteArrayInputStream.
+                                                       raw-byte-arr)
+                                               :headers {"accept"
+                                                           "s, pson"
+                                                         "content-type"
+                                                           "text/plain"}})
+               response (http-client/put (str "https://localhost:8140/"
+                                              "production/file_bucket_file/md5/"
+                                              expected-md5)
+                                         options)]
+           (is (= 200 (:status response)) "Bucket PUT request failed")
+           (is (fs/exists? expected-bucket-file)
+               "Bucket file not stored at expected location")
+           (is (= (seq raw-byte-arr)
+                  (if (fs/exists? expected-bucket-file)
+                    (-> expected-bucket-file
+                        (io/input-stream)
+                        (IOUtils/toByteArray)
+                        (seq))))
+               "Did not find expected content in bucket file"))
+         (finally
+           (fs/delete-dir bucket-dir)))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -37,3 +37,14 @@
                  method
                  ", path: "
                  path))))))
+
+(deftest file-bucket-file
+  (testing (str "that the content-type in the ring request is replaced with "
+                "application/octet-stream for a file_bucket_file put request")
+    (let [handler     (fn ([req] {:request req}))
+          app         (build-ring-handler handler)
+          resp        (app {:request-method :put
+                            :content-type   "text/plain"
+                            :uri            "/foo/file_bucket_file/bar"})]
+      (is (= "application/octet-stream"
+             (get-in resp [:request :content-type]))))))


### PR DESCRIPTION
In the previous commit, the body for any HTTP requests made to the
Puppet master service with a Content-Type of <none> or
"application/octet-stream" was inappropriately decoded into a UTF-8
string.

With the changes in this commit, the body for any HTTP requests made to
the Puppet master service with a Content-Type of <none> or
"application/octet-stream" is now passed through as raw bytes to the
JRuby request layer, where it is converted into an ASCII-8BIT Ruby
String.

Puppet agent requests to the "file_bucket_file" endpoint include a
Content-Type of "text/plain".  While these requests should technically,
per the HTTP spec, be transformed to ISO-8859-1 or US-ASCII instead of
UTF-8, the actual payload is intended to be treated as "binary".  This
commit treats requests to the "file_bucket_file" endpoint as though they
were including an "application/octet-stream" Content-Type, allowing the
raw bytes in the request body to be sent down to the JRuby request layer.