### PR TITLE
(SERVER-513) Bump tk-jetty9 dependency to 1.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def tk-version "1.1.0")
-(def tk-jetty-version "1.2.0")
+(def tk-jetty-version "1.3.0")
 (def ks-version "1.0.0")
 (def ps-version "1.0.4-SNAPSHOT")
 


### PR DESCRIPTION
This commit bumps the tk-jetty9 dependency to 1.3.0.