### PR TITLE
Revert Revert (SERVER-415) Update PUPPET_BUILD_VERSION for RE-4141

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -31,7 +31,7 @@ module PuppetServerExtensions
     # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "dc53fa36a1813454b9b55243a3f291dae122d614")
+                         "PUPPET_BUILD_VERSION", "890a4a29148a3ae2997cb1cf2cefd329e6badf3d")
 
     @config = {
       :base_dir => base_dir,

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -3,18 +3,28 @@ require 'spec_helper'
 require 'puppet/server/master'
 require 'puppet/server/jvm_profiler'
 
-describe Puppet::Server::Master do
+describe 'Puppet::Server::Master' do
+  let :master do
+    Puppet::Server::Master.new({}, {})
+  end
+
   context "run mode" do
+    subject do
+      master.run_mode
+    end
+
     it "is set to 'master'" do
-      master = Puppet::Server::Master.new({}, {})
-      master.run_mode.should == 'master'
+      expect(subject).to eq('master')
     end
   end
 
   context "puppet version" do
+    subject do
+      master.puppetVersion
+    end
+
     it "returns the correct puppet version number" do
-      master = Puppet::Server::Master.new({}, {})
-      master.puppetVersion.should == '3.7.4'
+      expect(subject).to eq('4.0.0-rc1')
     end
   end
 


### PR DESCRIPTION
This reverts commit f8c7e2fc47ed52477493a37c9bdb49f556889fb0.

Now that we have the unit tests fixed up with improved semver checking behavior
we can re-update to a PUPPET_BUILD_VERSION that works with RE-4141 and Puppet
4.0.0-rc1