### PR TITLE
(maint) Remove unused require from puppet-server-lib

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -1,7 +1,6 @@
 require 'puppet/server'
 
 require 'puppet/network/http'
-require 'puppet/network/http/api/master/v2'
 require 'puppet/network/http/api/master/v3'
 
 require 'puppet/server/config'


### PR DESCRIPTION
Prior to this commit, there was an old require that referenced a library
from puppet that no longer exists. This caused puppet-server to fail on
startup. This commit fixes that by removing the require reference.