### PR TITLE
(FOR REVIEW) (SERVER-325) flush jrubies after max requests

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -2,7 +2,7 @@
   (:import (org.jruby Main RubyInstanceConfig CompatVersion)
            (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (defn run!
   [config args]
@@ -17,7 +17,7 @@
                        (.put "GEM_HOME" gem-home))
         jruby-home   (.getJRubyHome jruby-config)
         load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir)
+                          (cons jruby-internal/ruby-code-dir)
                           (cons (str jruby-home "/lib/ruby/1.9"))
                           (cons (str jruby-home "/lib/ruby/shared"))
                           (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -2,12 +2,12 @@
   (:import (org.jruby Main RubyInstanceConfig CompatVersion)
            (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (defn new-jruby-main
   [config]
   (let [load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir))
+                          (cons jruby-internal/ruby-code-dir))
         gem-home     (get-in config [:jruby-puppet :gem-home])
         jruby-config (new RubyInstanceConfig)
         env          (doto (HashMap. (.getEnvironment jruby-config))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.services.jruby.jruby-puppet-agents
-  (:import (clojure.lang IFn Agent)
+  (:import (clojure.lang IFn)
            (com.puppetlabs.puppetserver PuppetProfiler)
            (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill))
   (:require [schema.core :as schema]
@@ -8,28 +8,14 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Schemas
-
-(def JRubyPoolAgent
-  "An agent configured for use in managing JRuby pools"
-  (schema/both Agent
-               (schema/pred
-                 (fn [a]
-                   (let [state @a]
-                     (and
-                       (map? state)
-                       (ifn? (:shutdown-on-error state))))))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (schema/defn ^:always-validate
-  send-agent :- JRubyPoolAgent
+  send-agent :- jruby-schemas/JRubyPoolAgent
   "Utility function; given a JRubyPoolAgent, send the specified function.
   Ensures that the function call is wrapped in a `shutdown-on-error`."
-  [jruby-agent :- JRubyPoolAgent
+  [jruby-agent :- jruby-schemas/JRubyPoolAgent
    f :- IFn]
   (letfn [(agent-fn [agent-ctxt]
                     (let [shutdown-on-error (:shutdown-on-error agent-ctxt)]
@@ -113,23 +99,21 @@
 ;;; Public
 
 (schema/defn ^:always-validate
-  pool-agent :- JRubyPoolAgent
+  pool-agent :- jruby-schemas/JRubyPoolAgent
   "Given a shutdown-on-error function, create an agent suitable for use in managing
   JRuby pools."
-  [shutdown-on-error-fn :- IFn]
+  [shutdown-on-error-fn :- (schema/maybe (schema/pred ifn?))]
   (agent {:shutdown-on-error shutdown-on-error-fn}))
 
 (schema/defn ^:always-validate
-  send-prime-pool! :- JRubyPoolAgent
+  send-prime-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends a request to the agent to prime the pool using the given pool context."
-  [pool-context :- jruby-schemas/PoolContext
-   pool-agent :- JRubyPoolAgent]
-  (let [{:keys [pool-state config profiler]} pool-context]
+  [pool-context :- jruby-schemas/PoolContext]
+  (let [{:keys [pool-state pool-agent config profiler]} pool-context]
     (send-agent pool-agent #(prime-pool! pool-state config profiler))))
 
 (schema/defn ^:always-validate
-  send-flush-pool! :- JRubyPoolAgent
+  send-flush-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends requests to the agent to flush the existing pool and create a new one."
-  [pool-context :- jruby-schemas/PoolContext
-   pool-agent :- JRubyPoolAgent]
-  (send-agent pool-agent #(flush-pool! pool-context)))
+  [pool-context :- jruby-schemas/PoolContext]
+  (send-agent (:pool-agent pool-context) #(flush-pool! pool-context)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -83,7 +83,10 @@
     (doseq [i (range count)]
       (try
         (let [id        (inc i)
-              instance  (jruby-internal/borrow-from-pool (:pool old-pool))]
+              instance  (jruby-internal/borrow-from-pool!*
+                          jruby-internal/borrow-without-timeout-fn
+                          (:pool old-pool)
+                          pool-context)]
           (flush-instance! instance new-pool id config profiler)
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
                      id count))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -56,7 +56,7 @@
                        id count))))
       (catch Exception e
         (.clear pool)
-        (.put pool (PoisonPill. e))
+        (.putFirst pool (PoisonPill. e))
         (throw (IllegalStateException. "There was a problem adding a JRubyPuppet instance to the pool." e))))))
 
 (schema/defn ^:always-validate
@@ -91,7 +91,7 @@
                      id count)
           (catch Exception e
             (.clear new-pool)
-            (.put new-pool (PoisonPill. e))
+            (.putFirst new-pool (PoisonPill. e))
             (throw (IllegalStateException.
                      "There was a problem adding a JRubyPuppet instance to the pool."
                      e))))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -80,21 +80,21 @@
     (reset! pool-state new-pool-state)
     (log/info "Swapped JRuby pools, beginning cleanup of old pool.")
     (doseq [i (range count)]
-      (let [id (inc i)
-            instance (jruby-core/borrow-from-pool (:pool old-pool))]
-        (try
+      (try
+        (let [id (inc i)
+              instance (jruby-core/borrow-from-pool (:pool old-pool))]
           (.terminate (:scripting-container instance))
           (log/infof "Cleaned up old JRuby instance %s of %s, creating replacement."
                      id count)
           (jruby-core/create-pool-instance! new-pool id config profiler)
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
-                     id count)
-          (catch Exception e
-            (.clear new-pool)
-            (.putFirst new-pool (PoisonPill. e))
-            (throw (IllegalStateException.
-                     "There was a problem adding a JRubyPuppet instance to the pool."
-                     e))))))
+                     id count))
+        (catch Exception e
+          (.clear new-pool)
+          (.putFirst new-pool (PoisonPill. e))
+          (throw (IllegalStateException.
+                   "There was a problem adding a JRubyPuppet instance to the pool."
+                   e)))))
     (jruby-core/return-to-pool (RetryPoisonPill. (:pool old-pool)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -1,15 +1,25 @@
 (ns puppetlabs.services.jruby.jruby-puppet-agents
-  (:import (clojure.lang IFn)
-           (com.puppetlabs.puppetserver PuppetProfiler)
-           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill))
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
+  (:import (clojure.lang IFn)
+           (com.puppetlabs.puppetserver PuppetProfiler)
+           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill JRubyPuppetInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
+
+(schema/defn ^:always-validate
+  next-instance-id :- schema/Int
+  [id :- schema/Int
+   pool-context :- jruby-schemas/PoolContext]
+  (let [pool-size (jruby-internal/get-pool-size pool-context)
+        next-id (+ id pool-size)]
+    (if (> next-id Integer/MAX_VALUE)
+      (mod next-id pool-size)
+      next-id)))
 
 (schema/defn ^:always-validate
   send-agent :- jruby-schemas/JRubyPoolAgent
@@ -50,7 +60,7 @@
   flush-instance!
   "Flush a single JRuby instance.  Create a new replacement instance
   and insert it into the specified pool."
-  [{:keys [scripting-container id]} :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  [{:keys [scripting-container id]} :- JRubyPuppetInstance
    new-pool :- jruby-schemas/pool-queue-type
    new-id   :- schema/Int
    config   :- jruby-schemas/JRubyPuppetConfig
@@ -59,6 +69,8 @@
   (log/infof "Cleaned up old JRuby instance with id %s, creating replacement."
              id)
   (jruby-internal/create-pool-instance! new-pool new-id config profiler))
+
+(declare send-flush-instance!)
 
 (schema/defn ^:always-validate
   flush-pool!
@@ -86,7 +98,8 @@
               instance  (jruby-internal/borrow-from-pool!*
                           jruby-internal/borrow-without-timeout-fn
                           (:pool old-pool)
-                          pool-context)]
+                          pool-context
+                          send-flush-instance!)]
           (flush-instance! instance new-pool id config profiler)
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
                      id count))
@@ -105,7 +118,7 @@
   pool-agent :- jruby-schemas/JRubyPoolAgent
   "Given a shutdown-on-error function, create an agent suitable for use in managing
   JRuby pools."
-  [shutdown-on-error-fn :- (schema/maybe (schema/pred ifn?))]
+  [shutdown-on-error-fn :- (schema/pred ifn?)]
   (agent {:shutdown-on-error shutdown-on-error-fn}))
 
 (schema/defn ^:always-validate
@@ -120,3 +133,13 @@
   "Sends requests to the agent to flush the existing pool and create a new one."
   [pool-context :- jruby-schemas/PoolContext]
   (send-agent (:pool-agent pool-context) #(flush-pool! pool-context)))
+
+(schema/defn ^:always-validate
+  send-flush-instance! :- jruby-schemas/JRubyPoolAgent
+  "Sends requests to the flush-instance agent to flush the instance and create a new one."
+  [pool :- jruby-schemas/pool-queue-type
+   pool-context :- jruby-schemas/PoolContext
+   instance :- JRubyPuppetInstance]
+  (let [{:keys [flush-instance-agent config profiler]} pool-context
+        id (next-instance-id (:id instance) pool-context)]
+    (send-agent flush-instance-agent #(flush-instance! instance pool id config profiler))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:import (java.util.concurrent ArrayBlockingQueue BlockingQueue TimeUnit)
+  (:import (java.util.concurrent LinkedBlockingDeque BlockingDeque TimeUnit)
            (java.util HashMap)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (org.jruby.embed ScriptingContainer LocalContextScope)
@@ -22,7 +22,7 @@
 (def pool-queue-type
   "The Java datastructure type used to store JRubyPuppet instances which are
   free to be borrowed."
-  BlockingQueue)
+  BlockingDeque)
 
 (def jruby-puppet-env
   "The environment variables that should be passed to the Puppet JRuby interpreters.
@@ -231,7 +231,7 @@
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
   {:post [(instance? pool-queue-type %)]}
-  (ArrayBlockingQueue. size))
+  (LinkedBlockingDeque. size))
 
 (defn verify-config-found!
   [config]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -68,11 +68,12 @@
   pool object has been created, it will need to be filled using `prime-pool!`."
   [config :- jruby-schemas/JRubyPuppetConfig
    profiler :- (schema/maybe PuppetProfiler)
-   agent-shutdown-fn :- (schema/maybe (schema/pred ifn?))]
-  {:config     config
-   :profiler   profiler
-   :pool-agent (jruby-agents/pool-agent agent-shutdown-fn)
-   :pool-state (atom (jruby-internal/create-pool-from-config config))})
+   agent-shutdown-fn :- (schema/pred ifn?)]
+  {:config                config
+   :profiler              profiler
+   :pool-agent            (jruby-agents/pool-agent agent-shutdown-fn)
+   :flush-instance-agent  (jruby-agents/pool-agent agent-shutdown-fn)
+   :pool-state            (atom (jruby-internal/create-pool-from-config config))})
 
 (schema/defn ^:always-validate
   free-instance-count
@@ -100,7 +101,9 @@
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool-context :- jruby-schemas/PoolContext]
-  (jruby-internal/borrow-from-pool pool-context))
+  (jruby-internal/borrow-from-pool
+    pool-context
+    jruby-agents/send-flush-instance!))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -113,7 +116,10 @@
   [pool-context :- jruby-schemas/PoolContext
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (jruby-internal/borrow-from-pool-with-timeout pool-context timeout))
+  (jruby-internal/borrow-from-pool-with-timeout
+    pool-context
+    timeout
+    jruby-agents/send-flush-instance!))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,16 +1,15 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:import (java.util.concurrent LinkedBlockingDeque BlockingDeque TimeUnit)
+  (:require [me.raynes.fs :as fs]
+            [schema.core :as schema]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env])
+  (:import (java.util.concurrent LinkedBlockingDeque TimeUnit)
            (java.util HashMap)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (org.jruby.embed ScriptingContainer LocalContextScope)
-           (clojure.lang Atom)
-           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet
-                                        EnvironmentRegistry))
-  (:require [clojure.tools.logging :as log]
-            [me.raynes.fs :as fs]
-            [schema.core :as schema]
-            [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]))
+           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill JRubyPuppetInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
@@ -18,11 +17,6 @@
 (def default-pool-size
   "The default size of each JRuby pool."
   (+ 2 (ks/num-cpus)))
-
-(def pool-queue-type
-  "The Java datastructure type used to store JRubyPuppet instances which are
-  free to be borrowed."
-  BlockingDeque)
 
 (def jruby-puppet-env
   "The environment variables that should be passed to the Puppet JRuby interpreters.
@@ -35,114 +29,6 @@
   "The name of the directory containing the ruby code in this project.
   This directory lives under src/ruby/"
   "puppet-server-lib")
-
-(defrecord PoisonPill
-  ;; A sentinel object to put into a pool in case an error occurs while we're trying
-  ;; to populate it.  This can be used by the `borrow` functions to detect error
-  ;; state in a thread-safe manner.
-  [err])
-
-(defrecord RetryPoisonPill
-  ;; A sentinel object to put into an old pool when we swap in a new pool.
-  ;; This can be used to build `borrow` functionality that will detect the
-  ;; case where we're trying to borrow from an old pool, so that we can retry
-  ;; with the new pool.
-  [pool])
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Schemas
-
-(def JRubyPuppetConfig
-  "Schema defining the config map for the JRubyPuppet pooling functions.
-
-  The keys should have the following values:
-
-    * :ruby-load-path - a vector of file paths, containing the locations of puppet source code.
-
-    * :gem-home - The location that JRuby gems are stored
-
-    * :master-conf-dir - file path to puppetmaster's conf dir;
-        if not specified, will use the puppet default.
-
-    * :master-var-dir - path to the puppetmaster' var dir;
-        if not specified, will use the puppet default.
-
-    * :max-active-instances - The maximum number of JRubyPuppet instances that
-        will be pooled. If not specified, the system's
-        number of CPUs+2 will be used.
-
-    * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
-        when https client requests are made.
-
-    * :http-client-cipher-suites - A list of legal SSL cipher suites that may
-        be used when https client requests are made."
-  {:ruby-load-path              (schema/both [schema/Str] (schema/pred vector?))
-   :gem-home                    schema/Str
-   :master-conf-dir             (schema/maybe schema/Str)
-   :master-var-dir              (schema/maybe schema/Str)
-   :http-client-ssl-protocols   [schema/Str]
-   :http-client-cipher-suites   [schema/Str]
-   :max-active-instances        schema/Int
-   :max-requests-per-instance   schema/Int})
-
-(def PoolState
-  "A map that describes all attributes of a particular JRubyPuppet pool."
-  {:pool         pool-queue-type
-   :size         schema/Int})
-
-(def PoolStateContainer
-  "An atom containing the current state of all of the JRubyPuppet pool."
-  (schema/pred #(and (instance? Atom %)
-                     (nil? (schema/check PoolState @%)))
-               'PoolStateContainer))
-
-(def PoolContext
-  "The data structure that stores all JRubyPuppet pools and the original configuration."
-  {:config     JRubyPuppetConfig
-   :profiler   (schema/maybe PuppetProfiler)
-   :pool-state PoolStateContainer})
-
-(def JRubyInstanceState
-  "State metadata for an individual JRubyPuppet instance"
-  {:request-count schema/Int})
-
-(def JRubyInstanceStateContainer
-  "An atom containing the current state of a given JRubyPuppet instance."
-  (schema/pred #(and (instance? Atom %)
-                     (nil? (schema/check JRubyInstanceState @%)))
-               'JRubyInstanceState))
-
-;; A record representing an individual entry in the JRubyPuppet pool.
-(schema/defrecord JRubyPuppetInstance
-  [pool :- pool-queue-type
-   id :- schema/Int
-   state :- JRubyInstanceStateContainer
-   jruby-puppet :- JRubyPuppet
-   scripting-container :- ScriptingContainer
-   environment-registry :- (schema/both
-                             EnvironmentRegistry
-                             (schema/pred
-                               #(satisfies? puppet-env/EnvironmentStateContainer %)))]
-  Object
-  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
-                           "puppetlabs.services.jruby.jruby_puppet_core.JRubyPuppetInstance"
-                           (Integer/toHexString (.hashCode this))
-                           id
-                           @state)))
-
-(defn jruby-puppet-instance?
-  [x]
-  (instance? JRubyPuppetInstance x))
-
-(defn retry-poison-pill?
-  [x]
-  (instance? RetryPoisonPill x))
-
-(def JRubyPuppetInstanceOrRetry
-  (schema/conditional
-    jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
-    retry-poison-pill? (schema/pred retry-poison-pill?)))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -185,9 +71,9 @@
 (schema/defn ^:always-validate
   create-pool-instance! :- JRubyPuppetInstance
   "Creates a new JRubyPuppet instance and adds it to the pool."
-  [pool     :- pool-queue-type
+  [pool     :- jruby-schemas/pool-queue-type
    id       :- schema/Int
-   config   :- JRubyPuppetConfig
+   config   :- jruby-schemas/JRubyPuppetConfig
    profiler :- (schema/maybe PuppetProfiler)]
   (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
                 http-client-ssl-protocols http-client-cipher-suites]} config]
@@ -211,7 +97,7 @@
       (.put puppet-server-config "profiler" profiler)
       (.put puppet-server-config "environment_registry" env-registry)
 
-      (let [instance (map->JRubyPuppetInstance
+      (let [instance (jruby-schemas/map->JRubyPuppetInstance
                        {:pool                 pool
                         :id                   id
                         :state                (atom {:request-count 0})
@@ -227,20 +113,20 @@
         instance))))
 
 (schema/defn ^:always-validate
-  get-pool-state :- PoolState
+  get-pool-state :- jruby-schemas/PoolState
   "Gets the PoolState from the pool context."
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   @(:pool-state context))
 
 (schema/defn ^:always-validate
-  get-pool :- pool-queue-type
+  get-pool :- jruby-schemas/pool-queue-type
   "Gets the JRubyPuppet pool object from the pool context."
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (:pool (get-pool-state context)))
 
 (schema/defn ^:always-validate
   pool->vec :- [JRubyPuppetInstance]
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (-> (get-pool context)
       .iterator
       iterator-seq
@@ -249,7 +135,7 @@
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
-  {:post [(instance? pool-queue-type %)]}
+  {:post [(instance? jruby-schemas/pool-queue-type %)]}
   (LinkedBlockingDeque. size))
 
 (defn verify-config-found!
@@ -260,19 +146,19 @@
                                            "you did not specify the --config option?")))))
 
 (schema/defn ^:always-validate
-  create-pool-from-config :- PoolState
+  create-pool-from-config :- jruby-schemas/PoolState
   "Create a new PoolData based on the config input."
-  [{size :max-active-instances} :- JRubyPuppetConfig]
+  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
   {:pool (instantiate-free-pool size)
    :size size})
 
-(schema/defn borrow-from-pool!* :- (schema/maybe JRubyPuppetInstanceOrRetry)
+(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
   If successful, updates the state information and returns the JRuby instance.
   Returns nil if the borrow function returns nil; throws an exception if
   the borrow function's return value indicates an error condition."
   [borrow-fn :- (schema/pred ifn?)
-   pool :- pool-queue-type]
+   pool :- jruby-schemas/pool-queue-type]
   (let [instance (borrow-fn pool)]
     (cond (instance? PoisonPill instance)
           (do
@@ -281,12 +167,12 @@
                      "Unable to borrow JRuby instance from pool"
                      (:err instance))))
 
-          (jruby-puppet-instance? instance)
+          (jruby-schemas/jruby-puppet-instance? instance)
           (do
             (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
             instance)
 
-          ((some-fn nil? retry-poison-pill?) instance)
+          ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
           instance
 
           :else
@@ -297,7 +183,7 @@
 ;;; Public
 
 (schema/defn ^:always-validate
-  initialize-config :- JRubyPuppetConfig
+  initialize-config :- jruby-schemas/JRubyPuppetConfig
   [config :- {schema/Keyword schema/Any}]
   (-> (get-in config [:jruby-puppet])
       (assoc :ruby-load-path (get-in config [:os-settings :ruby-load-path]))
@@ -311,7 +197,7 @@
       (update-in [:max-requests-per-instance] #(or % 0))))
 
 (schema/defn ^:always-validate
-  create-pool-context :- PoolContext
+  create-pool-context :- jruby-schemas/PoolContext
   "Creates a new JRubyPuppet pool context with an empty pool. Once the JRubyPuppet
   pool object has been created, it will need to be filled using `prime-pool!`."
   [config profiler]
@@ -322,41 +208,41 @@
 (schema/defn ^:always-validate
   free-instance-count
   "Returns the number of JRubyPuppet instances available in the pool."
-  [pool :- pool-queue-type]
+  [pool :- jruby-schemas/pool-queue-type]
   {:post [(>= % 0)]}
   (.size pool))
 
 (schema/defn ^:always-validate
-  instance-state :- JRubyInstanceState
+  instance-state :- jruby-schemas/JRubyInstanceState
   "Get the state metadata for a JRubyPuppet instance."
-  [jruby-puppet :- (schema/pred jruby-puppet-instance?)]
+  [jruby-puppet :- (schema/pred jruby-schemas/jruby-puppet-instance?)]
   @(:state jruby-puppet))
 
 (schema/defn ^:always-validate
   mark-all-environments-expired!
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (doseq [jruby-instance (pool->vec context)]
     (-> jruby-instance
         :environment-registry
         puppet-env/mark-all-environments-expired!)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool :- JRubyPuppetInstanceOrRetry
+  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool :- pool-queue-type]
+  [pool :- jruby-schemas/pool-queue-type]
   (let [borrow-fn #(.takeFirst %)]
     (borrow-from-pool!* borrow-fn pool)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool-with-timeout :- (schema/maybe JRubyPuppetInstanceOrRetry)
+  borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
   blocking timeout is provided. If an instance is available then it will be
   immediately returned to the caller, if not then this function will block
   waiting for an instance to be free for the number of milliseconds given in
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
-  [pool :- pool-queue-type
+  [pool :- jruby-schemas/pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
   (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
@@ -365,5 +251,5 @@
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
-  [instance :- JRubyPuppetInstanceOrRetry]
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
   (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,15 +1,10 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:require [me.raynes.fs :as fs]
-            [schema.core :as schema]
+  (:require [schema.core :as schema]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env])
-  (:import (java.util.concurrent LinkedBlockingDeque TimeUnit)
-           (java.util HashMap)
-           (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
-           (org.jruby.embed ScriptingContainer LocalContextScope)
-           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
-           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill JRubyPuppetInstance)))
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
+  (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
@@ -18,99 +13,8 @@
   "The default size of each JRuby pool."
   (+ 2 (ks/num-cpus)))
 
-(def jruby-puppet-env
-  "The environment variables that should be passed to the Puppet JRuby interpreters.
-  We don't want them to read any ruby environment variables, like $GEM_HOME or
-  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
-  Puppet needs HOME and PATH for facter resolution, so leave those."
-  (select-keys (System/getenv) ["HOME" "PATH"]))
-
-(def ruby-code-dir
-  "The name of the directory containing the ruby code in this project.
-  This directory lives under src/ruby/"
-  "puppet-server-lib")
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
-
-(defn prep-scripting-container
-  [scripting-container ruby-load-path gem-home]
-  (doto scripting-container
-    (.setLoadPaths (cons ruby-code-dir
-                         (map fs/absolute-path ruby-load-path)))
-    (.setCompatVersion (CompatVersion/RUBY1_9))
-    (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
-    (.setEnvironment (merge {"GEM_HOME" gem-home} jruby-puppet-env))))
-
-(defn empty-scripting-container
-  "Creates a clean instance of `org.jruby.embed.ScriptingContainer` with no code loaded."
-  [ruby-load-path gem-home]
-  {:pre [(sequential? ruby-load-path)
-         (every? string? ruby-load-path)
-         (string? gem-home)]
-   :post [(instance? ScriptingContainer %)]}
-  (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
-      (prep-scripting-container ruby-load-path gem-home)))
-
-(defn create-scripting-container
-  "Creates an instance of `org.jruby.embed.ScriptingContainer` and loads up the
-  puppet and facter code inside it."
-  [ruby-load-path gem-home]
-  {:pre [(sequential? ruby-load-path)
-         (every? string? ruby-load-path)
-         (string? gem-home)]
-   :post [(instance? ScriptingContainer %)]}
-  ;; for information on other legal values for `LocalContextScope`, there
-  ;; is some documentation available in the JRuby source code; e.g.:
-  ;; https://github.com/jruby/jruby/blob/1.7.11/core/src/main/java/org/jruby/embed/LocalContextScope.java#L58
-  ;; I'm convinced that this is the safest and most reasonable value
-  ;; to use here, but we could potentially explore optimizations in the future.
-  (doto (empty-scripting-container ruby-load-path gem-home)
-    (.runScriptlet "require 'puppet/server/master'")))
-
-(schema/defn ^:always-validate
-  create-pool-instance! :- JRubyPuppetInstance
-  "Creates a new JRubyPuppet instance and adds it to the pool."
-  [pool     :- jruby-schemas/pool-queue-type
-   id       :- schema/Int
-   config   :- jruby-schemas/JRubyPuppetConfig
-   profiler :- (schema/maybe PuppetProfiler)]
-  (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
-                http-client-ssl-protocols http-client-cipher-suites]} config]
-    (when-not ruby-load-path
-      (throw (Exception.
-               "JRuby service missing config value 'ruby-load-path'")))
-    (let [scripting-container   (create-scripting-container ruby-load-path gem-home)
-          env-registry          (puppet-env/environment-registry)
-          ruby-puppet-class     (.runScriptlet scripting-container "Puppet::Server::Master")
-          puppet-config         (HashMap.)
-          puppet-server-config  (HashMap.)]
-      (when master-conf-dir
-        (.put puppet-config "confdir" (fs/absolute-path master-conf-dir)))
-      (when master-var-dir
-        (.put puppet-config "vardir" (fs/absolute-path master-var-dir)))
-        
-      (when http-client-ssl-protocols
-        (.put puppet-server-config "ssl_protocols" (into-array String http-client-ssl-protocols)))
-      (when http-client-cipher-suites
-        (.put puppet-server-config "cipher_suites" (into-array String http-client-cipher-suites)))
-      (.put puppet-server-config "profiler" profiler)
-      (.put puppet-server-config "environment_registry" env-registry)
-
-      (let [instance (jruby-schemas/map->JRubyPuppetInstance
-                       {:pool                 pool
-                        :id                   id
-                        :state                (atom {:request-count 0})
-                        :jruby-puppet         (.callMethod scripting-container
-                                                           ruby-puppet-class
-                                                           "new"
-                                                           (into-array Object
-                                                                       [puppet-config puppet-server-config])
-                                                           JRubyPuppet)
-                        :scripting-container  scripting-container
-                        :environment-registry env-registry})]
-        (.putLast pool instance)
-        instance))))
 
 (schema/defn ^:always-validate
   get-pool-state :- jruby-schemas/PoolState
@@ -132,52 +36,12 @@
       iterator-seq
       vec))
 
-(defn instantiate-free-pool
-  "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
-  [size]
-  {:post [(instance? jruby-schemas/pool-queue-type %)]}
-  (LinkedBlockingDeque. size))
-
 (defn verify-config-found!
   [config]
   (if (or (not (map? config))
           (empty? config))
     (throw (IllegalArgumentException. (str "No configuration data found.  Perhaps "
                                            "you did not specify the --config option?")))))
-
-(schema/defn ^:always-validate
-  create-pool-from-config :- jruby-schemas/PoolState
-  "Create a new PoolData based on the config input."
-  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
-  {:pool (instantiate-free-pool size)
-   :size size})
-
-(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
-  "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
-  If successful, updates the state information and returns the JRuby instance.
-  Returns nil if the borrow function returns nil; throws an exception if
-  the borrow function's return value indicates an error condition."
-  [borrow-fn :- (schema/pred ifn?)
-   pool :- jruby-schemas/pool-queue-type]
-  (let [instance (borrow-fn pool)]
-    (cond (instance? PoisonPill instance)
-          (do
-            (.putFirst pool instance)
-            (throw (IllegalStateException.
-                     "Unable to borrow JRuby instance from pool"
-                     (:err instance))))
-
-          (jruby-schemas/jruby-puppet-instance? instance)
-          (do
-            (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
-            instance)
-
-          ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
-          instance
-
-          :else
-          (throw (IllegalStateException.
-                   (str "Borrowed unrecognized object from pool!: " instance))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -203,7 +67,7 @@
   [config profiler]
   {:config     config
    :profiler   profiler
-   :pool-state (atom (create-pool-from-config config))})
+   :pool-state (atom (jruby-internal/create-pool-from-config config))})
 
 (schema/defn ^:always-validate
   free-instance-count
@@ -231,8 +95,7 @@
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool :- jruby-schemas/pool-queue-type]
-  (let [borrow-fn #(.takeFirst %)]
-    (borrow-from-pool!* borrow-fn pool)))
+  (jruby-internal/borrow-from-pool pool))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -245,11 +108,10 @@
   [pool :- jruby-schemas/pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
-    (borrow-from-pool!* borrow-fn pool)))
+  (jruby-internal/borrow-from-pool-with-timeout pool timeout))
 
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
   [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
-  (.putFirst (:pool instance) instance))
+  (jruby-internal/return-to-pool instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -3,8 +3,10 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
-  (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents])
+  (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)
+           (com.puppetlabs.puppetserver PuppetProfiler)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
@@ -64,9 +66,12 @@
   create-pool-context :- jruby-schemas/PoolContext
   "Creates a new JRubyPuppet pool context with an empty pool. Once the JRubyPuppet
   pool object has been created, it will need to be filled using `prime-pool!`."
-  [config profiler]
+  [config :- jruby-schemas/JRubyPuppetConfig
+   profiler :- (schema/maybe PuppetProfiler)
+   agent-shutdown-fn :- (schema/maybe (schema/pred ifn?))]
   {:config     config
    :profiler   profiler
+   :pool-agent (jruby-agents/pool-agent agent-shutdown-fn)
    :pool-state (atom (jruby-internal/create-pool-from-config config))})
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -22,13 +22,13 @@
   get-pool-state :- jruby-schemas/PoolState
   "Gets the PoolState from the pool context."
   [context :- jruby-schemas/PoolContext]
-  @(:pool-state context))
+  (jruby-internal/get-pool-state context))
 
 (schema/defn ^:always-validate
   get-pool :- jruby-schemas/pool-queue-type
   "Gets the JRubyPuppet pool object from the pool context."
   [context :- jruby-schemas/PoolContext]
-  (:pool (get-pool-state context)))
+  (jruby-internal/get-pool context))
 
 (schema/defn ^:always-validate
   pool->vec :- [JRubyPuppetInstance]
@@ -99,8 +99,8 @@
   borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool :- jruby-schemas/pool-queue-type]
-  (jruby-internal/borrow-from-pool pool))
+  [pool-context :- jruby-schemas/PoolContext]
+  (jruby-internal/borrow-from-pool pool-context))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -110,10 +110,10 @@
   waiting for an instance to be free for the number of milliseconds given in
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (jruby-internal/borrow-from-pool-with-timeout pool timeout))
+  (jruby-internal/borrow-from-pool-with-timeout pool-context timeout))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -204,7 +204,7 @@
                                                            JRubyPuppet)
                         :scripting-container  scripting-container
                         :environment-registry env-registry})]
-        (.put pool instance)
+        (.putLast pool instance)
         instance))))
 
 (schema/defn ^:always-validate
@@ -256,7 +256,7 @@
   Otherwise returns the instance that was passed in."
   [instance pool]
   (when (instance? PoisonPill instance)
-    (.put pool instance)
+    (.putFirst pool instance)
     (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
                                    (:err instance))))
   instance)
