### PR TITLE
(SERVER-356) Fix foreground output

### DIFF
--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -18,6 +18,8 @@
 
     <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
+        <!-- ${logappender} logs to console when running the foreground command -->
+        <appender-ref ref="${logappender}"/>
         <appender-ref ref="F1"/>
     </root>
 </configuration>


### PR DESCRIPTION
This commit re-adds the logappender ref to the logback.xml file, which
was somehow lost during a rebase or merge. With this change, the
foreground subcommand should now produce output.