### PR TITLE
(SERVER-252) Add acceptance tests for irb and ruby subcommands

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -8,11 +8,7 @@ test_name "Puppetserver 'gem' subcommand tests."
 # the need to fix this once Beaker has been modified to make the paths to these
 # commands available.
 #
-if master.is_pe?
-  cli = "pe-puppetserver"
-else
-  cli = "puppetserver"
-end
+cli = "puppetserver"
 # --------------------------------------------------------------------------
 
 # define gems to test
@@ -84,4 +80,21 @@ on(master, gem_env) do
   assert_no_match(/ERROR:  While executing gem/, stdout, "gem env blew up!")
   assert_match(/SHELL PATH:/, stdout, "PATH expected but not present")
   assert_match(/INSTALLATION DIRECTORY:/, stdout, "GEM_HOME not present")
+end
+
+step "Install hiera-eyaml gem."
+on(master, "#{gem_install} hiera-eyaml --no-ri --no-rdoc")
+
+step "Check that ruby subcommand can load hiera/backend/eyaml from hiera-eyaml"
+on(master, "#{cli} ruby -rrubygems -rhiera/backend/eyaml -e 'puts %{OK}'") do
+  assert_match(/^OK$/, stdout, "ruby could not load eyaml after gem install")
+  assert_no_match(/Error/i, stdout, "error loading hiera-eyaml library")
+end
+
+step "Check that irb subcommand can load hiera/backend/eyaml from hiera-eyaml"
+cmd = "echo 'puts Hiera::Backend::Eyaml::DESCRIPTION'" \
+      "| #{cli} irb -rrubygems -rhiera/backend/eyaml"
+on(master, cmd) do
+  assert_match(/OpenSSL/i, stdout, "hiera-eyaml description does not match")
+  assert_no_match(/Error/i, stdout, "error loading hiera-eyaml library")
 end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -1,0 +1,32 @@
+require 'test/unit/assertions'
+
+test_name "Puppetserver 'irb' subcommand tests."
+
+# --------------------------------------------------------------------------
+# This behavior needs to be baked into Beaker but is not yet. SERVER-79 tracks
+# the need to fix this once Beaker has been modified to make the paths to these
+# commands available.
+#
+cli = "puppetserver"
+# --------------------------------------------------------------------------
+
+step "Check that GEM_HOME is managed"
+cmd = "echo 'puts ENV.to_hash.to_yaml' | GEM_HOME=UHOH #{cli} irb -ryaml -f"
+on(master, cmd) do
+  assert_match(/GEM_HOME/, stdout)
+  assert_no_match(/UHOH/, stdout)
+end
+
+step "Check that FOO_DEBUG is preserved"
+cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{BAD}' | FOO_DEBUG=OK #{cli} irb -f"
+on(master, cmd) do
+  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
+  assert_no_match(/BAD/, stdout)
+end
+
+step "Check that puppet is loadable"
+cmd = "echo 'puts %{GOOD: #{Puppet.version}}' | #{cli} irb -rpuppet -f"
+on(master, cmd) do
+  assert_match(/GOOD:/, stdout)
+  assert_no_match(/error/i, stdout)
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -1,0 +1,31 @@
+require 'test/unit/assertions'
+
+test_name "Puppetserver 'ruby' subcommand tests."
+
+# --------------------------------------------------------------------------
+# This behavior needs to be baked into Beaker but is not yet. SERVER-79 tracks
+# the need to fix this once Beaker has been modified to make the paths to these
+# commands available.
+#
+cli = "puppetserver"
+# --------------------------------------------------------------------------
+
+step "Check that GEM_HOME is managed"
+cmd = "GEM_HOME=UHOH #{cli} ruby -ryaml -e 'puts ENV.to_hash.to_yaml'"
+on(master, cmd) do
+  assert_match(/GEM_HOME/, stdout)
+  assert_no_match(/UHOH/, stdout)
+end
+
+step "Check that FOO_DEBUG is preserved"
+on(master, "FOO_DEBUG=OK #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{BAD}'") do
+  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
+  assert_no_match(/BAD/, stdout)
+end
+
+step "Check that puppet is loadable"
+cmd = "#{cli} ruby -rpuppet -e 'puts %{GOOD: #{Puppet.version}}'"
+on(master, cmd) do
+  assert_match(/GOOD:/, stdout)
+  assert_no_match(/error/i, stdout)
+end


### PR DESCRIPTION
Without this patch there are no acceptance level tests for the ruby and irb
subcommands as they relate to the `gem` subcommand.  This is a problem because
we need to ensure these commands behave as expected, particularly when the
`gem` subcommand is used to install third party libraries.

This patch addresses the problem by installing the `hiera-eyaml` gem and then
checking that the `ruby` and `irb` subcommand can `require 'eyaml'`.

This patch also adds basic testing of the behavior of GEM_HOME and FOO_DEBUG
with regard to the irb and ruby subcommands in addition to ensuring `require
'puppet'` works in both subcommands.