@@ -293,7 +293,7 @@
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool :- pool-queue-type]
-  (let [instance (.take pool)]
+  (let [instance (.takeFirst pool)]
     (validate-instance-from-pool! instance pool)))
 
 (schema/defn ^:always-validate
@@ -307,11 +307,11 @@
   [pool :- pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (let [instance (.poll pool timeout TimeUnit/MILLISECONDS)]
+  (let [instance (.pollFirst pool timeout TimeUnit/MILLISECONDS)]
     (validate-instance-from-pool! instance pool)))
 
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
   [instance :- JRubyPuppetInstanceOrRetry]
-  (.put (:pool instance) instance))
+  (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -1,0 +1,176 @@
+(ns puppetlabs.services.jruby.jruby-puppet-internal
+  (:require [schema.core :as schema]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [me.raynes.fs :as fs])
+  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+           (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
+           (java.util HashMap)
+           (org.jruby CompatVersion RubyInstanceConfig$CompileMode)
+           (org.jruby.embed ScriptingContainer LocalContextScope)
+           (java.util.concurrent LinkedBlockingDeque TimeUnit)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Definitions
+
+(def jruby-puppet-env
+  "The environment variables that should be passed to the Puppet JRuby interpreters.
+  We don't want them to read any ruby environment variables, like $GEM_HOME or
+  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
+  Puppet needs HOME and PATH for facter resolution, so leave those."
+  (select-keys (System/getenv) ["HOME" "PATH"]))
+
+(def ruby-code-dir
+  "The name of the directory containing the ruby code in this project.
+  This directory lives under src/ruby/"
+  "puppet-server-lib")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(defn instantiate-free-pool
+  "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
+  [size]
+  {:post [(instance? jruby-schemas/pool-queue-type %)]}
+  (LinkedBlockingDeque. size))
+
+(schema/defn ^:always-validate
+             create-pool-from-config :- jruby-schemas/PoolState
+  "Create a new PoolData based on the config input."
+  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
+  {:pool (instantiate-free-pool size)
+   :size size})
+
+(defn prep-scripting-container
+  [scripting-container ruby-load-path gem-home]
+  (doto scripting-container
+    (.setLoadPaths (cons ruby-code-dir
+                         (map fs/absolute-path ruby-load-path)))
+    (.setCompatVersion (CompatVersion/RUBY1_9))
+    (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
+    (.setEnvironment (merge {"GEM_HOME" gem-home} jruby-puppet-env))))
+
+(defn empty-scripting-container
+  "Creates a clean instance of `org.jruby.embed.ScriptingContainer` with no code loaded."
+  [ruby-load-path gem-home]
+  {:pre [(sequential? ruby-load-path)
+         (every? string? ruby-load-path)
+         (string? gem-home)]
+   :post [(instance? ScriptingContainer %)]}
+  (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
+      (prep-scripting-container ruby-load-path gem-home)))
+
+(defn create-scripting-container
+  "Creates an instance of `org.jruby.embed.ScriptingContainer` and loads up the
+  puppet and facter code inside it."
+  [ruby-load-path gem-home]
+  {:pre [(sequential? ruby-load-path)
+         (every? string? ruby-load-path)
+         (string? gem-home)]
+   :post [(instance? ScriptingContainer %)]}
+  ;; for information on other legal values for `LocalContextScope`, there
+  ;; is some documentation available in the JRuby source code; e.g.:
+  ;; https://github.com/jruby/jruby/blob/1.7.11/core/src/main/java/org/jruby/embed/LocalContextScope.java#L58
+  ;; I'm convinced that this is the safest and most reasonable value
+  ;; to use here, but we could potentially explore optimizations in the future.
+  (doto (empty-scripting-container ruby-load-path gem-home)
+    (.runScriptlet "require 'puppet/server/master'")))
+
+(schema/defn ^:always-validate
+  create-pool-instance! :- JRubyPuppetInstance
+  "Creates a new JRubyPuppet instance and adds it to the pool."
+  [pool     :- jruby-schemas/pool-queue-type
+   id       :- schema/Int
+   config   :- jruby-schemas/JRubyPuppetConfig
+   profiler :- (schema/maybe PuppetProfiler)]
+  (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
+                http-client-ssl-protocols http-client-cipher-suites]} config]
+    (when-not ruby-load-path
+      (throw (Exception.
+               "JRuby service missing config value 'ruby-load-path'")))
+    (let [scripting-container   (create-scripting-container ruby-load-path gem-home)
+          env-registry          (puppet-env/environment-registry)
+          ruby-puppet-class     (.runScriptlet scripting-container "Puppet::Server::Master")
+          puppet-config         (HashMap.)
+          puppet-server-config  (HashMap.)]
+      (when master-conf-dir
+        (.put puppet-config "confdir" (fs/absolute-path master-conf-dir)))
+      (when master-var-dir
+        (.put puppet-config "vardir" (fs/absolute-path master-var-dir)))
+
+      (when http-client-ssl-protocols
+        (.put puppet-server-config "ssl_protocols" (into-array String http-client-ssl-protocols)))
+      (when http-client-cipher-suites
+        (.put puppet-server-config "cipher_suites" (into-array String http-client-cipher-suites)))
+      (.put puppet-server-config "profiler" profiler)
+      (.put puppet-server-config "environment_registry" env-registry)
+
+      (let [instance (jruby-schemas/map->JRubyPuppetInstance
+                       {:pool                 pool
+                        :id                   id
+                        :state                (atom {:request-count 0})
+                        :jruby-puppet         (.callMethod scripting-container
+                                                           ruby-puppet-class
+                                                           "new"
+                                                           (into-array Object
+                                                                       [puppet-config puppet-server-config])
+                                                           JRubyPuppet)
+                        :scripting-container  scripting-container
+                        :environment-registry env-registry})]
+        (.putLast pool instance)
+        instance))))
+
+(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+  "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
+  If successful, updates the state information and returns the JRuby instance.
+  Returns nil if the borrow function returns nil; throws an exception if
+  the borrow function's return value indicates an error condition."
+  [borrow-fn :- (schema/pred ifn?)
+   pool :- jruby-schemas/pool-queue-type]
+  (let [instance (borrow-fn pool)]
+    (cond (instance? PoisonPill instance)
+          (do
+            (.putFirst pool instance)
+            (throw (IllegalStateException.
+                     "Unable to borrow JRuby instance from pool"
+                     (:err instance))))
+
+          (jruby-schemas/jruby-puppet-instance? instance)
+          (do
+            (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
+            instance)
+
+          ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
+          instance
+
+          :else
+          (throw (IllegalStateException.
+                   (str "Borrowed unrecognized object from pool!: " instance))))))
+
+(schema/defn ^:always-validate
+  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
+  left in the pool then this function will block until there is one available."
+  [pool :- jruby-schemas/pool-queue-type]
+  (let [borrow-fn #(.takeFirst %)]
+    (borrow-from-pool!* borrow-fn pool)))
+
+(schema/defn ^:always-validate
+  borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+  "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
+  blocking timeout is provided. If an instance is available then it will be
+  immediately returned to the caller, if not then this function will block
+  waiting for an instance to be free for the number of milliseconds given in
+  timeout. If the timeout runs out then nil will be returned, indicating that
+  there were no instances available."
+  [pool :- jruby-schemas/pool-queue-type
+   timeout :- schema/Int]
+  {:pre  [(>= timeout 0)]}
+  (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
+    (borrow-from-pool!* borrow-fn pool)))
+
+(schema/defn ^:always-validate
+  return-to-pool
+  "Return a borrowed pool instance to its free pool."
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
+  (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -120,13 +120,40 @@
         (.putLast pool instance)
         instance))))
 
+(schema/defn ^:always-validate
+             get-pool-state :- jruby-schemas/PoolState
+  "Gets the PoolState from the pool context."
+  [context :- jruby-schemas/PoolContext]
+  @(:pool-state context))
+
+(schema/defn ^:always-validate
+  get-pool :- jruby-schemas/pool-queue-type
+  "Gets the JRubyPuppet pool object from the pool context."
+  [context :- jruby-schemas/PoolContext]
+  (:pool (get-pool-state context)))
+
+(schema/defn borrow-without-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
+  [pool :- jruby-schemas/pool-queue-type]
+  (.takeFirst pool))
+
+(schema/defn borrow-with-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
+  [timeout :- schema/Int
+   pool :- jruby-schemas/pool-queue-type]
+  (.pollFirst pool timeout TimeUnit/MILLISECONDS))
+
 (schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
   If successful, updates the state information and returns the JRuby instance.
   Returns nil if the borrow function returns nil; throws an exception if
   the borrow function's return value indicates an error condition."
   [borrow-fn :- (schema/pred ifn?)
-   pool :- jruby-schemas/pool-queue-type]
+   ;; it looks unusual that we accept both the pool and the pool-context
+   ;; as arguments, since the PoolContext contains a reference to a pool.  However,
+   ;; in cases such as a full pool flush operation, there may be two distinct
+   ;; pools in play, and the one in the pool-context may be different from the
+   ;; one we're borrowing from.
+   pool :- jruby-schemas/pool-queue-type
+   pool-context :- jruby-schemas/PoolContext]
   (let [instance (borrow-fn pool)]
     (cond (instance? PoisonPill instance)
           (do
@@ -151,9 +178,9 @@
   borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool :- jruby-schemas/pool-queue-type]
-  (let [borrow-fn #(.takeFirst %)]
-    (borrow-from-pool!* borrow-fn pool)))
+  [pool-context :- jruby-schemas/PoolContext]
+  (borrow-from-pool!* borrow-without-timeout-fn
+                      (get-pool pool-context) pool-context))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -163,11 +190,11 @@
   waiting for an instance to be free for the number of milliseconds given in
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
-    (borrow-from-pool!* borrow-fn pool)))
+  (borrow-from-pool!* (partial borrow-with-timeout-fn timeout)
+                      (get-pool pool-context) pool-context))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -35,7 +35,7 @@
   (LinkedBlockingDeque. size))
 
 (schema/defn ^:always-validate
-             create-pool-from-config :- jruby-schemas/PoolState
+  create-pool-from-config :- jruby-schemas/PoolState
   "Create a new PoolData based on the config input."
   [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
   {:pool (instantiate-free-pool size)
@@ -121,7 +121,7 @@
         instance))))
 
 (schema/defn ^:always-validate
-             get-pool-state :- jruby-schemas/PoolState
+  get-pool-state :- jruby-schemas/PoolState
   "Gets the PoolState from the pool context."
   [context :- jruby-schemas/PoolContext]
   @(:pool-state context))
