### PR TITLE
(SERVER-220) Include Jetty dependency in uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -78,7 +78,9 @@
                                    [spyscope "0.1.4" :exclusions [clj-time]]]
                    :injections    [(require 'spyscope.core)]}
 
-             :uberjar {:aot [puppetlabs.trapperkeeper.main]}
+             :uberjar {:aot [puppetlabs.trapperkeeper.main]
+                       :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}
+
              :ci {:plugins [[lein-pprint "1.1.1"]]}}
 
   :test-selectors {:default (complement :integration)


### PR DESCRIPTION
This should fix the `lein uberjar` command to produce a working Puppet
Server uberjar that includes the Jetty dependency, without interfering
with the ezbake packaging process.