### PR TITLE
(SERVER-409) Plumb directories into jruby

### DIFF
--- a/dev-resources/puppetlabs/services/jruby/jruby_interpreter_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/jruby/jruby_interpreter_test/puppet.conf
@@ -1,2 +1,2 @@
 [main]
-vardir = ./target/master-var
+vardir = ./target/master-var-jruby-int-test

--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -48,10 +48,19 @@ jruby-puppet: {
     gem-home: ./target/jruby-gems
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
-    #master-conf-dir: /etc/puppet
+    #master-conf-dir: /etc/puppetlabs/puppet
+
+    # (optional) path to puppet code dir; if not specified, will use the puppet default
+    #master-code-dir: /etc/puppetlabs/code
 
     # (optional) path to puppet var dir; if not specified, will use the puppet default
-    #master-var-dir: /opt/puppetlabs/puppet/cache
+    #master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use the puppet default
+    #master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use the puppet default
+    #master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
     max-active-instances: 1

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -32,10 +32,7 @@
   (if-let [conf (resolve 'user/puppet-server-conf)]
     ((deref conf))
     {:global                {:logging-config "./dev/logback-dev.xml"}
-     :jruby-puppet          {:ruby-load-path       jruby-testutils/ruby-load-path
-                             :gem-home             jruby-testutils/gem-home
-                             :max-active-instances 1
-                             :master-conf-dir      jruby-testutils/conf-dir}
+     :jruby-puppet          (jruby-testutils/jruby-puppet-config {:max-active-instances 1})
      :webserver             {:client-auth "want"
                              :ssl-host    "localhost"
                              :ssl-port    8140}

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -60,15 +60,26 @@ This file contains the settings for Puppet Server itself.
     * `gem-home`: This setting determines where JRuby looks for gems. It is
       also used by the `puppetserver gem` command line tool. If not specified,
       uses the Puppet default `/opt/puppetlabs/puppet/cache/jruby-gems`.
-    * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
+    * `master-conf-dir`: Optionally, set the path to the Puppet configuration
+      directory. If not specified, uses the Puppet default `/etc/puppetlabs/puppet`.
+    * `master-code-dir`: Optionally, set the path to the Puppet code directory.
+      If not specified, uses the Puppet default `/etc/puppetlabs/code`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable
       directory. If not specified, uses the Puppet default
-      `/opt/puppetlabs/puppet/cache`.
-    * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus+2'.
-    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 1200000.
+      `/opt/puppetlabs/server/data/puppetserver`.
+    * `master-run-dir`: Optionally, set the path to the Puppet run directory.
+      If not specified, uses the Puppet default `/var/run/puppetlabs/puppetserver`.
+    * `master-log-dir`: Optionally, set the path to the Puppet log directory.
+      If not specified, uses the Puppet default `/var/log/puppetlabs/puppetserver`.
+    * `max-active-instances`: Optionally, set the maximum number of JRuby
+      instances to allow. Defaults to 'num-cpus+2'.
+    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow
+      an instance from the JRuby pool in milliseconds. Defaults to 1200000.
 * The `profiler` settings configure profiling:
-    * `enabled`: if this is set to `true`, it enables profiling for the Puppet Ruby code. Defaults to `false`.
-* The `puppet-admin` section configures the Puppet Server's administrative API. (This is a new API, which isn't provided by Rack or WEBrick Puppet masters.)
+    * `enabled`: if this is set to `true`, it enables profiling for the Puppet
+    Ruby code. Defaults to `false`.
+* The `puppet-admin` section configures the Puppet Server's administrative API.
+  (This is a new API, which isn't provided by Rack or WEBrick Puppet masters.)
     * `authorization-required` determines whether a client
     certificate is required to access the endpoints in this API.  If set to
     `false`, the client-whitelist will be ignored. Defaults to `true`.
@@ -82,8 +93,11 @@ This file contains the settings for Puppet Server itself.
 jruby-puppet: {
     ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
     gem-home: /opt/puppetlabs/puppet/cache/jruby-gems
-    master-conf-dir: /etc/puppet
-    master-var-dir: /opt/puppetlabs/puppet/cache
+    master-conf-dir: /etc/puppetlabs/puppet
+    master-code-dir: /etc/puppetlabs/code
+    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+    master-run-dir: /var/run/puppetlabs/puppetserver
+    master-log-dir: /var/log/puppetlabs/puppetserver
     max-active-instances: 1
 }
 

--- a/documentation/dev_running_from_source.markdown
+++ b/documentation/dev_running_from_source.markdown
@@ -65,13 +65,18 @@ Edit it to suit your needs.  A few notes:
   usual `confdir`.  The setting `master-conf-dir` may be used to modify the location
   of the Puppet `confdir`.  Otherwise, it will use the same default locations as
   Puppet normally uses (`~/.puppet` for non-root users, `/etc/puppet` for root).
+* Similar to `confdir`, you will likely want to specify the other top-level
+  Puppet directories `codedir`, `vardir`, `rundir`, and `logdir`.
 
 You probably don't need to make any changes to the sample config for your first run,
 but the settings that I edit the most frequently are:
 
  * `jruby-puppet.master-conf-dir`: the puppet master confdir (where `puppet.conf`,
    `modules`, `manifests`, etc. should be located).
+ * `jruby-puppet.master-code-dir`: the puppet master codedir
  * `jruby-puppet.master-var-dir`: the puppet master vardir
+ * `jruby-puppet.master-run-dir`: the puppet master rundir
+ * `jruby-puppet.master-log-dir`: the puppet master logdir
  * `jruby-puppet.max-active-instances`: the number of JRuby instances to put into the
    pool.  This can usually be set to 1 for dev purposes, unless you're working on
    something that involves concurrency.

--- a/project.clj
+++ b/project.clj
@@ -123,5 +123,3 @@
   ;; that from the final uberjar:
   :uberjar-exclusions [#"META-INF/jruby.home/lib/ruby/shared/org/bouncycastle"]
   )
-
-

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -11,8 +11,17 @@ jruby-puppet: {
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
     master-conf-dir: /etc/puppetlabs/puppet
 
+    # (optional) path to puppet code dir; if not specified, will use the puppet default
+    master-code-dir: /etc/puppetlabs/code
+
     # (optional) path to puppet var dir; if not specified, will use the puppet default
     master-var-dir: /opt/puppetlabs/server/data/puppetserver
+
+    # (optional) path to puppet run dir; if not specified, will use the puppet default
+    master-run-dir: /var/run/puppetlabs/puppetserver
+
+    # (optional) path to puppet log dir; if not specified, will use the puppet default
+    master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
     #max-active-instances: 1

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -206,7 +206,7 @@
   (let [{:keys [ruby-load-path gem-home
                 http-client-ssl-protocols http-client-cipher-suites]} config]
     (when-not ruby-load-path
-      (throw (Exception.
+      (throw (IllegalStateException.
                "JRuby service missing config value 'ruby-load-path'")))
     (let [scripting-container  (create-scripting-container ruby-load-path gem-home)
           env-registry         (puppet-env/environment-registry)

--- a/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
@@ -1,6 +1,4 @@
 (ns puppetlabs.puppetserver.bootstrap-int-test
-  (:import (java.io IOException)
-           (org.apache.http ConnectionClosedException))
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]))

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -17,8 +17,17 @@
 (def master-conf-dir
   "./target/master-conf")
 
+(def master-code-dir
+  "./target/master-code")
+
 (def master-var-dir
   "./target/master-var")
+
+(def master-run-dir
+  "./target/master-var/run")
+
+(def master-log-dir
+  "./target/master-var/log")
 
 (defn pem-file
   [& args]
@@ -31,7 +40,10 @@
     (let [config (-> (tk-config/load-config (.getPath tmp-conf))
                      (assoc-in [:global :logging-config] logging-test-conf-file)
                      (assoc-in [:jruby-puppet :master-conf-dir] master-conf-dir)
+                     (assoc-in [:jruby-puppet :master-code-dir] master-code-dir)
                      (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)
+                     (assoc-in [:jruby-puppet :master-run-dir] master-run-dir)
+                     (assoc-in [:jruby-puppet :master-log-dir] master-log-dir)
                      (ks/deep-merge config-overrides))]
       `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
          (tk-testutils/with-app-with-config

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -40,6 +40,3 @@
             jruby-puppet jruby-service
             (is (not (nil? (fs/list-dir ssl-dir))))
             (is (empty? (fs/list-dir (str ssl-dir "/ca"))))))))))
-
-
-

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -1,51 +1,61 @@
 (ns puppetlabs.services.jruby.jruby-interpreter-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.services.jruby.jruby-testutils :as testutils]
-            [puppetlabs.kitchensink.core :as ks]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.jruby-puppet-core :refer :all
-             :as core]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-puppet-core :refer :all]
+            [puppetlabs.services.jruby.jruby-testutils :as testutils]))
 
 (use-fixtures :once
-              (jruby-testutils/with-puppet-conf
+              (testutils/with-puppet-conf
                 "./dev-resources/puppetlabs/services/jruby/jruby_interpreter_test/puppet.conf"))
 
 (deftest create-jruby-instance-test
 
-  (testing "Var dir is not required."
-    (let [config        {:ruby-load-path  testutils/ruby-load-path
-                         :gem-home        testutils/gem-home
-                         :master-conf-dir testutils/conf-dir}
-          pool          (instantiate-free-pool 1)
-          pool-instance (create-pool-instance! pool 1 config testutils/default-profiler)
-          jruby-puppet  (:jruby-puppet pool-instance)
-          var-dir       (.getSetting jruby-puppet "vardir")]
-      (is (not (nil? var-dir)))))
+  (testing "Var dir is not required (it will be read from puppet.conf)"
+    (let [vardir (-> (testutils/jruby-puppet-config)
+                     (dissoc :master-var-dir)
+                     (testutils/create-pool-instance)
+                     (:jruby-puppet)
+                     (.getSetting "vardir"))]
+      (is (= (fs/absolute-path "target/master-var-jruby-int-test") vardir))))
+
+  (testing "Directories can be configured programatically
+            (and take precedence over puppet.conf)"
+    (let [puppet (-> {:ruby-load-path  testutils/ruby-load-path
+                      :gem-home        testutils/gem-home
+                      :master-conf-dir testutils/conf-dir
+                      :master-code-dir testutils/code-dir
+                      :master-var-dir  testutils/var-dir
+                      :master-run-dir  testutils/run-dir
+                      :master-log-dir  testutils/log-dir}
+                     (testutils/create-pool-instance)
+                     (:jruby-puppet))]
+      (are [setting expected] (= (-> expected
+                                     (fs/normalized-path)
+                                     (fs/absolute-path))
+                                 (.getSetting puppet setting))
+           "confdir" testutils/conf-dir
+           "codedir" testutils/code-dir
+           "vardir" testutils/var-dir
+           "rundir" testutils/run-dir
+           "logdir" testutils/log-dir)))
 
   (testing "Settings from Ruby Puppet are available"
-    (let [temp-dir      (.getAbsolutePath (ks/temp-dir))
-          config        (assoc (testutils/jruby-puppet-config)
-                          :master-var-dir temp-dir)
-          pool-instance (testutils/create-pool-instance config)
-          jruby-puppet  (:jruby-puppet pool-instance)]
-      (is (= "0.0.0.0" (.getSetting jruby-puppet "bindaddress")))
-      (is (= 8140 (.getSetting jruby-puppet "masterport")))
-      (is (= false (.getSetting jruby-puppet "onetime")))
-      (is (= (fs/absolute-path temp-dir)
-             (.getSetting jruby-puppet "vardir")))
-
-      (is (= (-> (:master-conf-dir config)
-                 fs/normalized-path
-                 fs/absolute-path)
-             (.getSetting jruby-puppet "confdir"))))))
+    (let [jruby-puppet (-> (testutils/jruby-puppet-config)
+                           (testutils/create-pool-instance)
+                           (:jruby-puppet))]
+      (testing "Various data types"
+        (is (= "0.0.0.0" (.getSetting jruby-puppet "bindaddress")))
+        (is (= 8140 (.getSetting jruby-puppet "masterport")))
+        (is (= false (.getSetting jruby-puppet "onetime")))))))
 
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
     (let [jruby-interpreter (create-scripting-container
-                              jruby-testutils/ruby-load-path
-                              jruby-testutils/gem-home)
+                              testutils/ruby-load-path
+                              testutils/gem-home)
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
 
-      ; $HOME and $PATH are left in by `jruby-puppet-env`
-      (is (= #{"HOME" "JARS_NO_REQUIRE" "PATH" "GEM_HOME"} (set (keys jruby-env)))))))
+      ;; $HOME and $PATH are left in by `jruby-puppet-env`
+      (is (= #{"HOME" "JARS_NO_REQUIRE" "PATH" "GEM_HOME"}
+             (set (keys jruby-env)))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -11,10 +11,13 @@
 ;; Constants
 
 (def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"])
+(def gem-home "./target/jruby-gem-home")
 
 (def conf-dir "./target/master-conf")
-
-(def gem-home "./target/jruby-gem-home")
+(def code-dir "./target/master-code")
+(def var-dir "./target/master-var")
+(def run-dir "./target/master-var/run")
+(def log-dir "./target/master-var/log")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JRubyPuppet Test fixtures
@@ -22,7 +25,7 @@
 (defn with-puppet-conf
   "This function returns a test fixture that will copy a specified puppet.conf
   file into the provided location for testing, and then delete it after the
-  tests have completed. If no destination dir is provided then the puppet.coonf
+  tests have completed. If no destination dir is provided then the puppet.conf
   file is copied to the default location of './target/master-conf'."
   ([puppet-conf-file]
    (with-puppet-conf puppet-conf-file conf-dir))
@@ -54,7 +57,11 @@
   ([]
    {:ruby-load-path  ruby-load-path
     :gem-home        gem-home
-    :master-conf-dir conf-dir})
+    :master-conf-dir conf-dir
+    :master-code-dir code-dir
+    :master-var-dir  var-dir
+    :master-run-dir  run-dir
+    :master-log-dir  log-dir})
   ([options]
    (merge (jruby-puppet-config) options)))
 


### PR DESCRIPTION
This commit adds plumbing for codedir, rundir, logdir in the same way we
were plumbing confdir and vardir through to JRuby.

This commit also bumps up the ruby Puppet submodule.

----

:+1: Unit tests pass
:+1: Can run the Server from source

:-1: Server is broken in packages, but not sure it's due to these changes, still investigating
**UPDATE**: Broken due to bindir and ssldir issues that are expected and not related to this PR
