### PR TITLE
(SERVER-319) Apache-style request logging

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -17,6 +17,7 @@ os-settings: {
 }
 
 webserver: {
+    access-log-config: ./dev/request-logging-dev.xml
     client-auth: want
     # ssl-host controls what networks the server will accept connections from.
     # The default value below is 'localhost', so will only accept connections from

--- a/dev/request-logging-dev.xml
+++ b/dev/request-logging-dev.xml
@@ -1,0 +1,9 @@
+<configuration scan="true" debug="false">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>./target/logs/puppetserver-access.log</file>
+    <encoder>
+        <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+    </encoder>
+  </appender>
+  <appender-ref ref="FILE" />
+</configuration>

--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,4 +1,5 @@
 webserver: {
+    access-log-config = /etc/puppetserver/request-logging.xml
     client-auth = want
     ssl-host = 0.0.0.0
     ssl-port = 8140

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,0 +1,9 @@
+<configuration debug="false">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/var/log/puppetserver/puppetserver-access.log</file>
+    <encoder>
+        <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+    </encoder>
+  </appender>
+  <appender-ref ref="FILE" />
+</configuration>


### PR DESCRIPTION
This commit adds a new Apache-style puppetserver-access.log file to
capture HTTP traffic.