### PR TITLE
(MAINT) Fix dujour issues

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -8,7 +8,7 @@ master: {
 
 product: {
     update-server-url: "http://localhost/"
-    name: {group-id: puppetlabs
+    name: {group-id: puppetlabs.dev
            artifact-id: puppet-server}
 }
 

--- a/ezbake/config/conf.d/global.conf
+++ b/ezbake/config/conf.d/global.conf
@@ -3,7 +3,3 @@ global: {
     # info, see http://logback.qos.ch/manual/configuration.html
     logging-config: /etc/puppetlabs/puppetserver/logback.xml
 }
-
-product: {
-    name: puppetserver
-}

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -78,7 +78,7 @@
        "Server Info:\n"
        "  Puppet Server version: " (version-check/get-version-string (:artifact-id product-name) (:group-id product-name)) "\n"
        "  Puppet version: " (:puppet-version (config/get-puppet-config jruby-service)) "\n"
-       "  Supported /puppet API versions: " puppet-API-versions
+       "  Supported /puppet API versions: " puppet-API-versions "\n"
        "  Supported /puppet-ca API versions: " puppet-ca-API-versions))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -69,14 +69,14 @@
     (route/not-found "Not Found")))
 
 (defn construct-404-error-message
-  [jruby-service]
+  [jruby-service product-name]
   (str "Error: Invalid URL - Puppet Server expects requests that conform to the "
        "/puppet and /puppet-ca APIs.\n\n"
        "Note that Puppet 3 agents aren't compatible with this version; if you're "
        "running Puppet 3, you must either upgrade your agents to match the server "
        "or point them to a server running Puppet 3.\n\n"
        "Server Info:\n"
-       "  Puppet Server version: " (version-check/get-version-string "puppet-server") "\n"
+       "  Puppet Server version: " (version-check/get-version-string (:artifact-id product-name) (:group-id product-name)) "\n"
        "  Puppet version: " (:puppet-version (config/get-puppet-config jruby-service)) "\n"
        "  Supported /puppet API versions: " puppet-API-versions
        "  Supported /puppet-ca API versions: " puppet-ca-API-versions))

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -23,9 +23,9 @@
          hostcrl           (get-in config [:puppet-server :hostcrl])
          settings          (ca/config->master-settings config)
          jruby-service     (tk-services/get-service this :JRubyPuppetService)
-         upgrade-error     (core/construct-404-error-message jruby-service)
-         product-name      (get-in config [:product :name])
-         update-server-url (get-in config [:product :update-server-url])]
+         product-name      (or (get-in config [:product :name]) {:group-id "puppetlabs" :artifact-id "puppet-server"})
+         upgrade-error     (core/construct-404-error-message jruby-service product-name)
+         update-server-url (or (get-in config [:product :update-server-url]) "http://updates.puppetlabs.com")]
 
      (version-check/check-for-updates! {:product-name product-name} update-server-url)
 

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -25,7 +25,7 @@
          jruby-service     (tk-services/get-service this :JRubyPuppetService)
          product-name      (or (get-in config [:product :name]) {:group-id "puppetlabs" :artifact-id "puppet-server"})
          upgrade-error     (core/construct-404-error-message jruby-service product-name)
-         update-server-url (or (get-in config [:product :update-server-url]) "http://updates.puppetlabs.com")]
+         update-server-url (get-in config [:product :update-server-url])]
 
      (version-check/check-for-updates! {:product-name product-name} update-server-url)
 


### PR DESCRIPTION
Fix an issue wherein the group-id "puppetlabs" was not being used,
which caused getting the version string for puppet-server to fail.
Make dujour configuration optional. Remove dujour configuration
from the default config file.