### PR TITLE
(MAINT) Bump lein-ezbake plugin dependency to 0.2.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -86,7 +86,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.5"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.6"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}


### PR DESCRIPTION
This commit bumps puppet-server's lein-ezbake plugin dependency to
0.2.6.