### PR TITLE
(SERVER-268) Improve Acceptance README

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -201,9 +201,11 @@ This is the expected workflow for running vcloud tests directly from one's
 laptop.
 
     bundle install --path vendor/bundle
-    export BEAKER_CONFIG=./acceptance/config/beaker/jenkins/debian-7-i386.cfg
-    export PACKAGE_BUILD_VERSION=0.1.2.SNAPSHOT.2014.05.12T1408
+    export BEAKER_CONFIG=./acceptance/config/beaker/jenkins/debian-7-x86_64-mdca.cfg
+    export PACKAGE_BUILD_VERSION=2.0.0.SNAPSHOT.2015.01.05T1228
     export BEAKER_OPTS="--keyfile /home/username/downloads/id_rsa-acceptance"
+    export BEAKER_TYPE=foss
+    export BEAKER_LOADPATH=./acceptance/lib
     bundle exec rake test:acceptance:beaker 
 
 Noteworthy here is BEAKER_OPTS which specifies an acceptance testing specific
@@ -280,7 +282,7 @@ test:acceptance:beaker Rake task and descriptions of the effect each has.
 
 * $BEAKER_TYPE 
   * Beaker CLI Option: --type 
-  * Default: foss 
+  * Default: None
   * Description: Same as the Beaker option.
 
 * $BEAKER_FAILMODE 
@@ -300,7 +302,7 @@ test:acceptance:beaker Rake task and descriptions of the effect each has.
 
 * $BEAKER_LOADPATH 
   * Beaker CLI Option: --load-path 
-  * Default: 
+  * Default: None
   * Description: Same as the Beaker option.
 
 * $BEAKER_HELPER 


### PR DESCRIPTION
Improve the README in the Acceptance folder to reflect that
setting the BEAKER_TYPE and BEAKER_LOADPATH environment variables
are required when running the tests with a Rakefile under
Workflow a.

I also went ahead and updated the PACKAGE_BUILD_VERSION to reflect a more recent snapshot build of puppet server, and updated the BEAKER_CONFIG variable to point to an actual config file in the acceptance folder, as the one previously being pointed to no longer exists.

This only addresses Rakefile Workflow a, as that's how I was running the acceptance tests when I ran into the issues with the README. Other parts of the README are likely outdated as well, so this will probably require some further investigation.