### PR TITLE
(MAINT) Fix intermittent gem install failures.

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -16,13 +16,13 @@ end
 # --------------------------------------------------------------------------
 
 # define gems to test
-gems = ['beaker']
+gems = ['nokogiri', 'excon']
 
 additional_gem_source = ENV['GEM_SOURCE']
 # define command lines
 gem_install = "#{cli} gem install --minimal-deps --force"
 if additional_gem_source
-  gem_install += " -s #{additional_gem_source}"
+  gem_install += " --clear-sources --source #{additional_gem_source}"
 end
 
 gem_uninstall = "#{cli} gem uninstall"


### PR DESCRIPTION
* Change list of installed gems to reduce complexity of install. Beaker changes
  too often to use it here without specifying a concrete version, which in turn
  would require more complex handing of this list of gems throughout the rest of
  the test.
* Clears the list of rubygems sources before adding the internal mirror to
  ensure that gem installation problems are not masked by network failures.