### PR TITLE
(SERVER-499) Fix inverted confinement for 10_install_release_repos

### DIFF
--- a/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
+++ b/acceptance/suites/pre_suite/foss/10_install_release_repos.rb
@@ -1,6 +1,6 @@
-confine :to, :platform => ['windows']
+confine :except, :platform => ['windows']
 
-step "Setup Puppet Labs Release repositories on windows nodes" do
+step "Setup Puppet Labs Release repositories" do
   hosts.each do |host|
     install_puppetlabs_release_repo host
   end


### PR DESCRIPTION
Without this patch the confinement added in 2f8d33c is a problem because it
changed behavior to install the release repository only on windows, but the
desired behavior is to avoid this step on windows.

This patch addresses the problem by inverting the confinement.