### PR TITLE
(server-358) Update permissions on ssldir for the puppet user

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -21,8 +21,9 @@ ezbake: {
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master rundir  /var/run/puppetlabs/puppetserver",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master pidfile /var/run/puppetlabs/puppetserver/puppetserver.pid",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master codedir /etc/puppetlabs/code",
-                 "usermod --home /opt/puppetlabs/server/data/puppetserver puppet",
-                 "install --directory --owner=puppet --group=puppet --mode=775 /opt/puppetlabs/server/data"
+                 "install --directory /etc/puppetlabs/puppet/ssl",
+                 "chown -R puppet:puppet /etc/puppetlabs/puppet/ssl",
+                 "find /etc/puppetlabs/puppet/ssl -type d -print0 | xargs -0 chmod 770"
                ]
              }
 
@@ -34,8 +35,9 @@ ezbake: {
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master rundir  /var/run/puppetlabs/puppetserver",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master pidfile /var/run/puppetlabs/puppetserver/puppetserver.pid",
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master codedir /etc/puppetlabs/code",
-                 "usermod --home /opt/puppetlabs/server/data/puppetserver puppet",
-                 "install --directory --owner=puppet --group=puppet --mode=775 /opt/puppetlabs/server/data"
+                 "install --directory /etc/puppetlabs/puppet/ssl",
+                 "chown -R puppet:puppet /etc/puppetlabs/puppet/ssl",
+                 "find /etc/puppetlabs/puppet/ssl -type d -print0 | xargs -0 chmod 770"
                ]
              }
    }


### PR DESCRIPTION
This removes the creation/permission handling for the app
data directory, which is added to the packaging in
https://github.com/puppetlabs/ezbake/pull/198, and
adds back some code to update the permissions on the
ssldir to work with the puppet user and group.