### PR TITLE
(docs) Fix glitchy link and list item spacing in install page

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -17,26 +17,26 @@ Puppet Server is configured to use 2GB of RAM by default. If you'd like to just 
 1. [Enable the Puppet Labs package repositories][repodocs], if you haven't already done so.
 2. Stop the existing Puppet master service. The method for doing this varies depending on how your system is set up.
 
-  If you're running a WEBrick Puppet master, use: `service puppetmaster stop`.
+    If you're running a WEBrick Puppet master, use: `service puppetmaster stop`.
 
-  If you're running Puppet under Apache, you'll instead need to disable the puppetmaster vhost and restart the Apache service. The exact method for this depends on what your Puppet master vhost file is called and how you enabled it. For full documentation, see the [Passenger guide][passengerguide].
+    If you're running Puppet under Apache, you'll instead need to disable the puppetmaster vhost and restart the Apache service. The exact method for this depends on what your Puppet master vhost file is called and how you enabled it. For full documentation, see the [Passenger guide][passengerguide].
 
     * On a Debian system, the command might be something like `sudo a2dissite puppetmaster`.
     * On RHEL/CentOS systems, the command might be something like `sudo mv /etc/httpd/conf.d/puppetmaster.conf ~/`. Alternatively, you can delete the file instead of moving it.
 
-  After you've disabled the vhost, restart Apache, which is a service called either `httpd` or `apache2`, depending on your OS.
+    After you've disabled the vhost, restart Apache, which is a service called either `httpd` or `apache2`, depending on your OS.
 
-  Alternatively, if you don't need to keep the Apache service running, you can stop Apache with `service httpd stop` or `service apache2 stop`.
+    Alternatively, if you don't need to keep the Apache service running, you can stop Apache with `service httpd stop` or `service apache2 stop`.
 
 3. Install the Puppet Server package by running:
 
         yum install puppetserver
 
-   Or
+    Or
 
         apt-get install puppetserver
 
-   Note that there is no `-` in the package name.
+    Note that there is no `-` in the package name.
 
 4. Start the Puppet Server service:
 
@@ -53,7 +53,7 @@ By default, Puppet Server will be configured to use 2GB of RAM. However, if you 
 
     Replace 2g with the amount of memory you want to allocate to Puppet Server. For example, to allocate 1GB of memory, use `JAVA_ARGS="-Xms1g -Xmx1g"`; for 512MB, use `JAVA_ARGS="-Xms512m -Xmx512m"`.
 
-     For more information about the recommended settings for the JVM, please see [http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm](http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm).
+    For more information about the recommended settings for the JVM, please see [Oracle's docs on JVM tuning.](http://docs.oracle.com/cd/E15523_01/web.1111/e13814/jvm_tuning.htm)
 
 2. Restart the `puppetserver` service after making any changes to this file.
 


### PR DESCRIPTION
The docs site MD parser thought we were trying to italicise, for some reason.