### PR TITLE
(SERVER-437) Upgrade to jvm-ssl-utils 0.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/certificate-authority "0.6.0"]
+                 [puppetlabs/ssl-utils "0.8.0"]
                  [puppetlabs/http-client "0.4.0"]
                  [org.jruby/jruby-core "1.7.19"
                   :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]

--- a/spec/puppet-server-lib/puppet/jvm/certificate_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/certificate_spec.rb
@@ -5,17 +5,17 @@ require 'puppet/ssl/base'
 require 'puppet/server/certificate'
 require 'rspec'
 
-java_import com.puppetlabs.certificate_authority.CertificateAuthority
+java_import com.puppetlabs.ssl_utils.SSLUtils
 java_import java.io.FileReader
 
 
 describe Puppet::Server::Certificate do
 
-  java_master_cert = CertificateAuthority.pem_to_cert(
+  java_master_cert = SSLUtils.pem_to_cert(
       FileReader.new("spec/fixtures/master-cert-with-dns-alts.pem"))
   master_certificate = Puppet::Server::Certificate.new(java_master_cert)
 
-  java_agent_cert = CertificateAuthority.pem_to_cert(
+  java_agent_cert = SSLUtils.pem_to_cert(
       FileReader.new("spec/fixtures/agent-cert-with-exts.pem"))
   agent_certificate = Puppet::Server::Certificate.new(java_agent_cert)
 

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -13,7 +13,7 @@
             [clj-time.coerce :as time-coerce]
             [slingshot.slingshot :as sling]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.certificate-authority.core :as utils]
+            [puppetlabs.ssl-utils.core :as utils]
             [clj-yaml.core :as yaml]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/puppetserver/ringutils.clj
+++ b/src/clj/puppetlabs/puppetserver/ringutils.clj
@@ -4,7 +4,7 @@
   (:require [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetserver.certificate-authority :as ca]
-            [puppetlabs.certificate-authority.core :as ca-utils]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -27,7 +27,7 @@
   [certificate]
   (-> certificate
       (ca/get-subject)
-      (ca-utils/x500-name->CN)))
+      (ssl-utils/x500-name->CN)))
 
 (defn log-access-denied
   [uri certificate]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.services.ca.certificate-authority-core
   (:import  [java.io InputStream])
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
-            [puppetlabs.certificate-authority.core :as ca-utils]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.puppetserver.liberator-utils :as utils]
             [slingshot.slingshot :as sling]

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -5,7 +5,7 @@
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.certificate-authority.core :as ssl]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [ring.middleware.params :as ring-params]
             [ring.util.codec :as ring-codec]
             [ring.util.response :as ring-response]
