### PR TITLE
(SERVER-454) Remove exception handler in config service test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -89,7 +89,7 @@
                                    [ring-basic-authentication "1.0.5"]
                                    [ring-mock "0.1.5"]
                                    [spyscope "0.1.4" :exclusions [clj-time]]
-                                   [grimradical/clj-semver "0.2.0" :exclusions [org.clojure/clojure]]]
+                                   [grimradical/clj-semver "0.3.0" :exclusions [org.clojure/clojure]]]
                    :injections    [(require 'spyscope.core)]
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -29,11 +29,6 @@
       (assoc-in [:jruby-puppet :master-conf-dir]
                 (str test-resources-dir "/master/conf"))))
 
-(defn valid-semver-number? [s]
-  (if (try (semver/valid-format? s)
-           (catch IllegalArgumentException e))
-    true false))
-
 (deftest config-service-functions
   (tk-testutils/with-app-with-config
     app
@@ -57,7 +52,7 @@
             (str "config not as expected: " service-config))
 
         (testing "The config service has puppet's version available."
-          (is (valid-semver-number?
+          (is (semver/valid-format?
                 (get-in-config service [:puppet-server :puppet-version]))))
 
         (testing "`get-in-config` functions"


### PR DESCRIPTION
Without this patch the config service test uses an exception hander to figure
out if a semver identifier is valid or not.  This is a problem because the
semver function may not have raised the exception being handled.  This patch
addresses the problem by updating the clj-semver library to 0.3.0 which
implements a semver check function that returns boolean true or false.