### PR TITLE
adding acceptance test to check puppetserver service after reboot

### DIFF
--- a/acceptance/suites/tests/555-puppetserver-service/reboot.rb
+++ b/acceptance/suites/tests/555-puppetserver-service/reboot.rb
@@ -1,0 +1,63 @@
+if (options[:type] == 'pe') then
+  pssn='pe-puppetserver'
+else
+  pssn='puppetserver'
+end
+
+test_name "Validates the ability of the #{pssn} service to reliably start after a reboot."
+
+max=10
+sleeptime=40
+retryCounter=0
+step "\n-----------\nValidate #{pssn} is up and running, then reboot, repeat #{max} times\n-----------"
+
+for i in 1..max 
+  step "\n-----\nLoop #{i}\n-----"
+   
+  step "check uptime"
+  origUptime=on(master, "awk '{print $1}' /proc/uptime").stdout.chomp.to_i
+
+  step "reboot"
+  #rebooting with on(master,'reboot') causes an IOError: stream end.  This seems like a sane workaround.
+  #QENG-1914 for more...
+  system "ssh -i #{options[:keyfile]} -o StrictHostKeyChecking=no root@#{master.reachable_name} \'reboot\'"
+
+  step "sleeping for 15 seconds and waiting for reboot."
+  sleep 15
+
+  unless port_open_within?(master,22,120)
+    raise Beaker::DSL::FailTest, 'Could not SSH into puppet master within 2 minutes after reboot'
+  end
+
+  step "look at uptime"
+  secondUptime=on(master, "awk '{print $1}' /proc/uptime").stdout.chomp.to_i
+
+  step "Checking for uptime sanity"
+  assert_operator(origUptime, :>, secondUptime, "Expect original uptime #{secondUptime} to be greater than original uptime #{origUptime} ")
+  
+  step "sleeping for #{sleeptime} seconds and waiting for #{pssn} to start."
+  sleep sleeptime
+
+  step "Check to see that #{pssn} is up and running."
+  ec = on(master,"service #{pssn} status", :acceptable_exit_codes => 0..99).exit_code
+
+  retryCounter = 0
+  while (ec != 0 and retryCounter < 20) do
+    sleep 1
+    retryCounter += 1
+    ec = on(master,"service #{pssn} status", :acceptable_exit_codes => 0..99).exit_code
+  end
+
+  step "Post loop check"
+  on(master,"service #{pssn} status")
+
+  step "Modifing sleeptime"
+  puts "  sleeptime is currently #{sleeptime}  retryCounter is currently #{retryCounter}"
+  sleeptime = sleeptime + retryCounter
+  puts "  Now sleeptime is #{sleeptime}"
+
+end
+
+puts "We should modify sleeptime to #{sleeptime}"
+
+

--- a/acceptance/suites/tests/555-puppetserver-service/reboot.rb
+++ b/acceptance/suites/tests/555-puppetserver-service/reboot.rb
@@ -1,15 +1,18 @@
 if (options[:type] == 'pe') then
-  pssn='pe-puppetserver'
+  puppetserverServiceName='pe-puppetserver'
 else
-  pssn='puppetserver'
+  puppetserverServiceName='puppetserver'
 end
 
-test_name "Validates the ability of the #{pssn} service to reliably start after a reboot."
+test_name "Validates the ability of the #{puppetserverServiceName} service to reliably start after a reboot."
 
 max=3
 sleeptime=45
 retryCounter=0
-step "\n-----------\nValidate #{pssn} is up and running, then reboot, repeat #{max} times\n-----------"
+step "Ensure #{puppetserverServiceName} is enabled."
+on(master, "puppet resource service #{puppetserverServiceName} enable=true")
+
+step "\n-----------\nValidate #{puppetserverServiceName} is up and running, then reboot, repeat #{max} times\n-----------"
 
 for i in 1..max 
   step "\n-----\nLoop #{i}\n-----"
@@ -26,28 +29,28 @@ for i in 1..max
   sleep 15
 
   unless port_open_within?(master,22,120)
-    raise Beaker::DSL::FailTest, 'Could not SSH into puppet master within 2 minutes after reboot'
+    raise Beaker::DSL::FailTest, 'Port 22 did not open on the puppet master host within 2 minutes after reboot'
   end
 
   step "look at uptime to ensure that we actually rebooted"
   secondUptime=on(master, "awk '{print $1}' /proc/uptime").stdout.chomp.to_i
   assert_operator(origUptime, :>, secondUptime, "Expect original uptime #{secondUptime} to be greater than original uptime #{origUptime} ")
   
