### PR TITLE
(MAINT) Move lein-voom plugin into profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,8 +53,7 @@
   :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
                  ["snapshots" "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
 
-  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]
+  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]]
 
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
@@ -91,7 +90,8 @@
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}
-             :ci {:plugins [[lein-pprint "1.1.1"]]}}
+             :ci {:plugins [[lein-pprint "1.1.1"]]}
+             :voom {:plugins [[lein-voom "0.1.0-20150115_230705-gd96d771" :exclusions [org.clojure/clojure]]]}}
 
   :test-selectors {:integration :integration
                    :unit (complement :integration)}


### PR DESCRIPTION
This commit moves the lein-voom plugin to a new :voom profile instead of
a top-level project plugin. The plugin causes several warnings any time
lein is invoked and this is pretty noisy.