### PR TITLE
(MAINT) Make cli .erb files more robust

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-${JAVA_BIN} -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
-    --config ${CONFIG} -- "$@"
+    --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/irb.erb
+++ b/resources/ext/cli/irb.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-${JAVA_BIN} -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.irb \
-    --config ${CONFIG} -- "$@"
+    --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/ruby.erb
+++ b/resources/ext/cli/ruby.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-${JAVA_BIN} -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.ruby \
-    --config ${CONFIG} -- "$@"
+    --config "${CONFIG}" -- "$@"


### PR DESCRIPTION
Make the cli .erb files more robust by adding quotes around the
JAVA_BIN and CONFIG environment variables.

This implements the changes suggested by @jeffmccune in https://github.com/puppetlabs/pe-puppet-server-extensions/pull/162. I thought this belonged in stable since it's a minor change and since it's going into 3.7.2, it might as well go into 1.0.1 as well.