-  step "sleeping for #{sleeptime} seconds and waiting for #{pssn} to start."
+  step "sleeping for #{sleeptime} seconds and waiting for #{puppetserverServiceName} to start."
   sleep sleeptime
 
-  step "Check to see that #{pssn} is up and running."
-  ec = on(master,"service #{pssn} status", :acceptable_exit_codes => 0..99).exit_code
+  step "Check to see that #{puppetserverServiceName} is up and running."
+  ec = on(master,"service #{puppetserverServiceName} status", :acceptable_exit_codes => 0..99).exit_code
 
   retryCounter = 0
-  while (ec != 0 and retryCounter < 20) do
-    sleep 1
+  while (ec != 0 and retryCounter < 30) do
+    sleep 2
     retryCounter += 1
-    ec = on(master,"service #{pssn} status", :acceptable_exit_codes => 0..99).exit_code
+    ec = on(master,"service #{puppetserverServiceName} status", :acceptable_exit_codes => 0..99).exit_code
   end
 
   step "Post loop check"
-  on(master,"service #{pssn} status")
+  on(master,"service #{puppetserverServiceName} status")
 
 end
 

--- a/acceptance/suites/tests/555-puppetserver-service/reboot.rb
+++ b/acceptance/suites/tests/555-puppetserver-service/reboot.rb
@@ -8,7 +8,7 @@ test_name "Validates the ability of the #{puppetserverServiceName} service to re
 
 max=3
 sleeptime=45
-retryCounter=0
+
 step "Ensure #{puppetserverServiceName} is enabled."
 on(master, "puppet resource service #{puppetserverServiceName} enable=true")
 
@@ -44,7 +44,7 @@ for i in 1..max
 
   retryCounter = 0
   while (ec != 0 and retryCounter < 30) do
-    sleep 2
+    sleep 1
     retryCounter += 1
     ec = on(master,"service #{puppetserverServiceName} status", :acceptable_exit_codes => 0..99).exit_code
   end

--- a/acceptance/suites/tests/555-puppetserver-service/reboot.rb
+++ b/acceptance/suites/tests/555-puppetserver-service/reboot.rb
@@ -6,8 +6,8 @@ end
 
 test_name "Validates the ability of the #{pssn} service to reliably start after a reboot."
 
-max=10
-sleeptime=40
+max=3
+sleeptime=45
 retryCounter=0
 step "\n-----------\nValidate #{pssn} is up and running, then reboot, repeat #{max} times\n-----------"
 
@@ -29,10 +29,8 @@ for i in 1..max
     raise Beaker::DSL::FailTest, 'Could not SSH into puppet master within 2 minutes after reboot'
   end
 
-  step "look at uptime"
+  step "look at uptime to ensure that we actually rebooted"
   secondUptime=on(master, "awk '{print $1}' /proc/uptime").stdout.chomp.to_i
-
-  step "Checking for uptime sanity"
   assert_operator(origUptime, :>, secondUptime, "Expect original uptime #{secondUptime} to be greater than original uptime #{origUptime} ")
   
   step "sleeping for #{sleeptime} seconds and waiting for #{pssn} to start."
@@ -51,13 +49,7 @@ for i in 1..max
   step "Post loop check"
   on(master,"service #{pssn} status")
 
-  step "Modifing sleeptime"
-  puts "  sleeptime is currently #{sleeptime}  retryCounter is currently #{retryCounter}"
-  sleeptime = sleeptime + retryCounter
-  puts "  Now sleeptime is #{sleeptime}"
-
 end
 
-puts "We should modify sleeptime to #{sleeptime}"
 
 

--- a/acceptance/test_run_scripts/555-puppetserver-service/reboot-foss-rhel7.sh
+++ b/acceptance/test_run_scripts/555-puppetserver-service/reboot-foss-rhel7.sh
@@ -9,21 +9,17 @@ fi
 export PACKAGE_BUILD_VERSION=1.0.4.SNAPSHOT.2015.03.24T0146
 
 configYaml=acceptance/config/beaker/jenkins/redhat-7-x86_64-mdca.cfg
