### PR TITLE
Revert "(SERVER-415) Update PUPPET_BUILD_VERSION for RE-4141"

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -31,7 +31,7 @@ module PuppetServerExtensions
     # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "890a4a29148a3ae2997cb1cf2cefd329e6badf3d")
+                         "PUPPET_BUILD_VERSION", "dc53fa36a1813454b9b55243a3f291dae122d614")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
This reverts commit b6fee071fb46a10e9c570218fa4f48ac98809f8d.

This is being reverted because version identifiers are the worst thing
ever and quite possibly the most difficult problem in computer science.

    lein test :only puppetlabs.services.config.puppet-server-config-service-test/config-service-functions
    FAIL in (config-service-functions) (puppet_server_config_service_test.clj:57)
    Basic puppet-server config service function usage The config service has puppet's version available.
    expected: (valid-semver-number? (get-in-config service [:puppet-server :puppet-version]))
      actual: (not (valid-semver-number? "4.0.0-rc1"))