### PR TITLE
(SERVER-499) Get smoke tests passing for windows agents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rspec'
   # gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || '~> 2.2')
   # See: SERVER-435 for the reasoning behind this specific version
-  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || 'git://github.com/puppetlabs/beaker#7d0cccf22cc7289113de862fe4a4494872f574bb')
+  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || 'git://github.com/puppetlabs/beaker#beaker2.7.1')
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '~> 0.11'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  # gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || '~> 2.2')
-  # See: SERVER-435 for the reasoning behind this specific version
-  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || 'git://github.com/puppetlabs/beaker#beaker2.7.1')
+  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || '2.7.1')
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '~> 0.11'
   end

--- a/acceptance/config/nodes/redhat7-64m-windows2008r2-64a.yaml
+++ b/acceptance/config/nodes/redhat7-64m-windows2008r2-64a.yaml
@@ -1,0 +1,30 @@
+---
+HOSTS:
+  redhat7-64-1:
+    roles:
+    - agent
+    - master
+    hypervisor: vcloud
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+  windows2008r2-64-2:
+    roles:
+    - agent
+    hypervisor: vcloud
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    platform: windows-2008r2-64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
+++ b/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
@@ -1,5 +1,8 @@
 step "Setup Puppet Labs Release repositories." do
   hosts.each do |host|
-    install_puppetlabs_release_repo host
+    platform = host.platform
+    if not /windows/.match(platform)
+      install_puppetlabs_release_repo host
+    end
   end
 end

--- a/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
+++ b/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
@@ -1,8 +1,7 @@
-step "Setup Puppet Labs Release repositories." do
+confine :to, :platform => ['windows']
+
+step "Setup Puppet Labs Release repositories on windows nodes" do
   hosts.each do |host|
-    platform = host.platform
-    if not /windows/.match(platform)
-      install_puppetlabs_release_repo host
-    end
+    install_puppetlabs_release_repo host
   end
 end

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -14,7 +14,10 @@ puppet_build_version = test_config[:puppet_build_version]
 if puppet_build_version
   step "Setup Puppet Labs Dev Repositories." do
     hosts.each do |host|
-      install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version
+      platform = host.platform
+      if not /windows/.match(platform)
+        install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version
+      end
     end
   end
 end

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -12,10 +12,9 @@ end
 
 puppet_build_version = test_config[:puppet_build_version]
 if puppet_build_version
-  step "Setup Puppet Labs Dev Repositories." do
-    hosts.each do |host|
-      platform = host.platform
-      if not /windows/.match(platform)
+  confine_block :except, :platform => ['windows'] do
+    step "Setup Puppet Labs Dev Repositories." do
+      hosts.each do |host|
         install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version
       end
     end

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -1,3 +1,19 @@
+module CommandUtils
+  def ruby_command(host)
+    "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+  end
+  module_function :ruby_command
+
+  def gem_command(host)
+    if host['platform'] =~ /windows/
+      "env PATH=\"#{host['privatebindir']}:${PATH}\" cmd /c gem"
+    else
+      "env PATH=\"#{host['privatebindir']}:${PATH}\" gem"
+    end
+  end
+  module_function :gem_command
+end
+
 def install_puppet_from_msi( host, opts )
   if not link_exists?(opts[:url])
     raise "Puppet does not exist at #{opts[:url]}!"
@@ -12,6 +28,8 @@ def install_puppet_from_msi( host, opts )
   # make sure install is sane, beaker has already added puppet and ruby
   # to PATH in ~/.ssh/environment
   on host, puppet('--version')
+  ruby = CommandUtils.ruby_command(host)
+  on host, "#{ruby} --version"
 end
 
 step "Install MRI Puppet Agents."

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -1,8 +1,31 @@
+def install_puppet_from_msi( host, opts )
+  if not link_exists?(opts[:url])
+    raise "Puppet does not exist at #{opts[:url]}!"
+  end
+
+  # `start /w` blocks until installation is complete, but needs to be wrapped in `cmd.exe /c`
+  on host, "cmd.exe /c start /w msiexec /qn /i #{opts[:url]} /L*V C:\\\\Windows\\\\Temp\\\\Puppet-Install.log"
+
+  # make sure the background service isn't running while the test executes
+  on host, "net stop puppet"
+
+  # make sure install is sane, beaker has already added puppet and ruby
+  # to PATH in ~/.ssh/environment
+  on host, puppet('--version')
+end
+
 step "Install MRI Puppet Agents."
   hosts.each do |host|
+    platform = host.platform
+
     puppet_version = test_config[:puppet_version]
 
-    if puppet_version
+    if /windows/.match(platform)
+      arch = host[:ruby_arch] || 'x86'
+      base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{test_config[:puppet_build_version]}/artifacts/windows"
+      filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
+      install_puppet_from_msi(host, :url => "#{base_url}/#{filename}")
+    elsif puppet_version
       install_package host, 'puppet-agent'
     else
       puppet_version = test_config[:puppet_version]

--- a/acceptance/suites/tests/00_smoke/testtest.rb
+++ b/acceptance/suites/tests/00_smoke/testtest.rb
@@ -1,5 +1,5 @@
 test_name "Testing Master/Agent connection"
 
 with_puppet_running_on( master, {} ) do
-  on agents, "puppet agent --test --server #{master}"
+  on agents, puppet("agent --test --server #{master}")
 end


### PR DESCRIPTION
Without this set of patches windows agents error out in the pre-suite.  This is
a problem because we need to test windows2008r2-64a against redhat7 and
ubuntu1404.

These patches install the AIO agent onto windows hosts.  It's unclear if the
full acceptance suite passes, but I'd like to get this up for review.