-helper=acceptance/lib/helper.rb
-options=acceptance/config/beaker/options.rb
 tests=acceptance/suites/tests/555-puppetserver-service/reboot.rb
 presuite=acceptance/suites/pre_suite/foss
-postsuite=acceptance/suites/post_suite
-BEAKER_TYPE=foss
 
 BEAKEROPTS="--debug \
 --keyfile ~/.ssh/id_rsa-acceptance \
---helper $helper \
+--helper acceptance/lib/helper.rb \
 --load-path ruby/puppet/acceptance/lib \
---options $options \
+--options acceptance/config/beaker/options.rb \
 --tests $tests \
---post-suite $postsuite \
---type $BEAKER_TYPE "
+--post-suite acceptance/suites/post_suite \
+--type foss "
 
 
 #########

--- a/acceptance/test_run_scripts/555-puppetserver-service/reboot-foss-rhel7.sh
+++ b/acceptance/test_run_scripts/555-puppetserver-service/reboot-foss-rhel7.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+SCRIPT_PATH=$(pwd)
+BASENAME_CMD="basename ${SCRIPT_PATH}"
+SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
+if [ $SCRIPT_BASE_PATH = "555-puppetserver-service" ]; then
+  cd ../../..
+fi
+
+export PACKAGE_BUILD_VERSION=1.0.4.SNAPSHOT.2015.03.24T0146
+
+configYaml=acceptance/config/beaker/jenkins/redhat-7-x86_64-mdca.cfg
+helper=acceptance/lib/helper.rb
+options=acceptance/config/beaker/options.rb
+tests=acceptance/suites/tests/555-puppetserver-service/reboot.rb
+presuite=acceptance/suites/pre_suite/foss
+postsuite=acceptance/suites/post_suite
+BEAKER_TYPE=foss
+
+BEAKEROPTS="--debug \
+--keyfile ~/.ssh/id_rsa-acceptance \
+--helper $helper \
+--load-path ruby/puppet/acceptance/lib \
+--options $options \
+--tests $tests \
+--post-suite $postsuite \
+--type $BEAKER_TYPE "
+
+
+#########
+mkBeakerHostConfig () {
+cp $configYaml existing
+
+perl -pi -e 's/hypervisor: vcloud\n/hypervisor: vcloud\n    ip:\n/mg' existing
+
+for i in ${ips[@]}
+do
+        echo inserting $i
+        perl -pi -e "\$a=1 if(!\$a && s/ip:\n/ip: $i\n/);" existing
+done
+}
+
+
+case "$1" in
+  "" )
+    beaker $BEAKEROPTS \
+    --hosts $configYaml \
+    --pre-suite $presuite \
+  ;;
+
+  --p* )
+    echo "$0 Preserving hosts and saving hostnames."
+    beaker $BEAKEROPTS \
+    --hosts $configYaml \
+    --pre-suite $presuite \
+    --preserve-hosts | \
+    tee .beakerlog.log
+
+    echo "$0 checking contents of .beakerlog.log"
+    for h in $(grep "Using available host" .beakerlog.log | grep -oE "[0-9a-z]{15}.delivery.puppetlabs.net" )
+      do
+      echo "\t$0 found host $h.  Storing in .beakerhosts"
+      echo $h >> .beakerhosts
+      done
+  ;;
+
+  --r*|--u* )
+    echo "$0 Looking for hosts to reuse in .beakerhosts"
+    # if .beakerhosts exists and has two entries we can proceed
+    ips=()
+    for h in $(cat .beakerhosts)
+      do
+      echo $h
+      ips+=( $h )
+      done
+    mkBeakerHostConfig ${ips[@]}
+    beaker $BEAKEROPTS \
+    --hosts existing \
+    --no-provision \
+    --preserve-hosts \
+  ;;
+
+  * )
+    echo "$1 is not a valid parameter"
+    echo "usage:"
+    echo "$0 \[--preserve|--useExisting\]"
+    echo "\t --p --preserve : Launches beaker with --preserve-hosts option set.  Stores resulting hosts for later use."
+    echo "\t --r --u --useExisting: looks for hosts in .beakerhosts: launches beaker with options to use existing hosts."
+  ;;
+
+esac
+

--- a/ext/beaker/acceptance-rhel7.sh
+++ b/ext/beaker/acceptance-rhel7.sh
@@ -20,7 +20,7 @@ export PACKAGE_BUILD_VERSION=1.0.8
 
 #TODO: read configYaml and tests in from the enviornment and perhaps command line
 #  and only assign defalut values that are very general 
