### PR TITLE
(maint) Update to ezbake 0.3.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.0"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.1"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
Without this patch puppetserver depends on ezbake 0.3.0 which is a
problem because that version of ezbake does not build working packages
for debian flavor platforms.  This patch addresses the problem by
updating to ezbake 0.3.1 which includes support for AIO with debian7,
ubuntu1404, and ubuntu1204