### PR TITLE
(SERVER-331) Fold os-settings back into jruby-puppet

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -155,27 +155,6 @@ module PuppetServerExtensions
     end
   end
 
-  def configure_puppet_server
-    variant, version, _, _ = master['platform'].to_array
-
-    case variant
-    when /^fedora$/
-      config_key = 'sitelibdir'
-      if version.to_i >= 17
-        config_key = 'vendorlibdir'
-      end
-    when /^(el|centos)$/
-      config_key = 'sitelibdir'
-      if version.to_i >= 7
-        config_key = 'vendorlibdir'
-      end
-    when /^(debian|ubuntu)$/
-      config_key = 'sitelibdir'
-    else
-      logger.warn("#{platform}: Unsupported platform for puppetserver.")
-    end
-  end
-
   def upgrade_package(host, name)
     variant, _, _, _ = master['platform'].to_array
     case variant

--- a/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/80_configure_puppet.rb
@@ -7,10 +7,3 @@ step "Configure puppet.conf" do
                            {"main" => { "dns_alt_names" => "puppet,#{hostname},#{fqdn}",
                                        "verbose" => true }}, dir)
 end
-
-case test_config[:puppetserver_install_type]
-when :git
-  step "Configure os-settings.conf" do
-    configure_puppet_server
-  end
-end

--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -12,10 +12,6 @@ product: {
            artifact-id: puppet-server}
 }
 