-configYaml=acceptance/config/beaker/jenkins/redhat-7-x86_64-mdca.cfg
+configYaml=acceptance/config/beaker/jenkins/el-7-x86_64-mdca.cfg
 tests=acceptance/suites/tests/555-puppetserver-service/reboot.rb
 presuite=acceptance/suites/pre_suite/foss
 

--- a/ext/beaker/acceptance-rhel7.sh
+++ b/ext/beaker/acceptance-rhel7.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
-SCRIPT_PATH=$(pwd)
-BASENAME_CMD="basename ${SCRIPT_PATH}"
-SCRIPT_BASE_PATH=`eval ${BASENAME_CMD}`
-if [ $SCRIPT_BASE_PATH = "555-puppetserver-service" ]; then
-  cd ../../..
+#########
+# This script provides: 
+# -- an easy way to run the puppet-server acceptance tests on vmpooler host(s)
+# -- the ability to keep vmpooler(s) around and rerun arbitrary acceptance 
+#    tests on them to aid with acceptance test development.
+#########
+
+# Point the present working directory to the top of the repository 
+SCRIPT_BASE_PATH=$(eval basename $(pwd))
+if [ $SCRIPT_BASE_PATH = "beaker" ]; then
+  cd ../..
 fi
 
-export PACKAGE_BUILD_VERSION=1.0.4.SNAPSHOT.2015.03.24T0146
+#TODO: read PACKAGE_BUILD_VERSION from an external source and the enviornment
+#    so that we don't have a hard coded value here
+#    if you are manually updating this value you should be checking on
+#    http://builds.puppetlabs.lan/puppetserver
+export PACKAGE_BUILD_VERSION=1.0.8
 
+#TODO: read configYaml and tests in from the enviornment and perhaps command line
+#  and only assign defalut values that are very general 
 configYaml=acceptance/config/beaker/jenkins/redhat-7-x86_64-mdca.cfg
 tests=acceptance/suites/tests/555-puppetserver-service/reboot.rb
 presuite=acceptance/suites/pre_suite/foss
@@ -21,20 +33,27 @@ BEAKEROPTS="--debug \
 --post-suite acceptance/suites/post_suite \
 --type foss "
 
-
 #########
+# mkBeakerHostConfig copies and rewrites an existing beaker host config
+# so that it contains the ipaddresses or hostnames of existing and provisioned 
+# hosts.  
 mkBeakerHostConfig () {
 cp $configYaml existing
-
 perl -pi -e 's/hypervisor: vcloud\n/hypervisor: vcloud\n    ip:\n/mg' existing
-
 for i in ${ips[@]}
 do
         echo inserting $i
         perl -pi -e "\$a=1 if(!\$a && s/ip:\n/ip: $i\n/);" existing
 done
 }
+#########
 
+if [ ! -e "ruby/puppet/bin/puppet" ] 
+  then
+  git submodule init
+  git submodule sync
+  git submodule update
+fi
 
 case "$1" in
   "" )
@@ -45,6 +64,8 @@ case "$1" in
 
   --p* )
     echo "$0 Preserving hosts and saving hostnames."
+    # TODO: if .beakerhosts exists, we should kill the hosts inside, wipe 
+    #     existing, and continue.
     beaker $BEAKEROPTS \
     --hosts $configYaml \
     --pre-suite $presuite \
@@ -52,6 +73,7 @@ case "$1" in
     tee .beakerlog.log
 
     echo "$0 checking contents of .beakerlog.log"
+    # TODO: make this also work with ec2 hosts.
     for h in $(grep "Using available host" .beakerlog.log | grep -oE "[0-9a-z]{15}.delivery.puppetlabs.net" )
       do
       echo "\t$0 found host $h.  Storing in .beakerhosts"
@@ -61,7 +83,8 @@ case "$1" in
 
   --r*|--u* )
     echo "$0 Looking for hosts to reuse in .beakerhosts"
-    # if .beakerhosts exists and has two entries we can proceed
+    # TODO: if .beakerhosts exists, has the required number of entries,
+    #     and if each of the hosts are reachable, then we can proceed.
     ips=()
     for h in $(cat .beakerhosts)
       do


### PR DESCRIPTION
This adds an acceptance test that validates puppetserver is running after reboot, and a script to make launching an acceptance test easier.