### PR TITLE
(SERVER-338) Use lein-ezbake 0.1.2 to resolve netstat issue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.1.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.1.2"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -1,8 +1,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent"
-                               "java-1.7.0-openjdk"],
+      redhat: { dependencies: ["puppet-agent"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.
@@ -36,8 +35,7 @@ ezbake: {
                           "chmod -R 770 /var/log/puppetlabs"]
              }
 
-      debian: { dependencies: ["puppet-agent"
-                               "openjdk-7-jre-headless"],
+      debian: { dependencies: ["puppet-agent"],
                # TODO: With AIO packages, ruby-load-path is now the same
                # across all platforms, so we don't need this. It should be
                # moved to a regular config file. See SERVER-331.


### PR DESCRIPTION
Without this patch the dependency on the JVM packages are expressed in the
project specific ezbake configuration.  This is a problem because it duplicates
the same dependency expressed statically in the [ezbake package
specifications][requires].  The duplication is confusing and more difficult to
coordinate and maintain over time.

The principle for dependencies is that those required to satisfy the behavior
of ezbake itself, or the system level service management scripts, should be
expressed statically in ezbake since those dependencies will apply to all
projects using ezbake and the resulting scripts.  Application level
dependencies should be specified in the project specific ezbake.conf file such
that individual applications are not interdependent on common dependencies.

[requires]: https://github.com/puppetlabs/ezbake/blob/418e4815edf159c753e148395b3e725f8d202c17/resources/puppetlabs/lein-ezbake/template/foss/ext/redhat/ezbake.spec.erb#L5