### PR TITLE
(SERVER-448) Reduce the default value for # JRubies

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -51,7 +51,7 @@ jruby-puppet: {
     # (optional) path to puppet var dir; if not specified, will use the puppet default
     #master-var-dir: /var/lib/puppet
 
-    # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
+    # (optional) maximum number of JRuby instances to allow
     max-active-instances: 1
 }
 

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -59,7 +59,8 @@ This file contains the settings for Puppet Server itself.
     * `gem-home`: This setting determines where JRuby looks for gems. It is also used by the `puppetserver gem` command line tool. If not specified, uses the Puppet default `/var/lib/puppet/jruby-gems`.
     * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable directory. If not specified, uses the Puppet default `/var/lib/puppet`.
-    * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus+2'.
+    * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to roughly 'num-cpus - 1', with a minimum default
+      value of 1 and a maximum default value of 4.
     * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 1200000.
 * The `profiler` settings configure profiling:
     * `enabled`: if this is set to `true`, it enables profiling for the Puppet Ruby code. Defaults to `false`.

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -59,7 +59,7 @@ This file contains the settings for Puppet Server itself.
     * `gem-home`: This setting determines where JRuby looks for gems. It is also used by the `puppetserver gem` command line tool. If not specified, uses the Puppet default `/var/lib/puppet/jruby-gems`.
     * `master-conf-dir`: Optionally, set the path to the Puppet configuration directory. If not specified, uses the Puppet default `/etc/puppet`.
     * `master-var-dir`: Optionally, set the path to the Puppet variable directory. If not specified, uses the Puppet default `/var/lib/puppet`.
-    * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to roughly 'num-cpus - 1', with a minimum default
+    * `max-active-instances`: Optionally, set the maximum number of JRuby instances to allow. Defaults to 'num-cpus - 1', with a minimum default
       value of 1 and a maximum default value of 4.
     * `borrow-timeout`: Optionally, set the timeout when attempting to borrow an instance from the JRuby pool in milliseconds. Defaults to 1200000.
 * The `profiler` settings configure profiling:

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -10,7 +10,7 @@ jruby-puppet: {
     # (optional) path to puppet var dir; if not specified, will use the puppet default
     master-var-dir: /var/lib/puppet
 
-    # (optional) maximum number of JRuby instances to allow; defaults to <num-cpus>+2
+    # (optional) maximum number of JRuby instances to allow
     #max-active-instances: 1
 }
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -64,8 +64,7 @@
         if not specified, will use the puppet default.
 
     * :max-active-instances - The maximum number of JRubyPuppet instances that
-        will be pooled. If not specified, the system's
-        number of CPUs+2 will be used.
+        will be pooled.
 
     * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
         when https client requests are made.

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -4,7 +4,8 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-core :refer :all :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]))
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -82,9 +83,10 @@
           (borrow-from-pool-with-timeout pool 120))))))
 
 (deftest test-default-pool-size
-  (let [config jruby-testutils/default-config-no-size
-        profiler   jruby-testutils/default-profiler
-        pool       (create-pool-context config profiler)
-        pool-state @(:pool-state pool)]
-    (is (= (core/default-pool-size (ks/num-cpus)) (:size pool-state)))))
+  (logutils/with-test-logging
+    (let [config jruby-testutils/default-config-no-size
+          profiler jruby-testutils/default-profiler
+          pool (create-pool-context config profiler)
+          pool-state @(:pool-state pool)]
+      (is (= (core/default-pool-size (ks/num-cpus)) (:size pool-state))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -86,5 +86,5 @@
         profiler   jruby-testutils/default-profiler
         pool       (create-pool-context config profiler)
         pool-state @(:pool-state pool)]
-    (is (= core/default-pool-size (:size pool-state)))))
+    (is (= (core/default-pool-size (ks/num-cpus)) (:size pool-state)))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,0 +1,21 @@
+(ns puppetlabs.services.jruby.jruby-puppet-core-test
+  (:require [clojure.test :refer :all]
+            [schema.test :as schema-test]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(deftest default-num-cpus-test
+  (testing "1 jruby instance for a 1 or 2-core box"
+    (is (= 1 (jruby-core/default-pool-size 1)))
+    (is (= 1 (jruby-core/default-pool-size 2))))
+  (testing "2 jruby instances for a 3-core box"
+    (is (= 2 (jruby-core/default-pool-size 3))))
+  (testing "3 jruby instances for a 4-core box"
+    (is (= 3 (jruby-core/default-pool-size 4))))
+  (testing "4 jruby instances for anything above 5 cores"
+    (is (= 4 (jruby-core/default-pool-size 5)))
+    (is (= 4 (jruby-core/default-pool-size 8)))
+    (is (= 4 (jruby-core/default-pool-size 16)))
+    (is (= 4 (jruby-core/default-pool-size 32)))
+    (is (= 4 (jruby-core/default-pool-size 64)))))


### PR DESCRIPTION
There was a glaring flaw in the way that we had previously been
calculating a default value for the number of JRuby instances.
The formula was 'num-cpus + 2', which meant that on a really large
server with e.g. 32 cores, you'd get 34 JRuby instances.  That
many JRuby instances will require a very large heap size, but we
default to a 2G heap size, so users were hitting OutOfMemory errors.

This commit changes the formula.  We now use 'num-cpus - 1', with
a minimum value of 1 and a maximum value of 4.  We also log a
warning message if the user hasn't provided an explicit value for
this setting, and suggest that they do so.