### PR TITLE
(maint) Update webrouting configs for master service

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -29,6 +29,8 @@ webserver: {
 
 # configure the mount points for the web apps
 web-router-service: {
+    # These two should not be modified because the Puppet 4.x agent expects
+    # them to be mounted at these specific paths
     "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": "/puppet-ca"
     "puppetlabs.services.master.master-service/master-service": {master-routes:       "/puppet"
 

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -42,7 +42,8 @@
      :certificate-authority {:certificate-status {:client-whitelist []
                                                   :authorization-required false}}
      :web-router-service    {:puppetlabs.services.ca.certificate-authority-service/certificate-authority-service "/puppet-ca"
-                             :puppetlabs.services.master.master-service/master-service "/puppet"
+                             :puppetlabs.services.master.master-service/master-service {:master-routes "/puppet"
+                                                                                        :invalid-in-puppet-4 "/"}
                              :puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service "/admin"}
      :puppet-admin          {:client-whitelist []
                              :authorization-required false}}))

--- a/ezbake/config/conf.d/web-routes.conf
+++ b/ezbake/config/conf.d/web-routes.conf
@@ -2,7 +2,11 @@ web-router-service: {
     # These two should not be modified because the Puppet 4.x agent expects them to
     # be mounted at these specific paths
     "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": "/puppet-ca"
-    "puppetlabs.services.master.master-service/master-service": "/puppet"
+    "puppetlabs.services.master.master-service/master-service": {master-routes:       "/puppet"
+
+                                                                 # The following controls 404 errors and should not
+                                                                 # be modified
+                                                                 invalid-in-puppet-4: "/" }
 
     # This controls the mount point for the puppet admin API.
     "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"


### PR DESCRIPTION
The webrouting config for the master service was changed for SERVER-300 to
have :master-routes and :invalid-in-puppet-4. This commit updates the
webrouting config for packaging and the repl so that everything will work
properly.