### PR TITLE
(SERVER-450) Add proper semver parsing to unit tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,8 +49,7 @@
                  [slingshot "0.10.3"]
                  [ring/ring-codec "1.0.0" :exclusions [commons-codec]]
                  [cheshire "5.3.1"]
-                 [trptcolin/versioneer "0.1.0"]
-                 [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]]
+                 [trptcolin/versioneer "0.1.0"]]
 
   :main puppetlabs.trapperkeeper.main
 
@@ -89,7 +88,8 @@
                                    [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
                                    [ring-basic-authentication "1.0.5"]
                                    [ring-mock "0.1.5"]
-                                   [spyscope "0.1.4" :exclusions [clj-time]]]
+                                   [spyscope "0.1.4" :exclusions [clj-time]]
+                                   [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]]
                    :injections    [(require 'spyscope.core)]
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}

--- a/project.clj
+++ b/project.clj
@@ -49,7 +49,8 @@
                  [slingshot "0.10.3"]
                  [ring/ring-codec "1.0.0" :exclusions [commons-codec]]
                  [cheshire "5.3.1"]
-                 [trptcolin/versioneer "0.1.0"]]
+                 [trptcolin/versioneer "0.1.0"]
+                 [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]]
 
   :main puppetlabs.trapperkeeper.main
 

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -12,7 +12,8 @@
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [clj-semver.core :as semver]))
 
 (def service-and-deps
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
@@ -28,8 +29,10 @@
       (assoc-in [:jruby-puppet :master-conf-dir]
                 (str test-resources-dir "/master/conf"))))
 
-(defn valid-semver-number? [v]
-  (re-matches #"[0-9]\.[0-9]\.[0-9]" v))
+(defn valid-semver-number? [s]
+  (if (try (semver/valid-format? s)
+           (catch IllegalArgumentException e))
+    true false))
 
 (deftest config-service-functions
   (tk-testutils/with-app-with-config


### PR DESCRIPTION
Without this patch the unit tests are not properly parsing semantic version
strings according to the specification.  This is a problem for RC versions of
dependencies with versions such as "4.0.0-rc1"  This patch addresses the
problem by using a third party library written by our very own Deepak designed
to parse and manipulate semantic version data.