### PR TITLE
(maint) Check service start right out of the package

### DIFF
--- a/acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb
+++ b/acceptance/suites/pre_suite/foss/71_smoke_test_puppetserver.rb
@@ -1,0 +1,23 @@
+# This step needs to execute as quickly as possible after the
+# install_puppet_server master step located in 70_install_puppet.rb
+#
+# This is because beaker uses `puppet resource` to manage the puppetserver
+# service which has the side-effect of changing ownership and permissions of key
+# paths such as /var/run/puppetlabs and /etc/puppetlabs/puppet/ssl
+#
+# This side-effect masks legitimate issues we need to test, such as "the
+# puppetserver fails to start out of the package"
+
+step "(SERVER-414) Make sure puppet-server can start without puppet resource, "\
+  "apply, or agent affecting the known good state of the SUT in a way that "\
+  "causes the tests to pass with false positive successful results."
+
+variant = master['platform'].to_array.first
+case variant
+  when /^(redhat|el|centos)$/
+    on(master, "service puppetserver start")
+    on(master, "service puppetserver status")
+    on(master, "service puppetserver stop")
+  else
+    step "(SERVER-414) Skipped for platform variant #{variant}"
+end


### PR DESCRIPTION
Without this patch the acceptance tests in the master branch are passing with
all green, successful, positive results.  This is a problem because those
results are misleading, immediately out of the package puppetserver fails to
start due to permission errors.

The problem is masked by the use of `puppet` in beaker shortly after installing
the puppetserver package.  The use of `puppet resource`, `puppet apply` or
`puppet agent` as root has the side-effect of changing ownership and
permissions of /var/run/puppetlabs, /var/log/puppetlabs, and
/etc/puppetlabs/puppet, all of which have the follow-on effect of allowing the
puppetserver service to start because the puppet user it runs as is then able
to create the directories it needs.

This patch addresses the problem by trying to start the puppetserver service
immediately after installing the package, just a like an user would.  The test
fails, like it should.