### PR TITLE
(SERVER-319) Apache-style access log

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -1,0 +1,14 @@
+puppetlabs.services.request-handler.request-handler-service/request-handler-service
+puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
+puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service
+puppetlabs.services.config.puppet-server-config-service/puppet-server-config-service
+puppetlabs.services.master.master-service/master-service
+puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
+puppetlabs.services.version.version-check-service/version-check-service
+
+# To enable the CA service, leave the following line uncommented
+puppetlabs.services.ca.certificate-authority-service/certificate-authority-service
+# To disable the CA service, comment out the above line and uncomment the line below
+#puppetlabs.services.ca.certificate-authority-disabled-service/certificate-authority-disabled-service

--- a/ezbake/config/conf.d/global.conf
+++ b/ezbake/config/conf.d/global.conf
@@ -1,0 +1,9 @@
+global: {
+    # Path to logback logging configuration file; for more
+    # info, see http://logback.qos.ch/manual/configuration.html
+    logging-config: /etc/puppetserver/logback.xml
+}
+
+product: {
+    name: puppetserver
+}

--- a/ezbake/config/conf.d/web-routes.conf
+++ b/ezbake/config/conf.d/web-routes.conf
@@ -1,0 +1,9 @@
+web-router-service: {
+    # These two should not be modified because the Puppet 3.x agent expects them to
+    # be mounted at "/"
+    "puppetlabs.services.ca.certificate-authority-service/certificate-authority-service": ""
+    "puppetlabs.services.master.master-service/master-service": ""
+
+    # This controls the mount point for the puppet admin API.
+    "puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service": "/puppet-admin-api"
+}

--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,0 +1,5 @@
+webserver: {
+    client-auth = want
+    ssl-host = 0.0.0.0
+    ssl-port = 8140
+}

--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,4 +1,5 @@
 webserver: {
+    access-log-config = /etc/puppetserver/request-logging.xml
     client-auth = want
     ssl-host = 0.0.0.0
     ssl-port = 8140

--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <!-- TODO: this path should not be hard-coded -->
+        <file>/var/log/puppetserver/puppetserver.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="info">
+        <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
 (def tk-version "1.0.1")
 (def tk-jetty-version "1.1.0")
 (def ks-version "1.0.0")
+(def ps-version "1.0.4-SNAPSHOT")
 
 (defn deploy-info
   [url]
@@ -9,7 +10,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/puppet-server "1.0.4-SNAPSHOT"
+(defproject puppetlabs/puppet-server ps-version
   :description "Puppet Server"
 
   :dependencies [[org.clojure/clojure "1.5.1"]
@@ -50,7 +51,17 @@
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
-  :plugins [[lein-release "1.0.5"]]
+  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
+
+  :uberjar-name "puppet-server-release.jar"
+  :lein-ezbake {:vars {:user "puppet"
+                       :group "puppet"
+                       :start-timeout "120"
+                       :build-type "foss"
+                       :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}
+                :resources {:dir "tmp/ezbake-resources"}
+                :config-dir "ezbake/config"}
+
   :lein-release {:scm         :git
                  :deploy-via  :lein-deploy}
 
@@ -69,6 +80,12 @@
                    :injections    [(require 'spyscope.core)]
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
+
+             :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
+                                               [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
+                                               [org.clojure/tools.nrepl "0.2.3"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.1.2"]]
+                      :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}
              :ci {:plugins [[lein-pprint "1.1.1"]]}}

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/var/log/puppetserver/puppetserver-access.log</file>
+    <encoder>
+        <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+    </encoder>
+  </appender>
+  <appender-ref ref="FILE" />
+</configuration>


### PR DESCRIPTION
This brings stable up to match master's ezbake-as-a-plugin support, and more importantly adds a new Apache-style `puppetserver-access.log` file to capture HTTP traffic.

This isn't naturally testable at a unit/integration level, but I hand-verified the package on a VM.
The result was `/var/log/puppetserver/puppetserver-access.log` with contents like:
```
172.16.127.170 - - - 22/Oct/2014:16:07:00 -0700 "GET /production/certificate_revocation_list/ca? HTTP/1.1" 200 975 172.16.127.170 172.16.127.170 8140 20
172.16.127.170 - - - 22/Oct/2014:16:07:01 -0700 "GET /production/node/centos6-64.localdomain?transaction_uuid=76760d6d-ae27-4e26-aa17-444bf4e72168&fail_on_404=true HTTP/1.1" 200 92 172.16.127.170 172.16.127.170 8140 188
172.16.127.170 - - - 22/Oct/2014:16:07:01 -0700 "GET /production/file_metadatas/pluginfacts?checksum_type=md5&ignore=.svn&ignore=CVS&ignore=.git&recurse=true&links=manage HTTP/1.1" 200 278 172.16.127.170 172.16.127.170 8140 102
172.16.127.170 - - - 22/Oct/2014:16:07:01 -0700 "GET /production/file_metadatas/plugins?checksum_type=md5&ignore=.svn&ignore=CVS&ignore=.git&recurse=true&links=manage HTTP/1.1" 200 278 172.16.127.170 172.16.127.170 8140 91
172.16.127.170 - - - 22/Oct/2014:16:07:02 -0700 "POST /production/catalog/centos6-64.localdomain HTTP/1.1" 200 583 172.16.127.170 172.16.127.170 8140 335
172.16.127.170 - - - 22/Oct/2014:16:07:02 -0700 "PUT /production/report/centos6-64.localdomain HTTP/1.1" 200 9 172.16.127.170 172.16.127.170 8140 73
172.16.127.170 - - - 22/Oct/2014:16:07:05 -0700 "GET /production/node/centos6-64.localdomain?transaction_uuid=923b3f56-415a-46a0-88b3-76e68d331b2e&fail_on_404=true HTTP/1.1" 200 4295 172.16.127.170 172.16.127.170 8140 47
172.16.127.170 - - - 22/Oct/2014:16:07:05 -0700 "GET /production/file_metadatas/pluginfacts?checksum_type=md5&ignore=.svn&ignore=CVS&ignore=.git&recurse=true&links=manage HTTP/1.1" 200 278 172.16.127.170 172.16.127.170 8140 17
172.16.127.170 - - - 22/Oct/2014:16:07:05 -0700 "GET /production/file_metadatas/plugins?checksum_type=md5&ignore=.svn&ignore=CVS&ignore=.git&recurse=true&links=manage HTTP/1.1" 200 278 172.16.127.170 172.16.127.170 8140 33
172.16.127.170 - - - 22/Oct/2014:16:07:06 -0700 "POST /production/catalog/centos6-64.localdomain HTTP/1.1" 200 583 172.16.127.170 172.16.127.170 8140 148
172.16.127.170 - - - 22/Oct/2014:16:07:06 -0700 "PUT /production/report/centos6-64.localdomain HTTP/1.1" 200 9 172.16.127.170 172.16.127.170 8140 51
```

<hr>

__IMPORTANT__ This breaks our release tool that automatically updates the project.clj version string because that tool expects a literal string after `(defproject puppetlabs/puppet-server ` but now we have a variable, `ps-version`.

This issue is tracked in [SERVER-359](https://tickets.puppetlabs.com/browse/SERVER-359).