### PR TITLE
(maint) Update packaging & acceptance tests to create puppet user

### DIFF
--- a/acceptance/suites/pre_suite/foss/20_install_released_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/20_install_released_puppet.rb
@@ -6,10 +6,6 @@ if (test_config[:puppetserver_install_mode] == :upgrade)
     end
   end
 
-  step "Run puppet as puppet user to prevent permissions errors later." do
-    puppet_apply_as_puppet_user
-  end
-
   step "Install released Puppet Server for upgrade test" do
     manifest = "
     package { 'puppetserver':

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -21,9 +21,6 @@ step "Install MRI Puppet Agents."
 
   end
 
-step "Run puppet as puppet user to prevent permissions errors later."
-  puppet_apply_as_puppet_user
-
 if (test_config[:puppetserver_install_mode] == :upgrade)
   step "Upgrade Puppet Server."
     upgrade_package(master, "puppetserver")

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,72 +1,74 @@
-# NOTE: I'm no longer certain whether or not it actually makes sense to keep this
-# file in this repo.  When we have to do preinst stuff, we get into a situation
-# where we need to do some kind of variable interpolation into the commands
-# that we're expressing here... and it's starting to feel like we just have
-# too many levels of indirection going on.  Maybe this stuff should just be
-# kept directly in the ezbake repo.
 ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["puppet-agent"
                                "java-1.7.0-openjdk"],
-               # This is terrible, but we need write access to puppet's
-               # var/conf dirs, so we need to add ourselves to the group.
-               # Then we need to chmod some dirs until the Puppet packaging
-               # is changed to allow group write; Haus said that this
-               # has probably the way to do it for now.  There might be a better
-               # way to get rid of the hard-coded paths here, but I don't
-               # know it.
-               preinst: ["install --group={{user}} --owner={{user}} -d /var/lib/puppet/jruby-gems",
-                         "mkdir -p /etc/puppet/agent/manifests"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.
                install: ["echo \\\"os-settings: {\\\"                         > %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf",
                          "echo \\\"    ruby-load-path: [/opt/puppetlabs/agent/lib/ruby/vendor_ruby]\\\" >> %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf",
                          "echo \\\"}\\\"                                      >> %{buildroot}%{_sysconfdir}/%{realname}/conf.d/os-settings.conf" ],
-               # TODO: All of this is only necessary because puppet-agent packages
-               # are currently missing some things. We should remove this once
-               # puppet-agent packages are settled. See SERVER-333.
-               postinst: ["usermod -d /opt/puppetlabs/agent/cache puppet",
+               # This is terrible, but we need write access to puppet's
+               # var/conf dirs, so we need to add ourselves to the group.
+               # Then we need to chmod some dirs until the Puppet packaging
+               # is changed to allow group write.
+               # TODO: The Puppet agent package is currently missing some
+               # things. We should clean this up if possible once puppet-agent
+               # packages are settled. See SERVER-333.
+               postinst: ["install --directory --group=puppet --owner=puppet /var/lib/puppet/jruby-gems",
+                          "usermod -d /opt/puppetlabs/agent/cache puppet",
                           "chown puppet:puppet /opt/puppetlabs/agent/cache",
                           "chmod 775 /opt/puppetlabs/agent/cache",
+                          "install --directory /opt/puppetlabs/agent/cache/reports",
+                          "chown puppet:puppet /opt/puppetlabs/agent/cache/reports",
+                          "chmod 775 /opt/puppetlabs/agent/cache/reports",
                           "echo \\\"[master]\\\"                               > /etc/puppetlabs/agent/puppet.conf"
                           "echo \\\"vardir = /opt/puppetlabs/agent/cache\\\"   >> /etc/puppetlabs/agent/puppet.conf",
                           "echo \\\"logdir = /var/log/puppetlabs\\\"           >> /etc/puppetlabs/agent/puppet.conf",
-                          "echo \\\"rundir = /var/run/puppetlabs\\\"    >> /etc/puppetlabs/agent/puppet.conf",
+                          "echo \\\"rundir = /var/run/puppetlabs\\\"           >> /etc/puppetlabs/agent/puppet.conf",
                           "chown puppet:puppet /etc/puppetlabs/agent/",
                           "chmod 775 /etc/puppetlabs/agent",
-                          "chown puppet:puppet /var/log/puppetlabs/",
-                          "chmod 770 /var/log/puppetlabs"]
+                          "install --directory /etc/puppetlabs/agent/ssl",
+                          "chown -R puppet:puppet /etc/puppetlabs/agent/ssl",
+                          "chmod -R 770 /etc/puppetlabs/agent/ssl",
+                          "chown -R puppet:puppet /var/log/puppetlabs/",
+                          "chmod -R 770 /var/log/puppetlabs"]
              }
 
       debian: { dependencies: ["puppet-agent"
                                "openjdk-7-jre-headless"],
-               # see redhat comments on why this is terrible
-               preinst: ["install --group={{user}} --owner={{user}} -d /var/lib/puppet/jruby-gems",
-                         "mkdir -p /var/run/puppet",
-                         "mkdir -p /etc/puppet/agent/manifests"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.
                install: ["echo \\\"os-settings: {\\\"                       > $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf"
                          "echo \\\"    ruby-load-path: [/opt/puppetlabs/agent/lib/ruby/vendor_ruby]\\\"  >> $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf",
                          "echo \\\"}\\\"                                    >> $(BUILD_ROOT)/$(confdir)/$(realname)/conf.d/os-settings.conf"],
-               # TODO: All of this is only necessary because puppet-agent packages
-               # are currently missing some things. We should remove this once
-               # puppet-agent packages are settled. See SERVER-333.
-               postinst: ["usermod -d /opt/puppetlabs/agent/cache puppet",
+               # This is terrible, but we need write access to puppet's
+               # var/conf dirs, so we need to add ourselves to the group.
+               # Then we need to chmod some dirs until the Puppet packaging
+               # is changed to allow group write.
+               # TODO: The Puppet agent package is currently missing some
+               # things. We should clean this up if possible once puppet-agent
+               # packages are settled. See SERVER-333.
+               postinst: ["install --directory --group=puppet --owner=puppet /var/lib/puppet/jruby-gems",
+                          "usermod -d /opt/puppetlabs/agent/cache puppet",
                           "chown puppet:puppet /opt/puppetlabs/agent/cache",
                           "chmod 775 /opt/puppetlabs/agent/cache",
+                          "install --directory /opt/puppetlabs/agent/cache/reports",
+                          "chown puppet:puppet /opt/puppetlabs/agent/cache/reports",
+                          "chmod 775 /opt/puppetlabs/agent/cache/reports",
                           "echo \\\"[master]\\\"                               > /etc/puppetlabs/agent/puppet.conf"
                           "echo \\\"vardir = /opt/puppetlabs/agent/cache\\\"   >> /etc/puppetlabs/agent/puppet.conf",
                           "echo \\\"logdir = /var/log/puppetlabs\\\"           >> /etc/puppetlabs/agent/puppet.conf",
-                          "echo \\\"rundir = /var/run/puppetlabs/server\\\"    >> /etc/puppetlabs/agent/puppet.conf",
+                          "echo \\\"rundir = /var/run/puppetlabs\\\"           >> /etc/puppetlabs/agent/puppet.conf",
                           "chown puppet:puppet /etc/puppetlabs/agent/",
                           "chmod 775 /etc/puppetlabs/agent",
-                          "chown puppet:puppet /var/log/puppetlabs/",
-                          "chmod 770 /var/log/puppetlabs"]
-
+                          "install --directory /etc/puppetlabs/agent/ssl",
+                          "chown -R puppet:puppet /etc/puppetlabs/agent/ssl",
+                          "chmod -R 770 /etc/puppetlabs/agent/ssl",
+                          "chown -R puppet:puppet /var/log/puppetlabs/",
+                          "chmod -R 770 /var/log/puppetlabs"]
              }
    }
 }


### PR DESCRIPTION
Previously, the puppet package created the puppet user and group. However, the
puppet agent does not require this user, since it runs as root. The puppet
user is only required for the master. The puppet-agent AIO packages will not
be creating the puppet user or group, so the puppetserver packages must now do
this and must also set proper permissions on certain directories. This commit
adds the necessary steps to the postinstall.

It also removes the `puppet_apply_as_puppet_user` method from the acceptance
helpers, which 1) is no longer required, and 2) since the puppet user is not
created before installing the puppetserver package, we couldn't complete this
step.