### PR TITLE
(SERVER-389) Increase JRuby pool default-borrow-timeout

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -60,7 +60,7 @@ This file contains the settings for Puppet Server itself.
     * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable directory. If not specified, uses the Puppet default `/var/lib/puppet`.
     * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus+2'.
-    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 60000.
+    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 1200000.
 * The `profiler` settings configure profiling:
     * `enabled`: if this is set to `true`, it enables profiling for the Puppet Ruby code. Defaults to `false`.
 * The `puppet-admin` section configures the Puppet Server's administrative API. (This is a new API, which isn't provided by Rack or WEBrick Puppet masters.)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -77,8 +77,8 @@
     * :http-client-cipher-suites - A list of legal SSL cipher suites that may
         be used when https client requests are made.
 
-    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool in milliseconds.
-        Defaults to 60000."
+    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool
+        in milliseconds. Defaults to 1200000."
   {:ruby-load-path                                  [schema/Str]
    :gem-home                                        schema/Str
    (schema/optional-key :master-conf-dir)           schema/Str
@@ -190,7 +190,7 @@
         (.put puppet-config "confdir" (fs/absolute-path master-conf-dir)))
       (when master-var-dir
         (.put puppet-config "vardir" (fs/absolute-path master-var-dir)))
-        
+
       (when http-client-ssl-protocols
         (.put puppet-server-config "ssl_protocols" (into-array String http-client-ssl-protocols)))
       (when http-client-cipher-suites

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -10,7 +10,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
 
-(def default-borrow-timeout 60000)
+(def default-borrow-timeout
+  "Default timeout when borrowing instances from the JRuby pool in
+   milliseconds. Current value is 1200000ms, or 20 minutes."
+  1200000)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -61,7 +64,7 @@
     (let [pool-context (:pool-context (tk-services/service-context this))
           pool         (core/get-pool pool-context)]
       (core/free-instance-count pool)))
-  
+
   (mark-all-environments-expired!
     [this]
     (let [pool-context (:pool-context (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -10,7 +10,7 @@
     available. A timeout (integer measured in milliseconds) can be configured
     which will either return an interpreter if one is available within the
     timeout length, or will return nil after the timeout expires if no
-    interpreters are available. This timeout defaults to 60000 milliseconds.")
+    interpreters are available. This timeout defaults to 1200000 milliseconds.")
 
   (return-instance
     [this jrubypuppet-instance]
@@ -27,5 +27,3 @@
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool."))
-
-      


### PR DESCRIPTION
This commit simply increases the timeout to 1200000 ms (20 minutes).