### PR TITLE
(SERVER-518) Update group-id and artifact-id for version checks

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/puppet-server ps-version
+(defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
   :dependencies [[org.clojure/clojure "1.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
 
-             :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
+             :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :plugins [[puppetlabs/lein-ezbake "0.2.6"]]

--- a/src/clj/puppetlabs/services/version/version_check_core.clj
+++ b/src/clj/puppetlabs/services/version/version_check_core.clj
@@ -10,7 +10,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
 
-(def default-group-id "puppetlabs.packages")
+(def default-group-id "puppetlabs")
 (def default-update-server-url "http://updates.puppetlabs.com")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/unit/puppetlabs/services/version/version_check_core_test.clj
+++ b/test/unit/puppetlabs/services/version/version_check_core_test.clj
@@ -10,7 +10,7 @@
 
 (deftest test-get-coords
   (testing "group-id should use the default if not specified"
-    (is (= {:group-id    "puppetlabs.packages"
+    (is (= {:group-id    "puppetlabs"
             :artifact-id "foo"}
            (get-coords "foo"))))
   (testing "should use group-id if specified"


### PR DESCRIPTION
This commit removes the hyphen from "puppet-server" in the project.clj
defproject.  This is needed in order to preserve backward compatibility
with dujour checkins of Puppet Server, which used "puppetserver" as the
artifact-id.