### PR TITLE
(SERVER-415) Update PUPPET_BUILD_VERSION for RE-4141

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -31,7 +31,7 @@ module PuppetServerExtensions
     # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "dc53fa36a1813454b9b55243a3f291dae122d614")
+                         "PUPPET_BUILD_VERSION", "890a4a29148a3ae2997cb1cf2cefd329e6badf3d")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
Without this patch we are not using a puppet-agent version in CI that contains the package provides improvements in RE-4141.  This is a problem because we need to run puppetserver through CI in combination with a puppet-agent that includes the RE-4141 improvements.

This patch addresses the problem by updating to puppet-agent build [890a4a2](http://builds.puppetlabs.lan/puppet-agent/890a4a29148a3ae2997cb1cf2cefd329e6badf3d/)
which includes these changes.

This commit also updates the submodule to the same commit of puppet included in the puppet-agent builds, which is the 4.0.0-rc1 tag in puppet.

See: [puppet.json](https://github.com/puppetlabs/puppet-agent/blob/890a4a29148a3ae2997cb1cf2cefd329e6badf3d/configs/components/puppet.json)
