### PR TITLE
(server-382)(packaging) Create default production environment

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -69,6 +69,7 @@
                        :group "puppet"
                        :start-timeout "120"
                        :build-type "foss"
+                       :create-dirs ["/etc/puppetlabs/code/environments/production/manifests", "/etc/puppetlabs/code/environments/production/modules"]
                        :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}
                 :resources {:dir "tmp/ezbake-resources"}
                 :config-dir "ezbake/config"}
@@ -125,5 +126,3 @@
   ;; that from the final uberjar:
   :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
   )
-
-


### PR DESCRIPTION
As described in SERVER-382, we should be creating the default production environment for puppet-server installations.

This updates to the ezbake-0.2.2 release that added the ability to create arbitrary directories, and adds the default "production" environment directories to puppet-server packaging.

Also included are some fixes required to work properly with recent ezbake plugin releases.