### PR TITLE
(SERVER-334) Generate upgrade message once

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -80,6 +80,19 @@
                        (v3-routes request-handler))
     (route/not-found "Not Found")))
 
+(defn construct-404-error-message
+  [jruby-service]
+  (str "Error: Invalid URL - Puppet Server expects requests that conform to the "
+       "/puppet and /puppet-ca APIs.\n\n"
+       "Note that Puppet 3 agents aren't compatible with this version; if you're "
+       "running Puppet 3, you must either upgrade your agents to match the server "
+       "or point them to a server running Puppet 3.\n\n"
+       "Server Info:\n"
+       "  Puppet Server version: " (version-check/get-version-string "puppet-server") "\n"
+       "  Puppet version: " (:puppet-version (config/get-puppet-config jruby-service)) "\n"
+       "  Supported /puppet API versions: " puppet-API-versions
+       "  Supported /puppet-ca API versions: " puppet-ca-API-versions))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions
 
@@ -125,22 +138,6 @@
                       "/etc/default/puppetserver on Debian systems.")))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Helper Functions
-
-(defn construct-404-error-message
-  [jruby-service]
-  (str "Error: Invalid URL - Puppet Server expects requests that conform to the "
-       "/puppet and /puppet-ca APIs.\n\n"
-       "Note that Puppet 3 agents aren't compatible with this version; if you're "
-       "running Puppet 3, you must either upgrade your agents to match the server "
-       "or point them to a server running Puppet 3.\n\n"
-       "Server Info:\n"
-       "  Puppet Server version: " (version-check/get-version-string "puppet-server") "\n"
-       "  Puppet version: " (:puppet-version (config/get-puppet-config jruby-service)) "\n"
-       "  Supported /puppet API versions: " puppet-API-versions
-       "  Supported /puppet-ca API versions: " puppet-ca-API-versions))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
 (defn build-ring-handler
@@ -155,8 +152,8 @@
 (defn construct-invalid-request-handler
   "Constructs a ring handler to handle an incorrectly formatted request and indicate to the user
    they need to update to Puppet 4"
-  [jruby-service]
+  [error-message]
   (fn
     [_]
     {:status 404
-     :body   (construct-404-error-message jruby-service)}))
+     :body   error-message}))

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -15,13 +15,14 @@
   (init
    [this context]
    (core/validate-memory-requirements!)
-   (let [path        (get-route this :master-routes)
-         config      (get-config)
-         certname    (get-in config [:puppet-server :certname])
-         localcacert (get-in config [:puppet-server :localcacert])
-         hostcrl     (get-in config [:puppet-server :hostcrl])
-         settings    (ca/config->master-settings config)
-         jruby-service (tk-services/get-service this :JRubyPuppetService)]
+   (let [path          (get-route this :master-routes)
+         config        (get-config)
+         certname      (get-in config [:puppet-server :certname])
+         localcacert   (get-in config [:puppet-server :localcacert])
+         hostcrl       (get-in config [:puppet-server :hostcrl])
+         settings      (ca/config->master-settings config)
+         jruby-service (tk-services/get-service this :JRubyPuppetService)
+         upgrade-error (core/construct-404-error-message jruby-service)]
 
      (retrieve-ca-cert! localcacert)
      (retrieve-ca-crl! hostcrl)
@@ -32,7 +33,7 @@
        this
       (compojure/context path [] (core/build-ring-handler handle-request))
       {:route-id :master-routes})
-     (add-ring-handler this (core/construct-invalid-request-handler jruby-service) {:route-id :invalid-in-puppet-4}))
+     (add-ring-handler this (core/construct-invalid-request-handler upgrade-error) {:route-id :invalid-in-puppet-4}))
    context)
   (start
     [this context]


### PR DESCRIPTION
Generate the 404 upgrade message once instead of on every request
handled, since the information displayed should not change and
grabbing the Puppet Version from JRuby is an expensive operation.