@@ -132,6 +132,12 @@
   [context :- jruby-schemas/PoolContext]
   (:pool (get-pool-state context)))
 
+(schema/defn ^:always-validate
+  get-pool-size :- schema/Int
+  "Gets the size of the JRubyPuppet pool from the pool context."
+  [context :- jruby-schemas/PoolContext]
+  (get-in context [:config :max-active-instances]))
+
 (schema/defn borrow-without-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
   [pool :- jruby-schemas/pool-queue-type]
   (.takeFirst pool))
@@ -140,6 +146,32 @@
   [timeout :- schema/Int
    pool :- jruby-schemas/pool-queue-type]
   (.pollFirst pool timeout TimeUnit/MILLISECONDS))
+
+(schema/defn borrowed-poison-pill
+  [pool :- jruby-schemas/pool-queue-type
+   instance :- PoisonPill]
+  (.putFirst pool instance)
+  (throw (IllegalStateException.
+           "Unable to borrow JRuby instance from pool"
+           (:err instance))))
+
+(declare borrow-from-pool!*)
+
+(schema/defn borrowed-jruby-instance :- jruby-schemas/JRubyPuppetBorrowResult
+  [borrow-fn :- (schema/pred ifn?)
+   pool :- jruby-schemas/pool-queue-type
+   pool-context :- jruby-schemas/PoolContext
+   flush-instance-fn :- (schema/pred ifn?)
+   instance :- JRubyPuppetInstance]
+  (let [new-state (swap! (:state instance)
+                         update-in [:request-count] inc)
+        max-requests (get-in pool-context [:config :max-requests-per-instance])]
+    (if (and (pos? max-requests)
+             (> (:request-count new-state) max-requests))
+      (do
+        (flush-instance-fn pool pool-context instance)
+        (borrow-from-pool!* borrow-fn pool pool-context flush-instance-fn))
+      instance)))
 
 (schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
@@ -153,19 +185,14 @@
    ;; pools in play, and the one in the pool-context may be different from the
    ;; one we're borrowing from.
    pool :- jruby-schemas/pool-queue-type
-   pool-context :- jruby-schemas/PoolContext]
+   pool-context :- jruby-schemas/PoolContext
+   flush-instance-fn :- (schema/pred ifn?)]
   (let [instance (borrow-fn pool)]
     (cond (instance? PoisonPill instance)
-          (do
-            (.putFirst pool instance)
-            (throw (IllegalStateException.
-                     "Unable to borrow JRuby instance from pool"
-                     (:err instance))))
+          (borrowed-poison-pill pool instance)
 
           (jruby-schemas/jruby-puppet-instance? instance)
-          (do
-            (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
-            instance)
+          (borrowed-jruby-instance borrow-fn pool pool-context flush-instance-fn instance)
 
           ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
           instance
@@ -178,9 +205,12 @@
   borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool-context :- jruby-schemas/PoolContext]
+  [pool-context :- jruby-schemas/PoolContext
+   flush-instance-fn :- (schema/pred ifn?)]
   (borrow-from-pool!* borrow-without-timeout-fn
-                      (get-pool pool-context) pool-context))
+                      (get-pool pool-context)
+                      pool-context
+                      flush-instance-fn))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -191,10 +221,13 @@
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
   [pool-context :- jruby-schemas/PoolContext
-   timeout :- schema/Int]
+   timeout :- schema/Int
+   flush-instance-fn :- (schema/pred ifn?)]
   {:pre  [(>= timeout 0)]}
   (borrow-from-pool!* (partial borrow-with-timeout-fn timeout)
-                      (get-pool pool-context) pool-context))
+                      (get-pool pool-context)
+                      pool-context
+                      flush-instance-fn))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -2,7 +2,8 @@
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [me.raynes.fs :as fs])
+            [me.raynes.fs :as fs]
+            [clojure.tools.logging :as log])
   (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
            (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
            (java.util HashMap)
@@ -169,6 +170,10 @@
     (if (and (pos? max-requests)
              (> (:request-count new-state) max-requests))
       (do
+        (log/infof (str "Flushing JRuby instance %s because it has exceeded the "
+                        "maximum number of requests (%s)")
+                   (:id instance)
+                   max-requests)
         (flush-instance-fn pool pool-context instance)
         (borrow-from-pool!* borrow-fn pool pool-context flush-instance-fn))
       instance)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -68,7 +68,7 @@
                    (let [state @a]
                      (and
                        (map? state)
-                       ((some-fn nil? ifn?) (:shutdown-on-error state))))))))
+                       (ifn? (:shutdown-on-error state))))))))
 
 (def PoolState
   "A map that describes all attributes of a particular JRubyPuppet pool."
@@ -83,10 +83,11 @@
 
 (def PoolContext
   "The data structure that stores all JRubyPuppet pools and the original configuration."
-  {:config     JRubyPuppetConfig
-   :profiler   (schema/maybe PuppetProfiler)
-   :pool-agent JRubyPoolAgent
-   :pool-state PoolStateContainer})
+  {:config                JRubyPuppetConfig
+   :profiler              (schema/maybe PuppetProfiler)
+   :pool-agent            JRubyPoolAgent
+   :flush-instance-agent  JRubyPoolAgent
+   :pool-state            PoolStateContainer})
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyPuppet instance"

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env])
   (:import (java.util.concurrent BlockingDeque)
-           (clojure.lang Atom)
+           (clojure.lang Atom Agent)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
            (org.jruby.embed ScriptingContainer)))
 
