### PR TITLE
(SERVER-377) gem doesn't work behind proxy

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,5 +1,48 @@
 #!/usr/bin/env bash
 
-"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+function parse_config_file() {
+    awk 'BEGIN{FS="="} /^[[:space:]]*'$1'/ {gsub(/ /, "",$2) ; print $2}' < "$(puppet config print confdir)/puppet.conf"
+}
+
+function parse_env() {
+    echo $http_proxy| awk "$1"
+}
+
+if [ -n "$http_proxy" ] ; then
+    HTTP_PROXY_HOST=$(parse_env 'BEGIN{FS=".*//(.+@)?"} {split($2,a,":"); print a[1]}')
+    HTTP_PROXY_PORT=$(parse_env 'BEGIN{FS=".*//(.+@)?"} {split($2,a,":"); print a[2]}')
+    HTTP_PROXY_USER=$(parse_env 'BEGIN{FS="//|@"} /@/ {split($2,a,":"); print a[1]}')
+    HTTP_PROXY_PASSWORD=$(parse_env 'BEGIN{FS="//|@"} /@/ {split($2,a,":"); print a[2]}')
+    SOURCE="http_proxy environment variable"
+else
+    HTTP_PROXY_HOST=$(parse_config_file http_proxy_host)
+    HTTP_PROXY_PORT=$(parse_config_file http_proxy_port)
+    HTTP_PROXY_USER=$(parse_config_file http_proxy_user)
+    HTTP_PROXY_PASSWORD=$(parse_config_file http_proxy_password)
+    SOURCE="$(puppet config print confdir)/puppet.conf"
+fi
+
+JVM_EXTRA=""
+if [ -n "$HTTP_PROXY_HOST" ] ; then
+    echo "Using proxy server specified in ${SOURCE}"
+    JVM_EXTRA+="-Dhttp.proxyHost=${HTTP_PROXY_HOST} "
+    JVM_EXTRA+="-Dhttps.proxyHost=${HTTP_PROXY_HOST} "
+
+    if [ -n "$HTTP_PROXY_PORT" ] ; then
+        JVM_EXTRA+="-Dhttp.proxyPort=${HTTP_PROXY_PORT} "
+        JVM_EXTRA+="-Dhttps.proxyPort=${HTTP_PROXY_PORT} "
+    fi
+
+    if [ -n "$HTTP_PROXY_USER" ] ; then
+        JVM_EXTRA+="-Dhttp.proxyUser=${HTTP_PROXY_USER} "
+    fi
+
+    if [ -n "$HTTP_PROXY_PASSWORD" ] ; then
+        JVM_EXTRA+="-Dhttp.proxyPassword=${HTTP_PROXY_PASSWORD} "
+    fi
+fi
+
+"${JAVA_BIN}" ${JVM_EXTRA} \
+    -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
+PATH=/opt/puppet/bin:$PATH
 
 function parse_config_file() {
-    awk 'BEGIN{FS="="} /^[[:space:]]*'$1'/ {gsub(/ /, "",$2) ; print $2}' < "$(puppet config print confdir)/puppet.conf"
+    VALUE=$(puppet config print --section user $1)
+    if [ "$VALUE" == "none" ] ; then
+        # remove any 'none' values
+        VALUE=""
+    fi
+    echo $VALUE
 }
 
 function parse_env() {
@@ -23,24 +29,19 @@ else
 fi
 
 JVM_EXTRA=""
-if [ -n "$HTTP_PROXY_HOST" ] ; then
+if [ -n "$HTTP_PROXY_USER" ] || [ "$HTTP_PROXY_PASSWORD" ] ; then
+    echo "This tool does not yet support proxies requiring authentication"
+    exit 1
+fi
+
+if [ -n "$HTTP_PROXY_HOST" ] && [ -n "$HTTP_PROXY_PORT" ] ; then
     echo "Using proxy server specified in ${SOURCE}"
     JVM_EXTRA+="-Dhttp.proxyHost=${HTTP_PROXY_HOST} "
     JVM_EXTRA+="-Dhttps.proxyHost=${HTTP_PROXY_HOST} "
-
-    if [ -n "$HTTP_PROXY_PORT" ] ; then
-        JVM_EXTRA+="-Dhttp.proxyPort=${HTTP_PROXY_PORT} "
-        JVM_EXTRA+="-Dhttps.proxyPort=${HTTP_PROXY_PORT} "
-    fi
-
-    if [ -n "$HTTP_PROXY_USER" ] ; then
-        JVM_EXTRA+="-Dhttp.proxyUser=${HTTP_PROXY_USER} "
-    fi
-
-    if [ -n "$HTTP_PROXY_PASSWORD" ] ; then
-        JVM_EXTRA+="-Dhttp.proxyPassword=${HTTP_PROXY_PASSWORD} "
-    fi
+    JVM_EXTRA+="-Dhttp.proxyPort=${HTTP_PROXY_PORT} "
+    JVM_EXTRA+="-Dhttps.proxyPort=${HTTP_PROXY_PORT} "
 fi
+
 
 "${JAVA_BIN}" ${JVM_EXTRA} \
     -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \


### PR DESCRIPTION
This is workaround for SERVER-377 (gem doesn't work behind proxy)

The PR checks for the presence of the `http_proxy` variable.  If set, it is split up into its component parts using `awk`  If no variable is found, we attempt to parse the `http_proxy_*` entries in the puppet.conf file.

Care has been taken to protect against:
* Only username being set (no password)
* No username or password (http_proxy)
* Don't attempt to use proxy if no proxy host is found
* Remove whitespace from entries parsed from puppet.conf
* Processing of commented out lines in puppet.conf
* Passwords cannot contain spaces as its too hard to tokenize

If after performing this parse, there is no value found for the proxy server host, the system will not attempt to use a proxy.  A message is printed indicating where the proxy was found (config file or variable) if the proxy is to be used.  The main method of debugging this script would be to put `set -x` at the top of it.

I was able to test the final version of the script which I've attached to SERVER-377 but I couldn't figure out how to compile this `.erb` file into the final script so have just copied in the tested code and created a PR from it.