@@ -125,8 +125,8 @@
 (defn header-auth-info
   "Return a map with authentication info based on header content"
   [header-dn-name header-dn-val header-auth-val]
-  (if (ssl/valid-x500-name? header-dn-val)
-    {:client-cert-cn (ssl/x500-name->CN header-dn-val)
+  (if (ssl-utils/valid-x500-name? header-dn-val)
+    {:client-cert-cn (ssl-utils/x500-name->CN header-dn-val)
      :authenticated  (= "SUCCESS" header-auth-val)}
     (do
       (if-not (nil? header-dn-val)
@@ -157,7 +157,7 @@
   [pem]
   (with-open [reader (StringReader. pem)]
     (try
-      (ssl/pem->certs reader)
+      (ssl-utils/pem->certs reader)
       (catch Exception e
         (throw-bad-request!
           (str "Unable to parse "

--- a/src/ruby/puppet-server-lib/puppet/server/certificate.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/certificate.rb
@@ -4,8 +4,8 @@ require 'puppet/ssl/oids'
 require 'puppet/server'
 require 'java'
 
-java_import com.puppetlabs.certificate_authority.CertificateAuthority
-java_import com.puppetlabs.certificate_authority.ExtensionsUtils
+java_import com.puppetlabs.ssl_utils.SSLUtils
+java_import com.puppetlabs.ssl_utils.ExtensionsUtils
 java_import java.security.cert.X509Certificate
 
 class Puppet::Server::Certificate < Puppet::SSL::Certificate
@@ -34,7 +34,7 @@ class Puppet::Server::Certificate < Puppet::SSL::Certificate
   end
 
   def unmunged_name
-    CertificateAuthority.get_cn_from_x500_principal(@java_cert.getSubjectX500Principal)
+    SSLUtils.get_cn_from_x500_principal(@java_cert.getSubjectX500Principal)
   end
 
   def custom_extensions

--- a/src/ruby/puppet-server-lib/puppet/server/config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/config.rb
@@ -10,7 +10,7 @@ require 'puppet/server/execution'
 require 'puppet/server/environments/cached'
 
 require 'java'
-java_import com.puppetlabs.certificate_authority.CertificateAuthority
+java_import com.puppetlabs.ssl_utils.SSLUtils
 java_import java.io.FileReader
 
 class Puppet::Server::Config
@@ -22,7 +22,7 @@ class Puppet::Server::Config
       @profiler = Puppet::Server::JvmProfiler.new(puppet_server_config["profiler"])
       Puppet::Util::Profiler.add_profiler(@profiler)
     end
-    
+
     Puppet::Server::HttpClient.initialize_settings(puppet_server_config)
     Puppet::Network::HttpPool.http_client_class = Puppet::Server::HttpClient
 
@@ -39,7 +39,7 @@ class Puppet::Server::Config
     # Do this lazily due to startup-ordering issues - to give the CA
     # service time to create these files before they are referenced here.
     unless @ssl_context
-      @ssl_context = CertificateAuthority.pems_to_ssl_context(
+      @ssl_context = SSLUtils.pems_to_ssl_context(
           FileReader.new(Puppet[:hostcert]),
           FileReader.new(Puppet[:hostprivkey]),
           FileReader.new(Puppet[:localcacert]))

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -2,7 +2,7 @@
   (:import (java.io StringReader ByteArrayInputStream ByteArrayOutputStream))
   (:require [puppetlabs.puppetserver.certificate-authority :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.certificate-authority.core :as utils]
+            [puppetlabs.ssl-utils.core :as utils]
             [puppetlabs.services.ca.ca-testutils :as testutils]
             [puppetlabs.kitchensink.core :as ks]
             [slingshot.slingshot :as sling]

--- a/test/unit/puppetlabs/puppetserver/ringutils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ringutils_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.puppetserver.ringutils-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.ringutils :refer :all]
-            [puppetlabs.certificate-authority.core :as utils]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.test :as schema-test]))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -17,10 +17,10 @@
   (str test-resources-dir "/" pem-file-name))
 
 (def localhost-cert
-  (utils/pem->cert (test-pem-file "localhost-cert.pem")))
+  (ssl-utils/pem->cert (test-pem-file "localhost-cert.pem")))
 
 (def other-cert
-  (utils/pem->cert (test-pem-file "revoked-agent.pem")))
+  (ssl-utils/pem->cert (test-pem-file "revoked-agent.pem")))
 
 (def base-handler
   (fn [request]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -4,7 +4,7 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [me.raynes.fs :as fs]
-            [puppetlabs.certificate-authority.core :as utils]
+            [puppetlabs.ssl-utils.core :as utils]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.services.ca.ca-testutils :as testutils]

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.services.request-handler.request-handler-core-test
   (:import (java.io StringReader ByteArrayInputStream))
   (:require [puppetlabs.services.request-handler.request-handler-core :as core]
-            [puppetlabs.certificate-authority.core :as cert-utils]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.puppetserver.certificate-authority :as cert-authority]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [clojure.test :refer :all]
@@ -38,7 +38,7 @@
 (deftest get-cert-common-name-test
   (testing (str "expected common name can be extracted from the certificate on "
                 "a request")
-    (let [cert (cert-utils/pem->cert
+    (let [cert (ssl-utils/pem->cert
                  (str test-resources-dir "/localhost.pem"))]
       (is (= "localhost" (core/get-cert-common-name cert)))))
   (testing "nil returned for cn when certificate on request is nil"
@@ -178,7 +178,7 @@
           (is (nil? (get req :client-cert)))))
 
       (testing "cert and cn from header used and not from SSL cert when allow-header-cert-info true"
-        (let [cert (cert-utils/pem->cert
+        (let [cert (ssl-utils/pem->cert
                     (str test-resources-dir "/localhost.pem"))
               req (core/as-jruby-request
                    (puppet-server-config true)
@@ -193,7 +193,7 @@
                  (cert-authority/get-subject (get req :client-cert))))))
 
       (testing "cert and cn from ssl used when allow-header-cert-info false"
-        (let [cert (cert-utils/pem->cert
+        (let [cert (ssl-utils/pem->cert
                     (str test-resources-dir "/localhost.pem"))
               req (core/as-jruby-request
                    (puppet-server-config false)


### PR DESCRIPTION
This commit upgrades the jvm-certificate-authority dependency
to jvm-ssl-utils. Most/all changes are just renames.