### PR TITLE
(SERVER-520) Remove hyphen from puppet-server in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
     :password :env/nexus_jenkins_password
     :sign-releases false })
 
-(defproject puppetlabs/puppet-server ps-version
+(defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
@@ -94,7 +94,7 @@
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
 
-             :ezbake {:dependencies ^:replace [[puppetlabs/puppet-server ~ps-version]
+             :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :plugins [[puppetlabs/lein-ezbake "0.3.1"]]

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -23,7 +23,9 @@
          hostcrl           (get-in config [:puppet-server :hostcrl])
          settings          (ca/config->master-settings config)
          jruby-service     (tk-services/get-service this :JRubyPuppetService)
-         product-name      (or (get-in config [:product :name]) {:group-id "puppetlabs" :artifact-id "puppet-server"})
+         product-name      (or (get-in config [:product :name])
+                               {:group-id    "puppetlabs"
+                                :artifact-id "puppetserver"})
          upgrade-error     (core/construct-404-error-message jruby-service product-name)
          update-server-url (get-in config [:product :update-server-url])]
 


### PR DESCRIPTION
This commit removes the hyphen from "puppet-server" in the project.clj
defproject. This is needed in order to preserve backward compatibility
with dujour checkins of Puppet Server, which used "puppetserver" as the
artifact-id.