### PR TITLE
(SERVER-360) Fix common_package_name_in_different_providers test

### DIFF
--- a/acceptance/suites/pre_suite/foss/50_install_puppet_acceptance_deps.rb
+++ b/acceptance/suites/pre_suite/foss/50_install_puppet_acceptance_deps.rb
@@ -1,0 +1,24 @@
+# NOTE: Ideally, the acceptance tests itself will manage its own dependencies,
+# however, the puppet agent codebase is in flux with AIO changes right now so we
+# are satisfying specific dependencies in the pre-suite of the puppet-server
+# codebase.  If you add to this file, please comment regarding what the
+# dependency is for (the specific puppet acceptance tests) so that we can easily
+# move these to the ideal location in the future.
+
+tests = options[:tests]
+
+step "Install System Dependencies for Puppet Acceptance Tests."
+hosts.each do |host|
+  variant = host['platform'].to_array.first
+  case variant
+    when /^(debian|ubuntu)$/
+      # Nothing to do
+    when /^(redhat|el|centos)$/
+      if tests.any? { |s| s =~ /common_package_name_in_different_providers/ }
+        step "Install deps for common_package_name_in_different_providers (REMOVE ONCE https://github.com/puppetlabs/puppet/pull/3601 is merged and present in ruby/puppet/)"
+        install_package host, 'createrepo'
+        install_package host, 'rpm-build'
+      end
+  end
+end
+


### PR DESCRIPTION
Without this patch the ruby puppet
`common_package_name_in_different_providers.rb` acceptance test is failing
because the createrepo command is not available on the system under test.  This
is causing the puppet-server acceptance tests to fail.

This patch resolves the problem by satisfying the dependency in the pre-suite.
This course of action is being taken over satisfying the dependency directly in
the common_package_name_in_different_providers.rb test because the state of the
puppet code-base is volatile with the AIO work.

This change will move the puppet-server tests closer to being green while also
leaving a clear indication of where the dependency installation should be moved
once the puppet code base is less volatile.