### PR TITLE
SERVER-377 support for (authenticated) proxies in puppetserver gem command

### DIFF
--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 PATH=/opt/puppet/bin:$PATH
 
 function parse_config_file() {
@@ -17,7 +16,9 @@ if [ ! -n "$http_proxy" ] ; then
     HTTP_PROXY_USER=$(parse_config_file http_proxy_user)
     HTTP_PROXY_PASSWORD=$(parse_config_file http_proxy_password)
     SOURCE="$(puppet config print confdir)/puppet.conf"
-    export http_proxy="http://${HTTP_PROXY_USER}:${HTTP_PROXY_PASSWORD}@${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT}"
+    if [ -n "$HTTP_PROXY_HOST" ] && [ -n "$HTTP_PROXY_PORT" ] ; then
+        export http_proxy="http://${HTTP_PROXY_USER}:${HTTP_PROXY_PASSWORD}@${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT}"
+    fi
 fi
 
 "${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \

--- a/resources/ext/cli/gem.erb
+++ b/resources/ext/cli/gem.erb
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+PATH=/opt/puppet/bin:$PATH
+
+function parse_config_file() {
+    VALUE=$(puppet config print --section user $1)
+    if [ "$VALUE" == "none" ] ; then
+        # remove any 'none' values
+        VALUE=""
+    fi
+    echo $VALUE
+}
+
+if [ ! -n "$http_proxy" ] ; then
+    HTTP_PROXY_HOST=$(parse_config_file http_proxy_host)
+    HTTP_PROXY_PORT=$(parse_config_file http_proxy_port)
+    HTTP_PROXY_USER=$(parse_config_file http_proxy_user)
+    HTTP_PROXY_PASSWORD=$(parse_config_file http_proxy_password)
+    SOURCE="$(puppet config print confdir)/puppet.conf"
+    export http_proxy="http://${HTTP_PROXY_USER}:${HTTP_PROXY_PASSWORD}@${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT}"
+fi
+
 "${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
     clojure.main -m puppetlabs.puppetserver.cli.gem \
     --config "${CONFIG}" -- "$@"

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -8,6 +8,8 @@
     (.setArgv (into-array String args))
     (.setEnvironment
       (hash-map
+        "http_proxy" (System/getenv "http_proxy")
+        "https_proxy" (System/getenv "https_proxy")
         "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
         "JARS_NO_REQUIRE" "true"))
     (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))


### PR DESCRIPTION
Support proxy access for the `puppetserver gem` command, including proxies requiring users to authenticate with username and password.

The PR works by building an `http_proxy` environment variable from the puppet config file if one isn't already exported from the bash instance we're running in.

The clojure code has been modified in `gem.clj` to pass the `http_proxy` variable to the underlying jruby environment which allows natural proxy support (including basic authentication)