### PR TITLE
(SERVER-294) delete Content-Type hack

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 lein2 test :all
 
 rake spec

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.0"]
-                 [puppetlabs/http-client "0.4.1"]
+                 [puppetlabs/http-client "0.4.2"]
                  [org.jruby/jruby-core "1.7.18"
                   :exclusions
                   [com.github.jnr/jffi com.github.jnr/jnr-x86asm com.github.jnr/jnr-ffi

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -37,22 +37,8 @@
                    (request-handler request))
     (compojure/GET "/file_bucket_file/*" request
                    (request-handler request))
-
-    ;; TODO: file_bucket_file request PUTs from Puppet agents currently use a
-    ;; Content-Type of 'text/plain', which, per HTTP specification, would imply
-    ;; a default character encoding of ISO-8859-1 or US-ASCII be used to decode
-    ;; the data.  This would be incorrect to do in this case, however, because
-    ;; the actual payload is "binary".  Coercing this to
-    ;; "application/octet-stream" for now as this is synonymous with "binary".
-    ;; This should be removed when/if Puppet agents start using an appropriate
-    ;; Content-Type to describe the input payload - see PUP-3812 for the core
-    ;; Puppet work and SERVER-294 for the related Puppet Server work that
-    ;; would be done.
     (compojure/PUT "/file_bucket_file/*" request
-                   (request-handler (assoc request
-                                           :content-type
-                                           "application/octet-stream")))
-
+                   (request-handler request))
     (compojure/HEAD "/file_bucket_file/*" request
                    (request-handler request))
     (compojure/GET "/catalog/*" request

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -66,7 +66,7 @@
                options                 (merge ssl-request-options
                                               {:body (ByteArrayInputStream.
                                                        raw-byte-arr)
-                                               :headers {"accept" "application/octet-stream"
+                                               :headers {"accept" "binary"
                                                          "content-type" "application/octet-stream"}})
                response (http-client/put (str "https://localhost:8140/"
                                               "puppet/v3/file_bucket_file/md5/"

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -63,18 +63,11 @@
                                                        (subs expected-md5 0 8))
                                           expected-md5
                                           "contents"])
-               ;; This accept and content-type header match what the Puppet
-               ;; agent sends to the master for a file-bucket PUT. Ideally,
-               ;; these should both be 'application/octet-stream', but for now
-               ;; we have to live with 'binary' content-type because
-               ;; everything is terrible.
                options                 (merge ssl-request-options
                                               {:body (ByteArrayInputStream.
                                                        raw-byte-arr)
-                                               :headers {"accept"
-                                                           "binary"
-                                                         "content-type"
-                                                           "application/octet-stream"}})
+                                               :headers {"accept" "application/octet-stream"
+                                                         "content-type" "application/octet-stream"}})
                response (http-client/put (str "https://localhost:8140/"
                                               "puppet/v3/file_bucket_file/md5/"
                                               expected-md5

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -37,16 +37,24 @@
                  ", path: "
                  path))))))
 
-(deftest file-bucket-file
-  (testing (str "that the content-type in the ring request is replaced with "
-                "application/octet-stream for a file_bucket_file put request")
+(deftest file-bucket-file-content-type-test
+  (testing (str "The 'Content-Type' header on incoming /file_bucket_file requests "
+                "is not overwritten, and simply passed through unmodified.")
     (let [handler     (fn ([req] {:request req}))
           app         (build-ring-handler handler)
           resp        (app {:request-method :put
-                            :content-type   "text/plain"
+                            :content-type   "application/octet-stream"
                             :uri            "/v3/file_bucket_file/bar"})]
       (is (= "application/octet-stream"
-             (get-in resp [:request :content-type]))))))
+             (get-in resp [:request :content-type])))
+
+      (testing "Even if the client sends something insane, "
+               "just pass it through and let the puppet code handle it."
+        (let [resp (app {:request-method :put
+                         :content-type   "something-crazy/for-content-type"
+                         :uri            "/v3/file_bucket_file/bar"})]
+          (is (= "something-crazy/for-content-type"
+                 (get-in resp [:request :content-type]))))))))
 
 (defn assert-failure-msg
   "Assert the message thrown by validate-memory-requirements! matches re"


### PR DESCRIPTION
Delete a terrible hack which munged the Content-Type header of incoming
/file_bucket_file requests to always be 'application/octet-stream'.
Historically, the agent has sent a value of 'text/plain' for this
header, but that is fixed as of PUP-3812.

I think that the primary risk of a regression here would be to accidentally break handling of non-UTF8 data (as we originally did in SERVER-269) - however, that should be sufficiently covered by the integration test in `puppetlabs.services.jruby.request-handler-test/file-bucket-test`.  So, I think this is good on test coverage.