### PR TITLE
(SERVER-252) Fix bad irb and ruby subcommand tests

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -21,7 +21,7 @@ step "Check that FOO_DEBUG is preserved"
 cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{BAD}' | FOO_DEBUG=OK #{cli} irb -f"
 on(master, cmd) do
   assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/BAD/, stdout)
+  assert_no_match(/^BAD$/, stdout, "FOO_DEBUG is being unset, it should not be")
 end
 
 step "Check that puppet is loadable"

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -20,11 +20,11 @@ end
 step "Check that FOO_DEBUG is preserved"
 on(master, "FOO_DEBUG=OK #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{BAD}'") do
   assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/BAD/, stdout)
+  assert_no_match(/BAD/, stdout, "FOO_DEBUG is being unset, it should not be")
 end
 
 step "Check that puppet is loadable"
-cmd = "#{cli} ruby -rpuppet -e 'puts %{GOOD: #{Puppet.version}}'"
+cmd = "#{cli} ruby -rpuppet -e 'puts %{GOOD: } + Puppet.version'"
 on(master, cmd) do
   assert_match(/GOOD:/, stdout)
   assert_no_match(/error/i, stdout)


### PR DESCRIPTION
Without this patch the tests are failing because of bad logic in the tests
themselves.  This patch addresses the problem by correcting the logic in the
tests, specifically /BAD/ was matching in the irb tests because irb echos input
to standard output.  /^BAD$/ will not match the echoed input.  The ruby test
was failing because string interpolation was happening in the beaker process
when it was intended to be passed through beaker to the ruby subcommand being
tested.  This patch addresses the problem by avoiding string interpolation
entirely and using concatenation instead.