### PR TITLE
(SERVER-438) Update version to 2.0.0-rc1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.0.1")
 (def tk-jetty-version "1.1.1")
 (def ks-version "1.0.0")
-(def ps-version "2.0.0-SNAPSHOT")
+(def ps-version "2.0.0-rc1")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
If this commit passes through CI then the merge commit that brings this change
in should be tagged as 2.0.0-rc1