### PR TITLE
(SERVER-332) Allow all TLS algorithms in the dev lein profile

### DIFF
--- a/dev-resources/java.security
+++ b/dev-resources/java.security
@@ -1,0 +1,44 @@
+#
+# This is the "override security properties file" which is used by default
+# in the lein dev profile.  End users may override java security properties in
+# a similar manner in the production code.
+#
+# This file augments and overrides $JAVA_HOME/jre/lib/security/java.security
+# when the java process is provided the option,
+# -Djava.security.properties=./dev/java.security
+#
+# NOTE: It is possible to make this file authoritative, discarding the values
+# in $JAVA_HOME/jre/lib/security/java.security by setting the first character
+# of the path to an '=' sign.
+#
+# Algorithm restrictions for Secure Socket Layer/Transport Layer Security
+# (SSL/TLS) processing
+
+# In some environments, certain algorithms or key lengths may be undesirable
+# when using SSL/TLS.  This section describes the mechanism for disabling
+# algorithms during SSL/TLS security parameters negotiation, including
+# protocol version negotiation, cipher suites selection, peer authentication
+# and key exchange mechanisms.
+#
+# Disabled algorithms will not be negotiated for SSL/TLS connections, even
+# if they are enabled explicitly in an application.
+#
+# For PKI-based peer authentication and key exchange mechanisms, this list
+# of disabled algorithms will also be checked during certification path
+# building and validation, including algorithms used in certificates, as
+# well as revocation information such as CRLs and signed OCSP Responses.
+# This is in addition to the jdk.certpath.disabledAlgorithms property above.
+#
+# See the specification of "jdk.certpath.disabledAlgorithms" for the
+# syntax of the disabled algorithm string.
+#
+# Note: This property is currently used by Oracle's JSSE implementation.
+# It is not guaranteed to be examined and used by other implementations.
+#
+# Example:
+#   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
+#
+# SERVER-332 Disable no algorithms so that unit tests are able to exercise the
+# behavior of the system when the end user explicitly configures deprecated
+# algorithms like SSLv3.
+jdk.tls.disabledAlgorithms=

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -195,3 +195,34 @@ a multi-master environment or using an external CA, you might want to disable
 the CA service on some nodes.
 
 
+## Java Secure Socket Extension (JSSE) configuration
+
+A result of the [POODLE](https://blogs.oracle.com/security/entry/information_about_ssl_poodle_vulnerability)
+is that SSLv3 is disabled by default at the JRE layer and in Puppet Server.
+It is possible to enable Puppet Server to negotiate with SSLv3 clients,
+however the recommended course of action is to upgrade clients to negotiate
+using secure protocols.
+
+SSLv3 has been disabled by default in javase 7u75 (1.7.0_u75).  See [7u75
+Update Release Notes](http://www.oracle.com/technetwork/java/javase/7u75-relnotes-2389086.html)
+for more information.
+
+To enable SSLv3 at the JRE layer, first create a properties file, e.g.
+`/etc/sysconfig/puppetserver-properties/java.security` with the following
+content:
+
+~~~
+# Override properties in $JAVA_HOME/jre/lib/security/java.security
+# An empty value enables all algorithms including INSECURE SSLv3
+# java should be started with
+# -Djava.security.properties=/etc/sysconfig/puppetserver-properties/java.security
+# for this file to take effect.
+jdk.tls.disabledAlgorithms=
+~~~
+
+Once this property file exists, update `JAVA_ARGS`, typically defined in
+`/etc/sysconfig/puppetserver` with
+`-Djava.security.properties=/etc/sysconfig/puppetserver-properties/java.security`.  This
+will configure the JVM to override the `jdk.tls.disabledAlgorithms` property
+defined in `$JAVA_HOME/jre/lib/security/java.security`.  The puppetserver
+service needs to be restarted for this setting to take effect.

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,9 @@
                                    [ring-basic-authentication "1.0.5"]
                                    [ring-mock "0.1.5"]
                                    [spyscope "0.1.4" :exclusions [clj-time]]]
-                   :injections    [(require 'spyscope.core)]}
+                   :injections    [(require 'spyscope.core)]
+                   ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
+                   :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
 
              :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]


### PR DESCRIPTION
Without this patch the unit tests fail on JVM versions more recent than
1.7.0_u75 because SSLv3 is disabled at the JRE layer by default.  This is a
problem because the end user may explicitly configure the JRE to allow SSLv3
algorithms, even though we disable them by default at the application layer,
and we need to test the behavior of the system in this scenario.  This patch
addresses the problem by allowing all SSLv3 algorithms by overriding the
java.security jdk.tls.disabledAlgorithms property.