### PR TITLE
(SERVER-326) Add /v3/environments route

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -54,6 +54,8 @@
                    (request-handler request))
     (compojure/GET "/resource_types/*" request
                    (request-handler request))
+    (compojure/GET "/environments" request
+                   (request-handler request))
 
     ;; TODO: when we get rid of the legacy dashboard after 3.4, we should remove
     ;; this endpoint as well.  It makes more sense for this type of query to be

--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -26,9 +26,12 @@ class Puppet::Server::Master
     Puppet::Server::Config.initialize_puppet_server(puppet_server_config)
     Puppet::Server::PuppetConfig.initialize_puppet(puppet_config)
     # Tell Puppet's network layer which routes we are willing handle - which is
-    # the master routes, not the CA routes. We are handling the URL prefixes
-    # on the Puppet Server side, so we don't include those here.
-    register([Puppet::Network::HTTP::API::Master::V3.routes])
+    # the master routes, not the CA routes.
+    master_prefix = Regexp.new("^#{Puppet::Network::HTTP::MASTER_URL_PREFIX}/")
+    master_routes = Puppet::Network::HTTP::Route.path(master_prefix).
+                          any.
+                          chain(Puppet::Network::HTTP::API::Master::V3.routes)
+    register([master_routes])
   end
 
   def handleRequest(request)

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -11,6 +11,7 @@
         app         (build-ring-handler handler)
         request     (fn r ([path] (r :get path))
                           ([method path] (app (mock/request method path))))]
+    (is (= 200 (:status (request "/v3/environments"))))
     (is (= 404 (:status (request "/foo"))))
     (is (= 404 (:status (request "/foo/bar"))))
     (doseq [[method paths]


### PR DESCRIPTION
Add the /environments route to the v3 routes, as it previously
existed in the v2 routes.