### PR TITLE
(SERVER-354) fix initialization of Puppet logging

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -1,0 +1,18 @@
+require 'puppet/server/puppet_config'
+
+describe Puppet::Server::PuppetConfig do
+  mock_puppet_config = {}
+  context "Puppet's log level" do
+    it "is set as high as possible during initialization, " +
+       "so that all log messages make it to logback" do
+
+      Puppet::Server::PuppetConfig.initialize_puppet mock_puppet_config
+
+      # The first line here is probably sufficient, but there's been some
+      # changes in Puppet recently around logging, so it seems worthwhile
+      # to test both of these.
+      Puppet[:log_level].should == "debug"
+      Puppet::Util::Log.level.should == :debug
+    end
+  end
+end

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -22,7 +22,7 @@ class Puppet::Server::PuppetConfig
     Puppet[:trace] = true
 
     # Crank Puppet's log level all the way up and just control it via logback.
-    Puppet::Util::Log.level = :debug
+    Puppet[:log_level] = "debug"
 
     master_run_mode = Puppet::Util::RunMode[:master]
     app_defaults = Puppet::Settings.app_defaults_for_run_mode(master_run_mode).


### PR DESCRIPTION
Recently, Puppet was changed to allow the log level to be configured via
settings.  This broke the way in which we were previously initializing
it.  This commit fixes that initialization and adds a ruby spec test to
ensure that logging is initialized correctly.

In addition to the spec test, I also manually verified this change - [here's the log output](https://gist.githubusercontent.com/KevinCorcoran/4b1338a6e0ab1edd3c81/raw/5cc253523ae6ab8bac73c9c9dfcd1f892e4de29f/gistfile1.txt) of starting Puppet Server and doing a no-op agent run against it previously, and [here's the logging](https://gist.githubusercontent.com/KevinCorcoran/704169f20c06efaf86de/raw/e19594eb81ec943f9828b7262c2eaf8f8e993b9a/gistfile1.txt) for the same process but including this patch.