### PR TITLE
(SERVER-408) backport jruby borrow timeouts

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -60,6 +60,7 @@ This file contains the settings for Puppet Server itself.
     * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable directory. If not specified, uses the Puppet default `/var/lib/puppet`.
     * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus+2'.
+    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 60000.
 * The `profiler` settings configure profiling:
     * `enabled`: if this is set to `true`, it enables profiling for the Puppet Ruby code. Defaults to `false`.
 * The `puppet-admin` section configures the Puppet Server's administrative API. (This is a new API, which isn't provided by Rack or WEBrick Puppet masters.)

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -60,7 +60,7 @@ This file contains the settings for Puppet Server itself.
     * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable directory. If not specified, uses the Puppet default `/var/lib/puppet`.
     * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus+2'.
-    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 60000.
+    * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 1200000.
 * The `profiler` settings configure profiling:
     * `enabled`: if this is set to `true`, it enables profiling for the Puppet Ruby code. Defaults to `false`.
 * The `puppet-admin` section configures the Puppet Server's administrative API. (This is a new API, which isn't provided by Rack or WEBrick Puppet masters.)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -75,14 +75,18 @@
         when https client requests are made.
 
     * :http-client-cipher-suites - A list of legal SSL cipher suites that may
-        be used when https client requests are made."
+        be used when https client requests are made.
+
+    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool in milliseconds.
+        Defaults to 60000."
   {:ruby-load-path                                  [schema/Str]
    :gem-home                                        schema/Str
    (schema/optional-key :master-conf-dir)           schema/Str
    (schema/optional-key :master-var-dir)            schema/Str
    (schema/optional-key :max-active-instances)      schema/Int
    (schema/optional-key :http-client-ssl-protocols) [schema/Str]
-   (schema/optional-key :http-client-cipher-suites) [schema/Str]})
+   (schema/optional-key :http-client-cipher-suites) [schema/Str]
+   (schema/optional-key :borrow-timeout)            schema/Int})
 
 (def PoolState
   "A map that describes all attributes of a particular JRubyPuppet pool."

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -77,8 +77,8 @@
     * :http-client-cipher-suites - A list of legal SSL cipher suites that may
         be used when https client requests are made.
 
-    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool in milliseconds.
-        Defaults to 60000."
+    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool
+        in milliseconds. Defaults to 1200000."
   {:ruby-load-path                                  [schema/Str]
    :gem-home                                        schema/Str
    (schema/optional-key :master-conf-dir)           schema/Str
@@ -191,7 +191,7 @@
         (.put puppet-config "confdir" (fs/absolute-path master-conf-dir)))
       (when master-var-dir
         (.put puppet-config "vardir" (fs/absolute-path master-var-dir)))
-        
+
       (when http-client-ssl-protocols
         (.put puppet-server-config "ssl_protocols" (into-array String http-client-ssl-protocols)))
       (when http-client-cipher-suites

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -81,9 +81,15 @@
     (with-jruby-puppet
       jruby-puppet
       jruby-service
-      (do-something-with-a-jruby-puppet-instance jruby-puppet)))"
+      (do-something-with-a-jruby-puppet-instance jruby-puppet)))
+
+  Will throw an IllegalStateException if borrowing an instance of
+  JRubyPuppet times out."
   [jruby-puppet jruby-service & body]
   `(loop [pool-instance# (jruby/borrow-instance ~jruby-service)]
+     (if (nil? pool-instance#)
+       (throw (IllegalStateException.
+                "Error: Attempt to borrow a JRuby instance from the pool timed out")))
      (if (core/retry-poison-pill? pool-instance#)
        (do
          (jruby-core/return-to-pool pool-instance#)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -8,6 +8,11 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Constants
+
+(def default-borrow-timeout 60000)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
 ;; This service uses TK's normal config service instead of the
@@ -29,26 +34,23 @@
           service-id        (tk-services/service-id this)
           agent-shutdown-fn (partial shutdown-on-error service-id)
           pool-agent  (jruby-agents/pool-agent agent-shutdown-fn)
-          profiler          (get-profiler)]
+          profiler          (get-profiler)
+          borrow-timeout (get-in-config [:jruby-puppet :borrow-timeout] default-borrow-timeout)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
       (let [pool-context (core/create-pool-context config profiler)]
         (jruby-agents/send-prime-pool! pool-context pool-agent)
         (-> context
             (assoc :pool-context pool-context)
-            (assoc :pool-agent pool-agent)))))
+            (assoc :pool-agent pool-agent)
+            (assoc :borrow-timeout borrow-timeout)))))
 
   (borrow-instance
     [this]
-    (let [pool-context (:pool-context (tk-services/service-context this))
-          pool         (core/get-pool pool-context)]
-      (core/borrow-from-pool pool)))
-
-  (borrow-instance
-    [this timeout]
-    (let [pool-context (:pool-context (tk-services/service-context this))
-          pool         (core/get-pool pool-context)]
-      (core/borrow-from-pool-with-timeout pool timeout)))
+    (let [pool-context   (:pool-context (tk-services/service-context this))
+          pool           (core/get-pool pool-context)
+          borrow-timeout (:borrow-timeout (tk-services/service-context this))]
+      (core/borrow-from-pool-with-timeout pool borrow-timeout)))
 
   (return-instance
     [this jruby-instance]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -10,7 +10,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
 
-(def default-borrow-timeout 60000)
+(def default-borrow-timeout
+  "Default timeout when borrowing instances from the JRuby pool in
+   milliseconds. Current value is 1200000ms, or 20 minutes."
+  1200000)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -61,7 +64,7 @@
     (let [pool-context (:pool-context (tk-services/service-context this))
           pool         (core/get-pool pool-context)]
       (core/free-instance-count pool)))
-  
+
   (mark-all-environments-expired!
     [this]
     (let [pool-context (:pool-context (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -5,13 +5,12 @@
 
   (borrow-instance
     [this]
-    [this timeout]
     "Borrows an instance from the JRubyPuppet interpreter pool. If there are no
     interpreters left in the pool then the operation blocks until there is one
-    available. A timeout (integer measured in milliseconds) can be provided
+    available. A timeout (integer measured in milliseconds) can be configured
     which will either return an interpreter if one is available within the
     timeout length, or will return nil after the timeout expires if no
-    interpreters are available.")
+    interpreters are available. This timeout defaults to 60000 milliseconds.")
 
   (return-instance
     [this jrubypuppet-instance]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -10,7 +10,7 @@
     available. A timeout (integer measured in milliseconds) can be configured
     which will either return an interpreter if one is available within the
     timeout length, or will return nil after the timeout expires if no
-    interpreters are available. This timeout defaults to 60000 milliseconds.")
+    interpreters are available. This timeout defaults to 1200000 milliseconds.")
 
   (return-instance
     [this jrubypuppet-instance]
@@ -27,5 +27,3 @@
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool."))
-
-      

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -31,7 +31,7 @@
          disabled/certificate-authority-disabled-service]
 
         (-> (jruby-testutils/jruby-puppet-tk-config
-              (jruby-testutils/jruby-puppet-config 1))
+              (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
             (assoc-in [:jruby-puppet :master-conf-dir]
                       puppet-conf-dir))
 

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -18,12 +18,17 @@
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
    profiler/puppet-profiler-service])
 
+(def required-config
+  (merge (jruby-testutils/jruby-puppet-tk-config
+           (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
+         {:webserver    {:port 8081}}))
+
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/config/puppet_server_config_service_test")
 
 (def required-config
   (-> (jruby-testutils/jruby-puppet-tk-config
-        (jruby-testutils/jruby-puppet-config 1))
+        (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
       (assoc-in [:webserver :port] 8081)
       (assoc-in [:jruby-puppet :master-conf-dir]
                 (str test-resources-dir "/master/conf"))))
@@ -45,11 +50,11 @@
         (is (= (-> (:jruby-puppet service-config)
                    (dissoc :master-conf-dir))
                (-> (:jruby-puppet (jruby-testutils/jruby-puppet-tk-config
-                                    (jruby-testutils/jruby-puppet-config 1)))
+                                    (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
                    (dissoc :master-conf-dir))))
         (is (= (:os-settings service-config)
                (:os-settings (jruby-testutils/jruby-puppet-tk-config
-                               (jruby-testutils/jruby-puppet-config 1)))))
+                               (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))))
         (is (= (:webserver service-config) {:port 8081}))
         (is (= (:my-config service-config) {:foo "bar"}))
         (is (= (set (keys (:puppet-server service-config)))

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -18,11 +18,6 @@
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
    profiler/puppet-profiler-service])
 
-(def required-config
-  (merge (jruby-testutils/jruby-puppet-tk-config
-           (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
-         {:webserver    {:port 8081}}))
-
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/config/puppet_server_config_service_test")
 

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -20,7 +20,7 @@
 
 (deftest test-jruby-service-core-funcs
   (let [pool-size        2
-        config           (jruby-testutils/jruby-puppet-config pool-size)
+        config           (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size})
         profiler         jruby-testutils/default-profiler
         pool-context     (create-pool-context config profiler)
         pool             (get-pool pool-context)]
@@ -59,7 +59,7 @@
 
 (deftest prime-pools-failure
   (let [pool-size 2
-        config        (jruby-testutils/jruby-puppet-config pool-size)
+        config        (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size})
         profiler      jruby-testutils/default-profiler
         pool-context  (create-pool-context config profiler)
         pool          (get-pool pool-context)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -23,7 +23,7 @@
       [jruby/jruby-puppet-pooled-service
        profiler/puppet-profiler-service]
       (-> (jruby-testutils/jruby-puppet-tk-config
-            (jruby-testutils/jruby-puppet-config 4)))
+            (jruby-testutils/jruby-puppet-config {:max-active-instances 4})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
             pool-context (:pool-context context)
@@ -50,7 +50,7 @@
       [jruby/jruby-puppet-pooled-service
        profiler/puppet-profiler-service]
       (-> (jruby-testutils/jruby-puppet-tk-config
-            (jruby-testutils/jruby-puppet-config 1)))
+            (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
             pool-context (:pool-context context)
@@ -78,7 +78,7 @@
       [jruby/jruby-puppet-pooled-service
        profiler/puppet-profiler-service]
       (-> (jruby-testutils/jruby-puppet-tk-config
-            (jruby-testutils/jruby-puppet-config 1)))
+            (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             real-pool     (-> (tk-services/service-context jruby-service)
                               :pool-context

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -55,8 +55,8 @@
    {:ruby-load-path  ruby-load-path
     :gem-home        gem-home
     :master-conf-dir conf-dir})
-  ([pool-size]
-   (assoc (jruby-puppet-config) :max-active-instances pool-size)))
+  ([options]
+   (merge (jruby-puppet-config) options)))
 
 (def default-config-no-size
   (jruby-puppet-config))
@@ -66,7 +66,7 @@
 
 (defn create-pool-instance
   ([]
-   (create-pool-instance (jruby-puppet-config 1)))
+   (create-pool-instance (jruby-puppet-config {:max-active-instances 1})))
   ([config]
    (let [pool (jruby-core/instantiate-free-pool 1)]
      (jruby-core/create-pool-instance! pool 1 config default-profiler))))

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -37,7 +37,7 @@
              certificate-authority-service]
 
             (-> (jruby-testutils/jruby-puppet-tk-config
-                  (jruby-testutils/jruby-puppet-config 1))
+                  (jruby-testutils/jruby-puppet-config {:max-active-instances 1}))
                 (assoc-in [:jruby-puppet :master-conf-dir]
                           "dev-resources/puppetlabs/services/master/master_service_test/conf")
                 (assoc :webserver {:port 8081})


### PR DESCRIPTION
This PR cherry-picks the following three commits from master:

f72c912b3b636dca0a2bf87fbffa574b422d0a4e
14c498ec2beb71786cc8b6791feb4cdde44d7c2d
8ef238393fa8e632412f3668ca18e4121b43fd6e

This should effectively back-port the jruby borrow timeout work to the stable branch.