### PR TITLE
(SERVER-338) Ensure netstat is available for service management

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -2,7 +2,8 @@ ezbake: {
    pe: {}
    foss: {
       redhat: { dependencies: ["puppet-agent"
-                               "java-1.7.0-openjdk"],
+                               "java-1.7.0-openjdk"
+                               "net-tools"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.
@@ -37,7 +38,8 @@ ezbake: {
              }
 
       debian: { dependencies: ["puppet-agent"
-                               "openjdk-7-jre-headless"],
+                               "openjdk-7-jre-headless"
+                               "net-tools"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.


### PR DESCRIPTION
Without this patch the puppet server service fails to start at the service
management framework layer.  The failure is caused by the service unit
attempting to use netstat to check for listening ports and netstat not being
available.

This patch addresses the problem by expressing a dependency on net-tools, which
contains netstat so that netstat is always available after package installation
and before service management.

Pre-testing
---

Verified by building the packages from this local topic branch as per
documentation at
https://confluence.puppetlabs.com/display/ENG/How+To+build+Puppet+Server+from+a+local+topic+branch
and running the acceptance tests.  The netstat command is successfully
installed and the service starts.  Huzzah.