### PR TITLE
(SERVER-252) Fix bad irb acceptance test... again.

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -25,7 +25,7 @@ on(master, cmd) do
 end
 
 step "Check that puppet is loadable"
-cmd = "echo 'puts %{GOOD: #{Puppet.version}}' | #{cli} irb -rpuppet -f"
+cmd = "echo 'puts %{GOOD: } + Puppet.version' | #{cli} irb -rpuppet -f"
 on(master, cmd) do
   assert_match(/GOOD:/, stdout)
   assert_no_match(/error/i, stdout)


### PR DESCRIPTION
Same issues as before, string interpolation was happening in beaker when it
should be passed through.  Switched from #{} to concatenation with +.