### PR TITLE
(SERVER-157) use the keylength settings from puppet.conf

### DIFF
--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -28,6 +28,7 @@
     :cert-inventory
     :certname
     :csrdir
+    :keylength
     :hostcert
     :hostcrl
     :hostprivkey

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -23,7 +23,8 @@
         :hostpubkey     (str ssldir "/public_keys/" hostname ".pem")
         :localcacert    (str ssldir "/certs/ca.pem")
         :requestdir     (str ssldir "/certificate_requests")
-        :csr-attributes (str confdir "/csr_attributes.yaml")})))
+        :csr-attributes (str confdir "/csr_attributes.yaml")
+        :keylength      512})))
 
 (defn ca-settings
   "CA configuration settings with defaults appropriate for testing.
@@ -41,6 +42,7 @@
    :capub                 (str cadir "/ca_pub.pem")
    :cert-inventory        (str cadir "/inventory.txt")
    :csrdir                (str cadir "/requests")
+   :keylength             512
    :signeddir             (str cadir "/signed")
    :serial                (str cadir "/serial")
    :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib"]})


### PR DESCRIPTION
Caution: this is a PR hacked at vey high speed during the Ghent Puppet Contributor Summit after several conference days, so it might have many issues :)

This new feature makes the puppet-server respect the puppet.conf keylength parameter when creating new certificates.

Unlike what suggested in the original ticket, there's no specific error message about invalid keylength as the jvm current error message looked sufficient. 

Please review and feel free to comment!
Brice 