### PR TITLE
(SERVER-414) Manage rundir during service startup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -96,7 +96,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.0-SNAPSHOT"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.0"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -23,6 +23,10 @@ ezbake: {
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master codedir /etc/puppetlabs/code",
                  "usermod --home /opt/puppetlabs/server/data/puppetserver puppet",
                  "install --directory --owner=puppet --group=puppet --mode=775 /opt/puppetlabs/server/data"
+               ],
+               # Note, pre-start-actions need to have fully qualified paths
+               pre-start-action: [
+                 "/usr/bin/install --directory --owner={{user}} --group={{user}} --mode=775 /var/run/puppetlabs/puppetserver"
                ]
              }
 
@@ -36,6 +40,10 @@ ezbake: {
                  "/opt/puppetlabs/puppet/bin/puppet config set --section master codedir /etc/puppetlabs/code",
                  "usermod --home /opt/puppetlabs/server/data/puppetserver puppet",
                  "install --directory --owner=puppet --group=puppet --mode=775 /opt/puppetlabs/server/data"
+               ],
+               # Note, pre-start-actions need to have fully qualified paths
+               pre-start-action: [
+                 "/usr/bin/install --directory --owner={{user}} --group={{user}} --mode=775 /var/run/puppetlabs/puppetserver"
                ]
              }
    }


### PR DESCRIPTION
Without this patch the puppetserver puppet rundir does not exist, which is a
problem because the parent directory of rundir is owned by root and
puppetserver runs as puppet which is unable to create the rundir.  This
prevents the service from starting up out of the package.

This patch addresses the problem by creating the rundir directory in a manner
owned by the same account puppetserver runs as.  This eliminates the need for
puppetserver to create the directory and allows puppetserver to create files in
the rundir directory.

NOTE: This does not cover the case of `puppetserver foreground` which will
still fail if executed before the service is started using the service
management framework.