-os-settings: {
-    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib]
-}
-
 webserver: {
     client-auth: want
     # ssl-host controls what networks the server will accept connections from.
@@ -43,6 +39,10 @@ web-router-service: {
 
 # configuration for the JRuby interpreters
 jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib]
+
     # This setting determines where JRuby will look for gems.  It is also
     # used by the `puppetserver gem` command line tool.
     gem-home: ./target/jruby-gems

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -32,8 +32,8 @@
   (if-let [conf (resolve 'user/puppet-server-conf)]
     ((deref conf))
     {:global                {:logging-config "./dev/logback-dev.xml"}
-     :os-settings           {:ruby-load-path jruby-testutils/ruby-load-path}
-     :jruby-puppet          {:gem-home             jruby-testutils/gem-home
+     :jruby-puppet          {:ruby-load-path       jruby-testutils/ruby-load-path
+                             :gem-home             jruby-testutils/gem-home
                              :max-active-instances 1
                              :master-conf-dir      jruby-testutils/conf-dir}
      :webserver             {:client-auth "want"

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -56,6 +56,7 @@ By default, Puppet Server is configured to use the correct Puppet Master and CA 
 This file contains the settings for Puppet Server itself.
 
 * The `jruby-puppet` settings configure the interpreter:
+    * `ruby-load-path`: Where the Puppet Server expects to find Puppet, Facter, etc.
     * `gem-home`: This setting determines where JRuby looks for gems. It is
       also used by the `puppetserver gem` command line tool. If not specified,
       uses the Puppet default `/opt/puppetlabs/puppet/cache/jruby-gems`.
@@ -79,6 +80,7 @@ This file contains the settings for Puppet Server itself.
 # configuration for the JRuby interpreters
 
 jruby-puppet: {
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
     gem-home: /opt/puppetlabs/puppet/cache/jruby-gems
     master-conf-dir: /etc/puppet
     master-var-dir: /opt/puppetlabs/puppet/cache
@@ -154,18 +156,6 @@ certificate-authority: {
         authorization-required: true
         client-whitelist: []
     }
-}
-~~~
-
-### `os-settings.conf`
-
-This file is set up by packaging and is used to initialize the Ruby load paths for JRuby. The only setting in this file is `ruby-load-path`. To avoid the risk of loading any gems or other code from your system Ruby, we recommend that you do not modify this file. However, if you must add additional paths to the JRuby load path, you can do so here.
-
-The Ruby load path defaults to the directory where Puppet is installed. In this release, this directory varies depending on what OS you are using.
-
-~~~
-os-settings: {
-    ruby-load-path: ["/usr/lib/ruby/site_ruby/1.8"]
 }
 ~~~
 

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -133,12 +133,9 @@ Puppet Server's conf.d directory contains:
 * `puppetserver.conf`: Settings for Puppet Server itself, including the JRuby interpreter and the administrative API.
 * `master.conf`: Settings for the Puppet master functionality of Puppet Server.
 * `ca.conf`: Settings for the Certificate Authority service.
-* `os-settings.conf`: Settings for the Ruby load paths for JRuby.
 
 For detailed information about Puppet Server settings and the conf.d directory, refer to the [Configuration](./configuration.markdown) page.
 
 While Puppet Server uses Puppet's [auth.conf](/latest/reference/config_file_auth.html) for most access control, access to the `certificate_status` endpoint is controlled in the ca.conf file mentioned above. By default, this file allows no access to this endpoint. (Access to the `certificate`, `certificate_request`, and `certificate_revocation_list` endpoints is always allowed.)
 
 As mentioned above, Puppet Server also uses Puppet's usual config files, including most of the settings in [puppet.conf](/puppet/latest/reference/config_file_main.html). However, Puppet Server does treat some puppet.conf settings differently, and you should be aware of [these differences](./puppet_conf_setting_diffs.html).
-
-

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -1,11 +1,9 @@
-# Where the puppet-agent dependency places puppet, facter, etc...
-# Puppet server expects to load Puppet from this location
-os-settings: {
-    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
-}
-
 # configuration for the JRuby interpreters
 jruby-puppet: {
+    # Where the puppet-agent dependency places puppet, facter, etc...
+    # Puppet server expects to load Puppet from this location
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
+
     # This setting determines where JRuby will look for gems.  It is also
     # used by the `puppetserver gem` command line tool.
     gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -706,14 +706,14 @@
   "Given the configuration map from the Puppet Server config
    service return a map with of all the CA settings.
    Throws an exception if any required configuration is not found."
-  [{:keys [puppet-server os-settings certificate-authority]}]
+  [{:keys [puppet-server jruby-puppet certificate-authority]}]
   (if-not certificate-authority
     (throw (IllegalStateException.
             (str "Missing required configuration for CA; "
                  "certificate-authority: { certificate-status: { client-whitelist: [...] } } "
                  "not found in puppet-server.conf"))))
   (-> (select-keys puppet-server (keys CaSettings))
-      (assoc :ruby-load-path (:ruby-load-path os-settings))
+      (assoc :ruby-load-path (:ruby-load-path jruby-puppet))
       (assoc :access-control certificate-authority)))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -17,7 +17,7 @@
                        (.put "GEM_HOME" gem-home)
                        (.put "JARS_NO_REQUIRE" "true"))
         jruby-home   (.getJRubyHome jruby-config)
-        load-path    (->> (get-in config [:os-settings :ruby-load-path])
+        load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
                           (cons jruby-puppet/ruby-code-dir)
                           (cons (str jruby-home "/lib/ruby/1.9"))
                           (cons (str jruby-home "/lib/ruby/shared"))

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -6,7 +6,7 @@
 
 (defn new-jruby-main
   [config]
-  (let [load-path    (->> (get-in config [:os-settings :ruby-load-path])
+  (let [load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
                           (cons jruby-puppet/ruby-code-dir))
         gem-home     (get-in config [:jruby-puppet :gem-home])
         jruby-config (new RubyInstanceConfig)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -29,16 +29,15 @@
   (init
     [this context]
     (let [config            (-> (get-in-config [:jruby-puppet])
-                              (assoc :ruby-load-path (get-in-config [:os-settings :ruby-load-path]))
-                              (assoc :http-client-ssl-protocols
-                                     (get-in-config [:http-client :ssl-protocols]))
-                              (assoc :http-client-cipher-suites
-                                     (get-in-config [:http-client :cipher-suites])))
+                                (assoc :http-client-ssl-protocols
+                                       (get-in-config [:http-client :ssl-protocols]))
+                                (assoc :http-client-cipher-suites
+                                       (get-in-config [:http-client :cipher-suites])))
           service-id        (tk-services/service-id this)
           agent-shutdown-fn (partial shutdown-on-error service-id)
-          pool-agent  (jruby-agents/pool-agent agent-shutdown-fn)
+          pool-agent        (jruby-agents/pool-agent agent-shutdown-fn)
           profiler          (get-profiler)
-          borrow-timeout (get-in-config [:jruby-puppet :borrow-timeout] default-borrow-timeout)]
+          borrow-timeout    (get-in-config [:jruby-puppet :borrow-timeout] default-borrow-timeout)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
       (let [pool-context (core/create-pool-context config profiler)]

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -47,9 +47,6 @@
                (-> (:jruby-puppet (jruby-testutils/jruby-puppet-tk-config
                                     (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
                    (dissoc :master-conf-dir))))
-        (is (= (:os-settings service-config)
-               (:os-settings (jruby-testutils/jruby-puppet-tk-config
-                               (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))))
         (is (= (:webserver service-config) {:port 8081}))
         (is (= (:my-config service-config) {:foo "bar"}))
         (is (= (set (keys (:puppet-server service-config)))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -42,8 +42,7 @@
   "Create a JRubyPuppet pool config with the given pool config.  Suitable for use
   in bootstrapping trapperkeeper."
   [pool-config]
-  {:os-settings  {:ruby-load-path ruby-load-path}
-   :product     {:name "puppet-server"
+  {:product     {:name "puppet-server"
                  :update-server-url "http://localhost:11111"}
    :jruby-puppet pool-config
    :certificate-authority {:certificate-status {:client-whitelist []}}})
@@ -133,4 +132,3 @@
                   (range size))]
     (fill-drained-pool jrubies)
     result))
-


### PR DESCRIPTION
This commit moves the :ruby-load-path setting out of the os-settings
section and into the jruby-puppet section. The os-settings section is no
longer necessary, so it was removed altogether.