### PR TITLE
(SERVER-438) Update version to 2.0.0-rc2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.0.1")
 (def tk-jetty-version "1.1.1")
 (def ks-version "1.0.0")
-(def ps-version "2.0.0-SNAPSHOT")
+(def ps-version "2.0.0-rc2")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
If this commit passes through CI then this change in will be tagged as
2.0.0-rc2

Note: It's not yet clear to me if this commit itself, or the merge commit that
brings it in should be tagged.  I'm thinking the merge commit, but I could see
us using the commit if there are specific tooling or processing that assumes
the version bump itself is the commit that is to be tagged.