@@ -60,6 +60,16 @@
    :max-active-instances        schema/Int
    :max-requests-per-instance   schema/Int})
 
+(def JRubyPoolAgent
+  "An agent configured for use in managing JRuby pools"
+  (schema/both Agent
+               (schema/pred
+                 (fn [a]
+                   (let [state @a]
+                     (and
+                       (map? state)
+                       ((some-fn nil? ifn?) (:shutdown-on-error state))))))))
+
 (def PoolState
   "A map that describes all attributes of a particular JRubyPuppet pool."
   {:pool         pool-queue-type
@@ -75,6 +85,7 @@
   "The data structure that stores all JRubyPuppet pools and the original configuration."
   {:config     JRubyPuppetConfig
    :profiler   (schema/maybe PuppetProfiler)
+   :pool-agent JRubyPoolAgent
    :pool-state PoolStateContainer})
 
 (def JRubyInstanceState

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -1,0 +1,120 @@
+(ns puppetlabs.services.jruby.jruby-puppet-schemas
+  (:require [schema.core :as schema]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env])
+  (:import (java.util.concurrent BlockingDeque)
+           (clojure.lang Atom)
+           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
+           (org.jruby.embed ScriptingContainer)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def pool-queue-type
+  "The Java datastructure type used to store JRubyPuppet instances which are
+  free to be borrowed."
+  BlockingDeque)
+
+(defrecord PoisonPill
+  ;; A sentinel object to put into a pool in case an error occurs while we're trying
+  ;; to populate it.  This can be used by the `borrow` functions to detect error
+  ;; state in a thread-safe manner.
+  [err])
+
+(defrecord RetryPoisonPill
+  ;; A sentinel object to put into an old pool when we swap in a new pool.
+  ;; This can be used to build `borrow` functionality that will detect the
+  ;; case where we're trying to borrow from an old pool, so that we can retry
+  ;; with the new pool.
+  [pool])
+
+(def JRubyPuppetConfig
+  "Schema defining the config map for the JRubyPuppet pooling functions.
+
+  The keys should have the following values:
+
+    * :ruby-load-path - a vector of file paths, containing the locations of puppet source code.
+
+    * :gem-home - The location that JRuby gems are stored
+
+    * :master-conf-dir - file path to puppetmaster's conf dir;
+        if not specified, will use the puppet default.
+
+    * :master-var-dir - path to the puppetmaster' var dir;
+        if not specified, will use the puppet default.
+
+    * :max-active-instances - The maximum number of JRubyPuppet instances that
+        will be pooled. If not specified, the system's
+        number of CPUs+2 will be used.
+
+    * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
+        when https client requests are made.
+
+    * :http-client-cipher-suites - A list of legal SSL cipher suites that may
+        be used when https client requests are made."
+  {:ruby-load-path              (schema/both [schema/Str] (schema/pred vector?))
+   :gem-home                    schema/Str
+   :master-conf-dir             (schema/maybe schema/Str)
+   :master-var-dir              (schema/maybe schema/Str)
+   :http-client-ssl-protocols   [schema/Str]
+   :http-client-cipher-suites   [schema/Str]
+   :max-active-instances        schema/Int
+   :max-requests-per-instance   schema/Int})
+
+(def PoolState
+  "A map that describes all attributes of a particular JRubyPuppet pool."
+  {:pool         pool-queue-type
+   :size schema/Int})
+
+(def PoolStateContainer
+  "An atom containing the current state of all of the JRubyPuppet pool."
+  (schema/pred #(and (instance? Atom %)
+                     (nil? (schema/check PoolState @%)))
+               'PoolStateContainer))
+
+(def PoolContext
+  "The data structure that stores all JRubyPuppet pools and the original configuration."
+  {:config     JRubyPuppetConfig
+   :profiler   (schema/maybe PuppetProfiler)
+   :pool-state PoolStateContainer})
+
+(def JRubyInstanceState
+  "State metadata for an individual JRubyPuppet instance"
+  {:request-count schema/Int})
+
+(def JRubyInstanceStateContainer
+  "An atom containing the current state of a given JRubyPuppet instance."
+  (schema/pred #(and (instance? Atom %)
+                     (nil? (schema/check JRubyInstanceState @%)))
+               'JRubyInstanceState))
+
+;; A record representing an individual entry in the JRubyPuppet pool.
+(schema/defrecord JRubyPuppetInstance
+                  [pool :- pool-queue-type
+                   id :- schema/Int
+                   state :- JRubyInstanceStateContainer
+                   jruby-puppet :- JRubyPuppet
+                   scripting-container :- ScriptingContainer
+                   environment-registry :- (schema/both
+                                             EnvironmentRegistry
+                                             (schema/pred
+                                               #(satisfies? puppet-env/EnvironmentStateContainer %)))]
+                  Object
+                  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
+                                           "puppetlabs.services.jruby.jruby_puppet_core.JRubyPuppetInstance"
+                                           (Integer/toHexString (.hashCode this))
+                                           id
+                                           @state)))
+
+(defn jruby-puppet-instance?
+  [x]
+  (instance? JRubyPuppetInstance x))
+
+(defn retry-poison-pill?
+  [x]
+  (instance? RetryPoisonPill x))
+
+(def JRubyPuppetInstanceOrRetry
+  (schema/conditional
+    jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
+    retry-poison-pill? (schema/pred retry-poison-pill?)))
+

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -120,6 +120,10 @@
   [x]
   (instance? JRubyPuppetInstance x))
 
+(defn poison-pill?
+  [x]
+  (instance? PoisonPill x))
+
 (defn retry-poison-pill?
   [x]
   (instance? RetryPoisonPill x))
@@ -128,4 +132,10 @@
   (schema/conditional
     jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
     retry-poison-pill? (schema/pred retry-poison-pill?)))
+
+(def JRubyPuppetBorrowResult
+  (schema/pred (some-fn nil?
+                        poison-pill?
+                        retry-poison-pill?
+                        jruby-puppet-instance?)))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -15,20 +15,15 @@
 
 (trapperkeeper/defservice jruby-puppet-pooled-service
                           jruby/JRubyPuppetService
-                          [[:ConfigService get-in-config]
+                          [[:ConfigService get-config]
                            [:ShutdownService shutdown-on-error]
                            [:PuppetProfilerService get-profiler]]
   (init
     [this context]
-    (let [config            (-> (get-in-config [:jruby-puppet])
-                              (assoc :ruby-load-path (get-in-config [:os-settings :ruby-load-path]))
-                              (assoc :http-client-ssl-protocols
-                                     (get-in-config [:http-client :ssl-protocols]))
-                              (assoc :http-client-cipher-suites
-                                     (get-in-config [:http-client :cipher-suites])))
+    (let [config            (core/initialize-config (get-config))
           service-id        (tk-services/service-id this)
           agent-shutdown-fn (partial shutdown-on-error service-id)
-          pool-agent  (jruby-agents/pool-agent agent-shutdown-fn)
+          pool-agent        (jruby-agents/pool-agent agent-shutdown-fn)
           profiler          (get-profiler)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -24,15 +24,13 @@
     (let [config            (core/initialize-config (get-config))
           service-id        (tk-services/service-id this)
           agent-shutdown-fn (partial shutdown-on-error service-id)
-          pool-agent        (jruby-agents/pool-agent agent-shutdown-fn)
           profiler          (get-profiler)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
-      (let [pool-context (core/create-pool-context config profiler)]
-        (jruby-agents/send-prime-pool! pool-context pool-agent)
+      (let [pool-context (core/create-pool-context config profiler agent-shutdown-fn)]
+        (jruby-agents/send-prime-pool! pool-context)
         (-> context
-            (assoc :pool-context pool-context)
-            (assoc :pool-agent pool-agent)))))
+            (assoc :pool-context pool-context)))))
 
   (borrow-instance
     [this]
@@ -64,8 +62,8 @@
   (flush-jruby-pool!
     [this]
     (let [service-context (tk-services/service-context this)
-          {:keys [pool-context pool-agent]} service-context]
-      (jruby-agents/send-flush-pool! pool-context pool-agent))))
+          {:keys [pool-context]} service-context]
+      (jruby-agents/send-flush-pool! pool-context))))
 
 (defmacro with-jruby-puppet
   "Encapsulates the behavior of borrowing and returning an instance of

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -5,7 +5,8 @@
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -77,7 +78,7 @@
       (do-something-with-a-jruby-puppet-instance jruby-puppet)))"
   [jruby-puppet jruby-service & body]
   `(loop [pool-instance# (jruby/borrow-instance ~jruby-service)]
-     (if (core/retry-poison-pill? pool-instance#)
+     (if (jruby-schemas/retry-poison-pill? pool-instance#)
        (do
          (jruby-core/return-to-pool pool-instance#)
          (recur (jruby/borrow-instance ~jruby-service)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -34,15 +34,13 @@
 
   (borrow-instance
     [this]
-    (let [pool-context (:pool-context (tk-services/service-context this))
-          pool         (core/get-pool pool-context)]
-      (core/borrow-from-pool pool)))
+    (let [pool-context (:pool-context (tk-services/service-context this))]
+      (core/borrow-from-pool pool-context)))
 
   (borrow-instance
     [this timeout]
-    (let [pool-context (:pool-context (tk-services/service-context this))
-          pool         (core/get-pool pool-context)]
-      (core/borrow-from-pool-with-timeout pool timeout)))
+    (let [pool-context (:pool-context (tk-services/service-context this))]
+      (core/borrow-from-pool-with-timeout pool-context timeout)))
 
   (return-instance
     [this jruby-instance]

--- a/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
@@ -1,6 +1,4 @@
 (ns puppetlabs.puppetserver.bootstrap-int-test
-  (:import (java.io IOException)
-           (org.apache.http ConnectionClosedException))
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -65,3 +65,5 @@
                       4
                       (constantly
                         "begin; InstanceID; false; rescue NameError; true; end"))))))))
+
+;; TODO: test flush instance while pool flush is in progress

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -59,7 +59,7 @@
                          ssl-request-options)]
           (is (= 204 (:status response))))
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [new-pool (jruby-core/get-pool pool-context)]
           (is (every? true?
                       (jruby-testutils/reduce-over-jrubies!

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -7,7 +7,8 @@
             [cheshire.core :as json]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/puppet_environments_int_test")
@@ -24,6 +25,8 @@
 
 (def localhost-key
   (bootstrap/pem-file "private_keys" "localhost.pem"))
+
+(def num-jrubies 2)
 
 (defn write-site-pp-file
   [site-pp-contents]
@@ -61,7 +64,7 @@
       service-id))
 
 (defn wait-for-jrubies
-  [app num-jrubies]
+  [app]
   (let [pool-context (-> (service-context app :JRubyPuppetService)
                          :pool-context)]
     (while (< (count (jruby-core/pool->vec pool-context))
@@ -69,12 +72,48 @@
       (Thread/sleep 100))))
 
 (defn get-catalog
+  "Make an HTTP request to get a catalog."
   []
   (-> (http-client/get
         "https://localhost:8140/production/catalog/localhost"
         catalog-request-options)
       :body
       json/parse-string))
+
+(defn get-catalog-and-borrow-jruby
+  "Gets a catalog, and then borrows a JRuby instance from a pool to ensure that
+  a subsequent catalog request will be directed to a different JRuby.  Returns a
+  map containing both the catalog and the JRuby instance.  This function
+  relies on the fact that we are using a LIFO algorithm for allocating JRuby
+  instances to handle requests."
+  [borrow-jruby-fn]
+  (let [catalog (get-catalog)
+        jruby   (borrow-jruby-fn)]
+    {:catalog catalog
+     :jruby   jruby}))
+
+(defn get-catalog-and-return-jruby
+  "Given a map containing a catalog and a JRuby instance, return the JRuby
+  instance to the pool and return the catalog."
+  [return-jruby-fn m]
+  (return-jruby-fn (:jruby m))
+  (:catalog m))
+
+(defn get-catalog-from-each-jruby
+  "Iterates through all of the JRuby instances and gets a catalog from each of
+  them.  Returns the sequence of catalogs."
+  [borrow-jruby-fn return-jruby-fn]
+  ;; iterate over all of the jrubies and call get-catalog-and-borrow-jruby.  It's
+  ;; important that this is not done lazily, otherwise the jrubies could be returned
+  ;; to the pool before the next borrow occurs.
+  (let [jrubies-and-catalogs (doall
+                               (repeatedly
+                                 num-jrubies
+                                (partial get-catalog-and-borrow-jruby borrow-jruby-fn)))]
+    ;; now we can return the jrubies to the pool, and return the seq of catalogs
+    ;; to our caller
+    (map (partial get-catalog-and-return-jruby return-jruby-fn)
+         jrubies-and-catalogs)))
 
 (defn resource-matches?
   [resource-type resource-title resource]
@@ -85,6 +124,10 @@
   [catalog resource-type resource-title]
   (let [resources (get-in catalog ["data" "resources"])]
     (some (partial resource-matches? resource-type resource-title) resources)))
+
+(defn num-catalogs-containing
+  [catalogs resource-type resource-title]
+  (count (filter #(catalog-contains? % resource-type resource-title) catalogs)))
 
 ;; This test is written in a way that relies on knowledge about
 ;; the underlying implementation of the JRuby pool. That is admittedly
@@ -110,46 +153,43 @@
     ;; two of them so that we can illustrate that the cache can
     ;; be out of sync between the two of them.
     (bootstrap/with-puppetserver-running app {:jruby-puppet
-                                               {:max-active-instances 2}}
-      ;; if we start making requests before we know that all of the
-      ;; jruby instances are ready, we won't be able to predict which
-      ;; instance is handling our request, so we need to wait for them.
-      (wait-for-jrubies app 2)
-      ;; Now we grab a catalog from the first jruby instance.  This
-      ;; catalog should contain the 'hello1' notify, and will cause
-      ;; the first jruby instance to cache the manifests.
-      (let [catalog1 (get-catalog)]
-        (is (catalog-contains? catalog1 "Notify" "hello1"))
-        (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
-      ;; Now we modify the class definition to have a 'hello2' notify,
-      ;; instead of 'hello1'.
-      (write-foo-pp-file "class foo { notify {'hello2': } }")
-      ;; Retrieving the catalog a second time will route us to the
-      ;; second jruby instance, which hasn't cached the manifest yet,
-      ;; so we should get 'hello2'.
-      (let [catalog2 (get-catalog)]
-        (is (not (catalog-contains? catalog2 "Notify" "hello1")))
-        (is (catalog-contains? catalog2 "Notify" "hello2")))
-      ;; The next catalog request goes back to the first jruby instance,
-      ;; which still has 'hello1' cached.
-      (let [catalog1 (get-catalog)]
-        (is (catalog-contains? catalog1 "Notify" "hello1"))
-        (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
-      ;; Now, make a DELETE request to the /environment-cache endpoint.
-      ;; This flushes Puppet's cache for all environments.
-      (let [response (http-client/delete
-                       "https://localhost:8140/puppet-admin-api/v1/environment-cache"
-                       ssl-request-options)]
-        (testing "A successful DELETE request to /environment-cache returns an HTTP 204"
-          (is (= 204 (:status response))
-              (ks/pprint-to-string response))))
-      ;; Next catalog request goes to the second jruby instance,
-      ;; where we should see 'hello2' regardless of caching.
-      (let [catalog2 (get-catalog)]
-        (is (not (catalog-contains? catalog2 "Notify" "hello1")))
-        (is (catalog-contains? catalog2 "Notify" "hello2")))
-      ;; And the final catalog request goes back to the first jruby instance,
-      ;; where we expect the cache to have been cleared so that we will get 'hello2'.
-      (let [catalog1 (get-catalog)]
-        (is (not (catalog-contains? catalog1 "Notify" "hello1")))
-        (is (catalog-contains? catalog1 "Notify" "hello2"))))))
+                                              {:max-active-instances num-jrubies}}
+      (let [jruby-service   (tk-app/get-service app :JRubyPuppetService)
+            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service)
+            return-jruby-fn (partial jruby-protocol/return-instance jruby-service)]
+        ;; wait for all of the jrubies to be ready so that we can
+        ;; validate cache state differences between them.
+        (wait-for-jrubies app)
+
+        ;;; Now we grab a catalog from the first jruby instance.  This
+        ;;; catalog should contain the 'hello1' notify, and will cause
+        ;;; the first jruby instance to cache the manifests.
+        (let [catalog1 (get-catalog)]
+          (is (catalog-contains? catalog1 "Notify" "hello1"))
+          (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
+
+        ;; Now we modify the class definition to have a 'hello2' notify,
+        ;; instead of 'hello1'.
+        (write-foo-pp-file "class foo { notify {'hello2': } }")
+
+        ;; Now we grab a catalog from both of the jrubies.  One should have the
+        ;; old, cached state, and one should have the new state.
+        (let [catalogs (get-catalog-from-each-jruby borrow-jruby-fn return-jruby-fn)]
+          (is (= 1 (num-catalogs-containing catalogs "Notify" "hello1")))
+          (is (= 1 (num-catalogs-containing catalogs "Notify" "hello2"))))
+
+        ;; Now, make a DELETE request to the /environment-cache endpoint.
+        ;; This flushes Puppet's cache for all environments.
+        (let [response (http-client/delete
+                         "https://localhost:8140/puppet-admin-api/v1/environment-cache"
+                         ssl-request-options)]
+          (testing "A successful DELETE request to /environment-cache returns an HTTP 204"
+            (is (= 204 (:status response))
+                (ks/pprint-to-string response))))
+
+        ;; Now if we get catalogs from both of the JRubies again, we should get
+        ;; the 'hello2' catalog from both, since the cache should have been
+        ;; cleared.
+        (let [catalogs (get-catalog-from-each-jruby borrow-jruby-fn return-jruby-fn)]
+          (is (= 0 (num-catalogs-containing catalogs "Notify" "hello1")))
+          (is (= 2 (num-catalogs-containing catalogs "Notify" "hello2"))))))))

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -4,15 +4,14 @@
            (org.apache.http ConnectionClosedException)
            (com.puppetlabs.http.client HttpClientException)
            (javax.net.ssl SSLHandshakeException)
-           (java.util HashMap)
-           (java.io IOException))
+           (java.util HashMap))
   (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
             [puppetlabs.trapperkeeper.testutils.webserver.common :refer [http-get]]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [ring.middleware.basic-authentication :as auth]))
+            [ring.middleware.basic-authentication :as auth]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 ;; NOTE: this namespace is pretty disgusting.  It'd be much nicer to test this
 ;; ruby code via ruby spec tests, but since we need to stand up a webserver to
@@ -57,7 +56,7 @@
                                 (select-keys options [:ssl-protocols :cipher-suites]))
          sc                   (ScriptingContainer. LocalContextScope/SINGLETHREAD
                                                    LocalVariableBehavior/PERSISTENT)]
-     (jruby-puppet/prep-scripting-container sc
+     (jruby-internal/prep-scripting-container sc
                                             jruby-testutils/ruby-load-path
                                             jruby-testutils/gem-home)
      (.runScriptlet sc "require 'puppet/server/http_client'")

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -4,15 +4,14 @@
             [puppetlabs.services.config.puppet-server-config-service :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (def service-and-deps
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
@@ -85,7 +84,7 @@
              "Providing config values that should be read from Puppet results "
              "in an error that mentions all offending config keys.")
     (with-redefs
-      [jruby-puppet-core/create-pool-instance!
+      [jruby-internal/create-pool-instance!
          jruby-testutils/create-mock-pool-instance]
       (with-test-logging
         (is (thrown-with-msg?

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -5,7 +5,8 @@
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-puppet-core :refer :all
              :as core]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (use-fixtures :once
               (jruby-testutils/with-puppet-conf
@@ -14,9 +15,10 @@
 (deftest create-jruby-instance-test
 
   (testing "Var dir is not required."
-    (let [config        {:ruby-load-path  testutils/ruby-load-path
-                         :gem-home        testutils/gem-home
-                         :master-conf-dir testutils/conf-dir}
+    (let [config        (jruby-core/initialize-config
+                          {:jruby-puppet {:gem-home        testutils/gem-home
+                                          :master-conf-dir testutils/conf-dir}
+                           :os-settings  {:ruby-load-path testutils/ruby-load-path}})
           pool          (instantiate-free-pool 1)
           pool-instance (create-pool-instance! pool 1 config testutils/default-profiler)
           jruby-puppet  (:jruby-puppet pool-instance)

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -3,10 +3,9 @@
             [puppetlabs.services.jruby.jruby-testutils :as testutils]
             [puppetlabs.kitchensink.core :as ks]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.jruby-puppet-core :refer :all
-             :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (use-fixtures :once
               (jruby-testutils/with-puppet-conf
@@ -19,8 +18,8 @@
                           {:jruby-puppet {:gem-home        testutils/gem-home
                                           :master-conf-dir testutils/conf-dir}
                            :os-settings  {:ruby-load-path testutils/ruby-load-path}})
-          pool          (instantiate-free-pool 1)
-          pool-instance (create-pool-instance! pool 1 config testutils/default-profiler)
+          pool          (jruby-internal/instantiate-free-pool 1)
+          pool-instance (jruby-internal/create-pool-instance! pool 1 config testutils/default-profiler)
           jruby-puppet  (:jruby-puppet pool-instance)
           var-dir       (.getSetting jruby-puppet "vardir")]
       (is (not (nil? var-dir)))))
@@ -44,7 +43,7 @@
 
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
-    (let [jruby-interpreter (create-scripting-container
+    (let [jruby-interpreter (jruby-internal/create-scripting-container
                               jruby-testutils/ruby-load-path
                               jruby-testutils/gem-home)
           jruby-env (.runScriptlet jruby-interpreter "ENV")]

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -17,8 +17,8 @@
   (testing "malformed configuration fails"
     (let [malformed-config {:illegal-key [1 2 3]}]
       (is (thrown-with-msg? ExceptionInfo
-                            #"Input to create-pool-from-config does not match schema"
-                            (create-pool-context malformed-config nil)))))
+                            #"Input to create-pool-context does not match schema"
+                            (create-pool-context malformed-config nil nil)))))
   (let [minimal-config {:jruby-puppet {:gem-home "/dev/null"}
                         :os-settings  {:ruby-load-path ["/dev/null"]}}
         config        (jruby-core/initialize-config minimal-config)]
@@ -36,7 +36,7 @@
   (let [pool-size        2
         config           (jruby-testutils/jruby-puppet-config pool-size)
         profiler         jruby-testutils/default-profiler
-        pool-context     (create-pool-context config profiler)
+        pool-context     (create-pool-context config profiler nil)
         pool             (get-pool pool-context)]
 
     (testing "The pool should not yet be full as it is being primed in the
@@ -93,7 +93,7 @@
   (let [pool-size 2
         config        (jruby-testutils/jruby-puppet-config pool-size)
         profiler      jruby-testutils/default-profiler
-        pool-context  (create-pool-context config profiler)
+        pool-context  (create-pool-context config profiler nil)
         pool          (get-pool pool-context)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
     (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -2,7 +2,6 @@
   (:import (clojure.lang ExceptionInfo))
   (:require [clojure.test :refer :all]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-puppet-core :refer :all :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
@@ -18,7 +17,7 @@
     (let [malformed-config {:illegal-key [1 2 3]}]
       (is (thrown-with-msg? ExceptionInfo
                             #"Input to create-pool-context does not match schema"
-                            (create-pool-context malformed-config nil nil)))))
+                            (jruby-core/create-pool-context malformed-config nil nil)))))
   (let [minimal-config {:jruby-puppet {:gem-home "/dev/null"}
                         :os-settings  {:ruby-load-path ["/dev/null"]}}
         config        (jruby-core/initialize-config minimal-config)]
@@ -36,40 +35,41 @@
   (let [pool-size        2
         config           (jruby-testutils/jruby-puppet-config pool-size)
         profiler         jruby-testutils/default-profiler
-        pool-context     (create-pool-context config profiler nil)
-        pool             (get-pool pool-context)]
+        pool-context     (jruby-core/create-pool-context
+                           config profiler jruby-testutils/default-shutdown-fn)
+        pool             (jruby-core/get-pool pool-context)]
 
     (testing "The pool should not yet be full as it is being primed in the
              background."
-      (is (= (free-instance-count pool) 0)))
+      (is (= (jruby-core/free-instance-count pool) 0)))
 
     (jruby-agents/prime-pool! (:pool-state pool-context) config profiler)
 
     (testing "Borrowing all instances from a pool while it is being primed and
              returning them."
       (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)]
-        (is (= 0 (free-instance-count pool)))
+        (is (= 0 (jruby-core/free-instance-count pool)))
         (doseq [instance all-the-jrubys]
           (is (not (nil? instance)) "One of JRubyPuppet instances is nil"))
         (jruby-testutils/fill-drained-pool all-the-jrubys)
-        (is (= pool-size (free-instance-count pool)))))
+        (is (= pool-size (jruby-core/free-instance-count pool)))))
 
     (testing "Borrowing from an empty pool with a timeout returns nil within the
              proper amount of time."
       (let [timeout              250
             all-the-jrubys       (jruby-testutils/drain-pool pool-context pool-size)
             test-start-in-millis (System/currentTimeMillis)]
-        (is (nil? (borrow-from-pool-with-timeout pool-context timeout)))
+        (is (nil? (jruby-core/borrow-from-pool-with-timeout pool-context timeout)))
         (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout)
             "The timeout value was not honored.")
         (jruby-testutils/fill-drained-pool all-the-jrubys)
-        (is (= (free-instance-count pool) pool-size)
+        (is (= (jruby-core/free-instance-count pool) pool-size)
             "All JRubyPuppet instances were not returned to the pool.")))
 
     (testing "Removing an instance decrements the pool size by 1."
-      (let [jruby-instance (borrow-from-pool pool-context)]
-        (is (= (free-instance-count pool) (dec pool-size)))
-        (return-to-pool jruby-instance)))
+      (let [jruby-instance (jruby-core/borrow-from-pool pool-context)]
+        (is (= (jruby-core/free-instance-count pool) (dec pool-size)))
+        (jruby-core/return-to-pool jruby-instance)))
 
     (testing "Borrowing an instance increments its request count."
       (let [drain-via   (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
@@ -93,22 +93,55 @@
   (let [pool-size 2
         config        (jruby-testutils/jruby-puppet-config pool-size)
         profiler      jruby-testutils/default-profiler
-        pool-context  (create-pool-context config profiler nil)
+        pool-context  (jruby-core/create-pool-context
+                        config profiler jruby-testutils/default-shutdown-fn)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
     (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
                  (is (thrown? IllegalStateException (jruby-agents/prime-pool! (:pool-state pool-context) config profiler))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException
             err-msg
-            (borrow-from-pool pool-context)))
+            (jruby-core/borrow-from-pool pool-context)))
       (is (thrown-with-msg? IllegalStateException
             err-msg
-            (borrow-from-pool-with-timeout pool-context 120))))
+            (jruby-core/borrow-from-pool-with-timeout pool-context 120))))
     (testing "borrow and borrow-with-timeout both continue to throw exceptions on subsequent calls"
       (is (thrown-with-msg? IllegalStateException
           err-msg
-          (borrow-from-pool pool-context)))
+          (jruby-core/borrow-from-pool pool-context)))
       (is (thrown-with-msg? IllegalStateException
           err-msg
-          (borrow-from-pool-with-timeout pool-context 120))))))
+          (jruby-core/borrow-from-pool-with-timeout pool-context 120))))))
 
+(defn create-pool-context
+  [max-requests]
+  (let [config (-> (jruby-testutils/jruby-puppet-config 1)
+                   (assoc :max-requests-per-instance max-requests))
+        profiler jruby-testutils/default-profiler
+        pool-context (jruby-core/create-pool-context
+                       config profiler jruby-testutils/default-shutdown-fn)]
+    (jruby-agents/prime-pool! (:pool-state pool-context) config profiler)
+    pool-context))
+
+(deftest flush-jruby-after-max-requests
+  (testing "JRuby instance is not flushed if it has not exceeded max requests"
+    (let [pool-context  (create-pool-context 2)
+          instance      (jruby-core/borrow-from-pool pool-context)
+          id            (:id instance)]
+      (jruby-core/return-to-pool instance)
+      (let [instance (jruby-core/borrow-from-pool pool-context)]
+        (is (= id (:id instance))))))
+  (testing "JRuby instance is flushed after exceeding max requests"
+    (let [pool-context  (create-pool-context 1)
+          instance      (jruby-core/borrow-from-pool pool-context)
+          id            (:id instance)]
+      (jruby-core/return-to-pool instance)
+      (let [instance (jruby-core/borrow-from-pool pool-context)]
+        (is (not= id (:id instance))))))
+  (testing "JRuby instance is not flushed if max requests setting is set to 0"
+    (let [pool-context  (create-pool-context 0)
+          instance      (jruby-core/borrow-from-pool pool-context)
+          id            (:id instance)]
+      (jruby-core/return-to-pool instance)
+      (let [instance (jruby-core/borrow-from-pool pool-context)]
+        (is (= id (:id instance)))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -47,7 +47,7 @@
 
     (testing "Borrowing all instances from a pool while it is being primed and
              returning them."
-      (let [all-the-jrubys (jruby-testutils/drain-pool pool pool-size)]
+      (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)]
         (is (= 0 (free-instance-count pool)))
         (doseq [instance all-the-jrubys]
           (is (not (nil? instance)) "One of JRubyPuppet instances is nil"))
@@ -57,9 +57,9 @@
     (testing "Borrowing from an empty pool with a timeout returns nil within the
              proper amount of time."
       (let [timeout              250
-            all-the-jrubys       (jruby-testutils/drain-pool pool pool-size)
+            all-the-jrubys       (jruby-testutils/drain-pool pool-context pool-size)
             test-start-in-millis (System/currentTimeMillis)]
-        (is (nil? (borrow-from-pool-with-timeout pool timeout)))
+        (is (nil? (borrow-from-pool-with-timeout pool-context timeout)))
         (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout)
             "The timeout value was not honored.")
         (jruby-testutils/fill-drained-pool all-the-jrubys)
@@ -67,7 +67,7 @@
             "All JRubyPuppet instances were not returned to the pool.")))
 
     (testing "Removing an instance decrements the pool size by 1."
-      (let [jruby-instance (borrow-from-pool pool)]
+      (let [jruby-instance (borrow-from-pool pool-context)]
         (is (= (free-instance-count pool) (dec pool-size)))
         (return-to-pool jruby-instance)))
 
@@ -77,8 +77,8 @@
                           (assoc acc (:id jruby)
                                      (:request-count @(:state jruby))))
             get-counts  (fn [jrubies] (reduce assoc-count {} jrubies))]
-        (doseq [drain-fn [#(jruby-core/borrow-from-pool pool)
-                          #(jruby-core/borrow-from-pool-with-timeout pool 20000)]]
+        (doseq [drain-fn [#(jruby-core/borrow-from-pool pool-context)
+                          #(jruby-core/borrow-from-pool-with-timeout pool-context 20000)]]
           (let [jrubies (drain-via drain-fn)
                 counts  (get-counts jrubies)]
             (jruby-testutils/fill-drained-pool jrubies)
@@ -94,22 +94,21 @@
         config        (jruby-testutils/jruby-puppet-config pool-size)
         profiler      jruby-testutils/default-profiler
         pool-context  (create-pool-context config profiler nil)
-        pool          (get-pool pool-context)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
     (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
                  (is (thrown? IllegalStateException (jruby-agents/prime-pool! (:pool-state pool-context) config profiler))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException
             err-msg
-            (borrow-from-pool pool)))
+            (borrow-from-pool pool-context)))
       (is (thrown-with-msg? IllegalStateException
             err-msg
-            (borrow-from-pool-with-timeout pool 120))))
+            (borrow-from-pool-with-timeout pool-context 120))))
     (testing "borrow and borrow-with-timeout both continue to throw exceptions on subsequent calls"
       (is (thrown-with-msg? IllegalStateException
           err-msg
-          (borrow-from-pool pool)))
+          (borrow-from-pool pool-context)))
       (is (thrown-with-msg? IllegalStateException
           err-msg
-          (borrow-from-pool-with-timeout pool 120))))))
+          (borrow-from-pool-with-timeout pool-context 120))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -5,7 +5,8 @@
             [puppetlabs.services.jruby.jruby-puppet-core :refer :all :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -95,7 +96,7 @@
         pool-context  (create-pool-context config profiler)
         pool          (get-pool pool-context)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
-    (with-redefs [core/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
+    (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
                  (is (thrown? IllegalStateException (jruby-agents/prime-pool! (:pool-state pool-context) config profiler))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -35,7 +35,7 @@
                    set)))
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [new-pool (jruby-core/get-pool pool-context)]
           (is (every? true?
                       (jruby-testutils/reduce-over-jrubies!
@@ -68,7 +68,7 @@
         ; wait until we know the new pool has been swapped in
         @pool-state-swapped
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
           (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -11,7 +11,7 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol])
   (:import (puppetlabs.services.jruby.jruby_puppet_core RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
-           (java.util.concurrent ArrayBlockingQueue)))
+           (java.util.concurrent LinkedBlockingDeque)))
 
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -83,7 +83,7 @@
             real-pool     (-> (tk-services/service-context jruby-service)
                               :pool-context
                               (jruby-core/get-pool))
-            retry-pool    (ArrayBlockingQueue. 1)
+            retry-pool    (LinkedBlockingDeque. 1)
             _             (-> retry-pool (RetryPoisonPill.) jruby-core/return-to-pool)
             mock-pools    [retry-pool retry-pool retry-pool real-pool]
             num-borrows   (atom 0)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -8,8 +8,9 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
-            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol])
-  (:import (puppetlabs.services.jruby.jruby_puppet_core RetryPoisonPill)
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
+  (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
            (java.util.concurrent LinkedBlockingDeque)))
 
@@ -69,7 +70,7 @@
         ; wait until the flush is complete
         (await (:pool-agent context))
         (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
-          (is (jruby-core/retry-poison-pill? old-pool-instance)))))))
+          (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 
 (deftest with-jruby-retry-test-via-mock-get-pool
   (testing "with-jruby-puppet retries if it encounters a RetryPoisonPill"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -10,7 +10,8 @@
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
            (java.util.concurrent LinkedBlockingDeque)))
@@ -71,7 +72,8 @@
         (let [old-pool-instance (jruby-internal/borrow-from-pool!*
                                   jruby-internal/borrow-without-timeout-fn
                                   old-pool
-                                  pool-context)]
+                                  pool-context
+                                  jruby-agents/send-flush-instance!)]
           (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 
 (deftest with-jruby-retry-test-via-mock-get-pool
@@ -99,3 +101,15 @@
             jruby-service
             (is (instance? JRubyPuppet jruby-puppet))))
         (is (= 4 @num-borrows))))))
+
+(deftest next-instance-id-test
+  (let [pool-context (jruby-core/create-pool-context
+                       (jruby-testutils/jruby-puppet-config 8)
+                       jruby-testutils/default-profiler
+                       jruby-testutils/default-shutdown-fn)]
+    (testing "next instance id should be based on the pool size"
+      (is (= 10 (jruby-agents/next-instance-id 2 pool-context)))
+      (is (= 100 (jruby-agents/next-instance-id 92 pool-context))))
+    (testing "next instance id should wrap after max int"
+      (let [id (- Integer/MAX_VALUE 1)]
+        (is (= (mod id 8) (jruby-agents/next-instance-id id pool-context)))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -9,7 +9,8 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
            (java.util.concurrent LinkedBlockingDeque)))
@@ -27,22 +28,20 @@
             (jruby-testutils/jruby-puppet-config 4)))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
-            pool-context (:pool-context context)
-            pool (jruby-core/get-pool pool-context)]
-        (jruby-testutils/reduce-over-jrubies! pool 4 #(format "InstanceID = %s" %))
+            pool-context (:pool-context context)]
+        (jruby-testutils/reduce-over-jrubies! pool-context 4 #(format "InstanceID = %s" %))
         (is (= #{0 1 2 3}
-               (-> (jruby-testutils/reduce-over-jrubies! pool 4 (constantly "InstanceID"))
+               (-> (jruby-testutils/reduce-over-jrubies! pool-context 4 (constantly "InstanceID"))
                    set)))
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until the flush is complete
         (await (:pool-agent pool-context))
-        (let [new-pool (jruby-core/get-pool pool-context)]
-          (is (every? true?
-                      (jruby-testutils/reduce-over-jrubies!
-                        new-pool
-                        4
-                        (constantly
-                          "begin; InstanceID; false; rescue NameError; true; end")))))))))
+        (is (every? true?
+                    (jruby-testutils/reduce-over-jrubies!
+                      pool-context
+                      4
+                      (constantly
+                        "begin; InstanceID; false; rescue NameError; true; end"))))))))
 
 (deftest retry-poison-pill-test
   (testing "Flush puts a retry poison pill into the old pool"
@@ -69,7 +68,10 @@
         @pool-state-swapped
         ; wait until the flush is complete
         (await (:pool-agent pool-context))
-        (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
+        (let [old-pool-instance (jruby-internal/borrow-from-pool!*
+                                  jruby-internal/borrow-without-timeout-fn
+                                  old-pool
+                                  pool-context)]
           (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 
 (deftest with-jruby-retry-test-via-mock-get-pool
@@ -91,7 +93,7 @@
             get-mock-pool (fn [_] (let [result (nth mock-pools @num-borrows)]
                                     (swap! num-borrows inc)
                                     result))]
-        (with-redefs [jruby-core/get-pool get-mock-pool]
+        (with-redefs [jruby-internal/get-pool get-mock-pool]
           (jruby/with-jruby-puppet
             jruby-puppet
             jruby-service

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -11,7 +11,8 @@
             [clojure.stacktrace :as stacktrace]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]))
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -91,4 +92,6 @@
           service
           (is (instance? JRubyPuppet jruby-puppet))
           (is (= 0 (jruby-protocol/free-instance-count service))))
-        (is (= 1 (jruby-protocol/free-instance-count service)))))))
+        (is (= 1 (jruby-protocol/free-instance-count service)))
+        (let [jruby (jruby-protocol/borrow-instance service)]
+          (is (= 2 (:request-count (jruby-core/instance-state jruby)))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -17,7 +17,8 @@
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
 (def jruby-service-test-config
-  {:jruby-puppet (jruby-testutils/jruby-puppet-config 1)})
+  {:jruby-puppet (jruby-testutils/jruby-puppet-config 1)
+   :os-settings {:ruby-load-path []}})
 
 (deftest test-error-during-init
   (testing

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -12,7 +12,8 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -25,7 +26,7 @@
       (str "If there as an exception while putting a JRubyPuppet instance in "
            "the pool the application should shut down.")
     (logging/with-test-logging
-      (with-redefs [jruby-puppet-core/create-pool-instance!
+      (with-redefs [jruby-internal/create-pool-instance!
                     (fn [& _] (throw (Exception. "42")))]
                    (let [got-expected-exception (atom false)]
                      (try

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -12,6 +12,7 @@
 (def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"])
 
 (def conf-dir "./target/master-conf")
+(def var-dir "./target/master-var")
 
 (def gem-home "./target/jruby-gem-home")
 
@@ -52,14 +53,13 @@
   JRubyPuppet pool size with be included with the config, otherwise no size
   will be specified."
   ([]
-   {:ruby-load-path  ruby-load-path
-    :gem-home        gem-home
-    :master-conf-dir conf-dir})
+   (jruby-core/initialize-config
+     {:jruby-puppet {:gem-home        gem-home
+                     :master-conf-dir conf-dir
+                     :master-var-dir  var-dir}
+      :os-settings  {:ruby-load-path  ruby-load-path}}))
   ([pool-size]
    (assoc (jruby-puppet-config) :max-active-instances pool-size)))
-
-(def default-config-no-size
-  (jruby-puppet-config))
 
 (def default-profiler
   nil)

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -81,10 +81,11 @@
       (Object.))))
 
 (defn create-mock-pool-instance
-  [pool _ _ _]
+  [pool id _ _]
   (let [instance (jruby-core/map->JRubyPuppetInstance
                    {:pool                 pool
-                    :id                   1
+                    :id                   id
+                    :state                (atom {:request-count 0})
                     :jruby-puppet         (create-mock-jruby-instance)
                     :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
                     :environment-registry (puppet-env/environment-registry)})]

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -103,8 +103,8 @@
 
 (defn drain-pool
   "Drains the JRubyPuppet pool and returns each instance in a vector."
-  [pool size]
-  (mapv (fn [_] (jruby-core/borrow-from-pool pool)) (range size)))
+  [pool-context size]
+  (mapv (fn [_] (jruby-core/borrow-from-pool pool-context)) (range size)))
 
 (defn fill-drained-pool
   "Returns a list of JRubyPuppet instances back to their pool."
@@ -120,8 +120,8 @@
 
   Returns a vector containing the results of executing the scripts against the
   JRuby instances."
-  [pool size f]
-  (let [jrubies (drain-pool pool size)
+  [pool-context size f]
+  (let [jrubies (drain-pool pool-context size)
         result  (reduce
                   (fn [acc jruby-offset]
                     (let [sc (:scripting-container (nth jrubies jruby-offset))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -2,9 +2,9 @@
   (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse)
            (org.jruby.embed ScriptingContainer LocalContextScope))
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
-            [puppetlabs.services.puppet-profiler.puppet-profiler-core :as profiler-core]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]))
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -82,7 +82,7 @@
 
 (defn create-mock-pool-instance
   [pool id _ _]
-  (let [instance (jruby-core/map->JRubyPuppetInstance
+  (let [instance (jruby-schemas/map->JRubyPuppetInstance
                    {:pool                 pool
                     :id                   id
                     :state                (atom {:request-count 0})

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -65,6 +65,10 @@
 (def default-profiler
   nil)
 
+(defn default-shutdown-fn
+  [f]
+  (f))
+
 (defn create-pool-instance
   ([]
    (create-pool-instance (jruby-puppet-config 1)))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -4,7 +4,8 @@
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -68,8 +69,8 @@
   ([]
    (create-pool-instance (jruby-puppet-config 1)))
   ([config]
-   (let [pool (jruby-core/instantiate-free-pool 1)]
-     (jruby-core/create-pool-instance! pool 1 config default-profiler))))
+   (let [pool (jruby-internal/instantiate-free-pool 1)]
+     (jruby-internal/create-pool-instance! pool 1 config default-profiler))))
 
 (defn create-mock-jruby-instance
   "Creates a mock implementation of the JRubyPuppet interface."
@@ -97,7 +98,7 @@
   mock JRubyPuppet instances."
   [f]
   (with-redefs
-    [jruby-core/create-pool-instance! create-mock-pool-instance]
+    [jruby-internal/create-pool-instance! create-mock-pool-instance]
     (f)))
 
 (defn drain-pool


### PR DESCRIPTION
NOTE: not ready for merge; need to clean up some of the last few commits and add a few more tests.

---------------------

This PR does the following:

* Change our JRuby queuing strategy from FIFO to LIFO.  (This improves memory usage by a great deal when the system is not under high load, and also makes it possible for us to flush individual JRuby instances after a maximum number of requests in a sane way; in a FIFO model, all JRuby instances would hit the max number of requests at roughly the same time.)
* Refactors a lot of the JRuby code to make it possible to flush instances with more granularity than the entire pool
* Introduce a setting 'max-requests-per-instance'; after any JRuby instance handles more requests than this, it will be flushed and replaced in the pool by a fresh one