### PR TITLE
(SERVER-206) Close client on scripting container termination

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -83,7 +83,7 @@
       (let [id (inc i)
             instance (jruby-core/borrow-from-pool (:pool old-pool))]
         (try
-          (.runScriptlet (:scripting-container instance) "Puppet::Server::Master.terminate")
+          (.terminate (:jruby-puppet instance))
           (.terminate (:scripting-container instance))
           (log/infof "Cleaned up old JRuby instance %s of %s, creating replacement."
                      id count)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -83,6 +83,7 @@
       (let [id (inc i)
             instance (jruby-core/borrow-from-pool (:pool old-pool))]
         (try
+          (.runScriptlet (:scripting-container instance) "Puppet::Server::Master.terminate")
           (.terminate (:scripting-container instance))
           (log/infof "Cleaned up old JRuby instance %s of %s, creating replacement."
                      id count)

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -18,4 +18,5 @@ public interface JRubyPuppet {
     JRubyPuppetResponse handleRequest(Map request);
     Object getSetting(String setting);
     String puppetVersion();
+    void terminate();
 }

--- a/src/ruby/puppet-server-lib/puppet/server/config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/config.rb
@@ -46,4 +46,8 @@ class Puppet::Server::Config
     end
     @ssl_context
   end
+
+  def self.terminate_puppet_server
+    Puppet::Server::HttpClient.terminate
+  end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -34,8 +34,8 @@ class Puppet::Server::HttpClient
 
     @server = server
     @port = port
-    self.class.use_ssl = options[:use_ssl]
-    @protocol = self.class.use_ssl ? "https" : "http"
+    @use_ssl = options[:use_ssl]
+    @protocol = @use_ssl ? "https" : "http"
   end
 
   def post(url, body, headers, options = {})
@@ -83,10 +83,10 @@ class Puppet::Server::HttpClient
   private
 
   def self.configure_ssl(request_options)
-    return unless self.use_ssl
     request_options.set_ssl_context(Puppet::Server::Config.ssl_context)
 
     settings = self.settings
+
     if settings.has_key?("ssl_protocols")
       request_options.set_ssl_protocols(settings["ssl_protocols"])
     end
@@ -143,11 +143,4 @@ class Puppet::Server::HttpClient
     self.client.get(request_options)
   end
 
-  def self.use_ssl=(use_ssl)
-    @use_ssl = use_ssl
-  end
-
-  def self.use_ssl
-    @use_ssl
-  end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -11,7 +11,9 @@ java_import com.puppetlabs.http.client.ResponseBodyType
 SyncHttpClient = com.puppetlabs.http.client.Sync
 
 class Puppet::Server::HttpClient
+
   attr_reader :client
+  @@client = nil
 
   OPTION_DEFAULTS = {
       :use_ssl => true,
@@ -62,7 +64,7 @@ class Puppet::Server::HttpClient
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
     request_options.set_body(body)
-    response = @client.post(request_options)
+    response = @@client.post(request_options)
     ruby_response(response)
   end
 
@@ -75,8 +77,14 @@ class Puppet::Server::HttpClient
     request_options = RequestOptions.new(build_url(url))
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
-    response = @client.get(request_options)
+    response = @@client.get(request_options)
     ruby_response(response)
+  end
+
+  def self.terminate
+    unless @@client.nil?
+      @@client.close
+    end
   end
 
   private
@@ -125,10 +133,10 @@ class Puppet::Server::HttpClient
   end
 
   def create_client_if_nil
-    if @client.nil?
+    if @@client.nil?
       client_options = ClientOptions.new
       configure_ssl(client_options)
-      @client = SyncHttpClient.createClient(client_options)
+      @@client = SyncHttpClient.createClient(client_options)
     end
   end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -67,7 +67,7 @@ class Puppet::Server::Master
     Puppet.run_mode.name.to_s
   end
 
-  def self.terminate
+  def terminate
     Puppet::Server::Config.terminate_puppet_server
   end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -66,4 +66,8 @@ class Puppet::Server::Master
   def run_mode()
     Puppet.run_mode.name.to_s
   end
+
+  def self.terminate
+    Puppet::Server::Config.terminate_puppet_server
+  end
 end

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -86,10 +86,10 @@
                    {:pool                 pool
                     :id                   1
                     :jruby-puppet         (create-mock-jruby-instance)
-                    :scripting-container (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
-                                             (jruby-core/prep-scripting-container ruby-load-path gem-home))
+                    :scripting-container (doto (ScriptingContainer. LocalContextScope/SINGLETHREAD)
+                                               (jruby-core/prep-scripting-container ruby-load-path gem-home)
+                                               (.runScriptlet "require 'puppet/server/master'"))
                     :environment-registry (puppet-env/environment-registry)})]
-    (.runScriptlet (:scripting-container instance) "require 'puppet/server/master'")
     (.put pool instance)
     instance))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -86,8 +86,10 @@
                    {:pool                 pool
                     :id                   1
                     :jruby-puppet         (create-mock-jruby-instance)
-                    :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
+                    :scripting-container (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
+                                             (jruby-core/prep-scripting-container ruby-load-path gem-home))
                     :environment-registry (puppet-env/environment-registry)})]
+    (.runScriptlet (:scripting-container instance) "require 'puppet/server/master'")
     (.put pool instance)
     instance))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -4,7 +4,8 @@
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [puppetlabs.services.puppet-profiler.puppet-profiler-core :as profiler-core]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]))
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [clojure.tools.logging :as log]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -78,7 +79,9 @@
     (handleRequest [_ _]
       (JRubyPuppetResponse. 0 nil nil nil))
     (getSetting [_ _]
-      (Object.))))
+      (Object.))
+    (terminate [_]
+      (log/info "Terminating Master"))))
 
 (defn create-mock-pool-instance
   [pool _ _ _]
@@ -86,9 +89,7 @@
                    {:pool                 pool
                     :id                   1
                     :jruby-puppet         (create-mock-jruby-instance)
-                    :scripting-container (doto (ScriptingContainer. LocalContextScope/SINGLETHREAD)
-                                               (jruby-core/prep-scripting-container ruby-load-path gem-home)
-                                               (.runScriptlet "require 'puppet/server/master'"))
+                    :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
                     :environment-registry (puppet-env/environment-registry)})]
     (.put pool instance)
     instance))


### PR DESCRIPTION
Add in a new `terminate` method to the master that closes the HTTP client and call it before terminating the JRuby scripting container.

I'm definitely looking for some feedback on this one. In particular, I'm not sure about testing. I was having trouble figuring out how to test this. I did add a test to ensure that the master termination function works as intended, but wasn't sure how to write a test to ensure a client is closed before we destroy its scripting container, so any feedback or suggestions on that front are very much appreciated.