### PR TITLE
(SERVER-410) Always cache features in puppet server

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -20,5 +20,12 @@ describe 'Puppet::Server::PuppetConfig' do
         expect(subject).to eq('debug')
       end
     end
+
+    describe '(SERVER-410) Puppet[:always_cache_features]' do
+      subject { Puppet[:always_cache_features] }
+      it 'is true for increased performance in puppet-server' do
+        expect(subject).to eq(true)
+      end
+    end
   end
 end

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -1,18 +1,24 @@
 require 'puppet/server/puppet_config'
 
-describe Puppet::Server::PuppetConfig do
-  mock_puppet_config = {}
-  context "Puppet's log level" do
-    it "is set as high as possible during initialization, " +
-       "so that all log messages make it to logback" do
+describe 'Puppet::Server::PuppetConfig' do
+  context "When puppet has had settings initialized" do
+    before :each do
+      mock_puppet_config = {}
+      Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
+    end
 
-      Puppet::Server::PuppetConfig.initialize_puppet mock_puppet_config
+    describe "the puppet log level (Puppet[:log_level])" do
+      subject { Puppet[:log_level] }
+      it 'is set to debug (the highest) so messages make it to logback' do
+        expect(subject).to eq('debug')
+      end
+    end
 
-      # The first line here is probably sufficient, but there's been some
-      # changes in Puppet recently around logging, so it seems worthwhile
-      # to test both of these.
-      Puppet[:log_level].should == "debug"
-      Puppet::Util::Log.level.should == :debug
+    describe "the puppet log level (Puppet::Util::Log.level)" do
+      subject { Puppet::Util::Log.level }
+      it 'is set to debug (the highest) so messages make it to logback' do
+        expect(subject).to eq('debug')
+      end
     end
   end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -21,6 +21,10 @@ class Puppet::Server::PuppetConfig
     )
     Puppet[:trace] = true
 
+    # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
+    # the cache is intended for agents to reload features mid-catalog-run.
+    Puppet[:always_cache_features] = true
+
     # Crank Puppet's log level all the way up and just control it via logback.
     Puppet[:log_level] = "debug"
 


### PR DESCRIPTION
Without this patch puppet server defers to puppet on the value of the
always_cache_features setting.  This is a problem because it does not
make sense for features to be reloaded frequently on the puppet server,
this behavior is only useful for puppet agent processes that need to
update the set of installed features mid-run.

This patch addresses the problem by explicitly setting
Puppet[:always_cache_features] to true in Puppet::Server::PuppetConfig.

This approach is employed to keep all of the static jruby-puppet related
settings in one place, internal to the JRuby contexts.  This approach is
employed in order to avoid expanding the surface area between Clojure
and JRuby.