### PR TITLE
(MAINT) Restore jira-ruby gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
+gem 'rake', :group => [:development, :test]
+gem 'jira-ruby', :group => :development
+
 group :test do
-  gem 'rake'
   gem 'rspec'
   gem 'beaker', '~>1.20.0'
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
@@ -9,3 +11,6 @@ group :test do
   end
 end
 
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end


### PR DESCRIPTION
The Gemfile on puppet-server's master branch has 'jira-ruby' as a
development gem.  This commit adds that gem for the stable branch as
well.

This commit also makes 'rake' a development and test gem and sources a
Gemfile local if one is defined for the user.  These changes were done
just to replicate the behavior we now have on the master branch.