### PR TITLE
(SERVER-386) Depend on puppet-agent AIO dev version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -26,13 +26,13 @@ module PuppetServerExtensions
                          nil, "Puppet Version", "PUPPET_VERSION", nil) ||
                          get_puppet_version
 
-    # SERVER-339 - puppet-agent commit 49f7b1b967e44020587ab087f87e2f5e3ff2b1f6
-    # corresponds to packaged development version located at
-    # http://builds.delivery.puppetlabs.net/puppet-agent/49f7b1b967e44020587ab087f87e2f5e3ff2b1f6/
+    # SERVER-339, SERVER-386 - puppet-agent version corresponds to packaged
+    # development version located at http://builds.delivery.puppetlabs
+    # .net/puppet-agent/
     # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "49f7b1b967e44020587ab087f87e2f5e3ff2b1f6")
+                         "PUPPET_BUILD_VERSION", "bc00b6e7106846aae0af5b915976a8d192e53803")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
Without this patch the puppet-agent dependency is out of date.  This is a
problem because we need to track puppet-agent as closely as possible to
minimize the likelihood of issues stemming from divergence from the underlying
Puppet behavior.

This updated version should have no behavior changes relative to the behavior
of the puppet-agent version in 33f5cf9.