### PR TITLE
(MAINT) Fix broken config service test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,9 +43,10 @@
                  [prismatic/schema "0.2.2"]
                  [commons-lang "2.6"]
                  [commons-io "2.4"]
+                 [commons-codec "1.9"]
                  [clj-yaml "0.4.0" :exclusions [org.yaml/snakeyaml]]
                  [slingshot "0.10.3"]
-                 [ring/ring-codec "1.0.0"]
+                 [ring/ring-codec "1.0.0" :exclusions [commons-codec]]
                  [cheshire "5.3.1"]
                  [trptcolin/versioneer "0.1.0"]]
 

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -7,7 +7,8 @@
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :refer [keyset]]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
-            [schema.core :as schema]))
+            [schema.core :as schema]
+            [clojure.string :as str]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; config
@@ -90,7 +91,8 @@
       (throw (Exception.
                (str "The following configuration keys "
                     "conflict with the values to be "
-                    "read from puppet: " key-conflicts))))))
+                    "read from puppet: "
+                    (str/join ", " (sort key-conflicts))))))))
 
 (schema/defn ^:always-validate
   get-puppet-config :- Config

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -19,9 +19,11 @@
    profiler/puppet-profiler-service])
 
 (def required-config
-  (merge (jruby-testutils/jruby-puppet-tk-config
-           (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
-         {:webserver    {:port 8081}}))
+  (-> (jruby-testutils/jruby-puppet-tk-config
+        (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
+      (assoc-in [:webserver :port] 8081)
+      (assoc-in [:jruby-puppet :master-conf-dir]
+                (str test-resources-dir "/master/conf"))))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/config/puppet_server_config_service_test")
@@ -34,8 +36,7 @@
     app
     service-and-deps
     (-> required-config
-        (assoc :my-config {:foo "bar"})
-        (assoc-in [:jruby-puppet :master-conf-dir] (str test-resources-dir "/master/conf")))
+        (assoc :my-config {:foo "bar"}))
     (testing "Basic puppet-server config service function usage"
 
       (let [service (tk-app/get-service app :PuppetServerConfigService)
@@ -90,7 +91,7 @@
       (with-test-logging
         (is (thrown-with-msg?
               Exception
-              #".*configuration.*conflict.*cacrl.*cacert"
+              #".*configuration.*conflict.*:cacert, :cacrl"
               (tk-testutils/with-app-with-config
                 app service-and-deps (assoc required-config :cacrl "bogus"
                                                             :cacert "meow")


### PR DESCRIPTION
There was a test in the PuppetServerConfigService that was relying
on the string representation of a set to be printed in a certain
order, even though the data structure makes no guarantees about
sort order.  It seems that this test started failing when we
updated to Clojure 1.6.0 (perhaps intermittently), probably due
to changes in the underlying implementation of the set data structure.

This commit adds an explicit sort to the set before representing
it as a string, so that the resulting string is deterministic.  It
also updates the test to account for this.

The test was also not specifying a confdir, so it was attempting
to access the default user vardir (`~/.puppet`).  This commit addresses
that problem as well.

There was also an issue with the project dependencies bringing in
conflicting versions of `commons-codec` in certain cases, so this
commit pins us to an explicit version of `commons-codec`.