### PR TITLE
(SERVER-517) Raise Ruby errors from HTTP client

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
@@ -21,4 +21,19 @@ describe Puppet::Server::HttpClient do
       expect(request_options.get_connect_timeout_milliseconds).to equal(connect_timeout)
     end
   end
+
+  context "requests" do
+    it "throw Ruby SocketErrors instead of Java exceptions" do
+      client = Puppet::Server::HttpClient.new("localhost", 0, {})
+      [lambda { client.get('/', nil) },
+       lambda { client.post('/', nil, nil) }
+      ].each do |request_block|
+        expect(&request_block).to raise_error { |error|
+          expect(error).to be_a(SocketError)
+          expect(error).to be_a(Puppet::Server::HttpClientError)
+          expect(error.message).to eq('com.puppetlabs.http.client.HttpClientException: Error executing http request')
+        }
+      end
+    end
+  end
 end

--- a/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
@@ -4,35 +4,59 @@ require 'puppet/server/http_client'
 require 'java'
 java_import com.puppetlabs.http.client.SimpleRequestOptions
 
-describe Puppet::Server::HttpClient do
-  context "options" do
-    let(:connect_timeout) { 42 }
-    let(:idle_timeout) { 24 }
+describe 'Puppet::Server::HttpClient' do
+  let :client do
+    Puppet::Server::HttpClient.new("localhost", 0, {})
+  end
 
-    it "timeout settings are properly set" do
+  context "when settings are initialized with specific values" do
+    before :all do
+      @settings = Puppet::Server::HttpClient.settings
       Puppet::Server::HttpClient.initialize_settings(
-          {"http_connect_timeout_milliseconds" => connect_timeout,
-           "http_idle_timeout_milliseconds"  => idle_timeout})
+        {"http_connect_timeout_milliseconds" => 42,
+         "http_idle_timeout_milliseconds"  => 24})
+    end
 
-      client = Puppet::Server::HttpClient.new(nil, 0, {})
+    after :all do
+      Puppet::Server::HttpClient.initialize_settings(@settings)
+    end
+
+    subject do
       request_options = SimpleRequestOptions.new("http://i.love.ruby")
       client.send(:configure_timeouts, request_options)
-      expect(request_options.get_socket_timeout_milliseconds).to equal(idle_timeout)
-      expect(request_options.get_connect_timeout_milliseconds).to equal(connect_timeout)
+      request_options
+    end
+
+    it 'then get_socket_timeout_milliseconds is 24' do
+      expect(subject.get_socket_timeout_milliseconds).to eq(24)
+    end
+
+    it 'then get_connect_timeout_milliseconds is 42' do
+      expect(subject.get_connect_timeout_milliseconds).to eq(42)
     end
   end
 
-  context "requests" do
-    it "throw Ruby SocketErrors instead of Java exceptions" do
-      client = Puppet::Server::HttpClient.new("localhost", 0, {})
-      [lambda { client.get('/', nil) },
-       lambda { client.post('/', nil, nil) }
-      ].each do |request_block|
-        expect(&request_block).to raise_error { |error|
-          expect(error).to be_a(SocketError)
-          expect(error).to be_a(Puppet::Server::HttpClientError)
-          expect(error.message).to eq('com.puppetlabs.http.client.HttpClientException: Error executing http request')
-        }
+  context "when making a request that triggers a Java exception" do
+    let :requests do
+      {
+        get: lambda { client.get('/', nil) },
+        post: lambda { client.post('/', nil, nil) }
+      }
+    end
+
+    [:get, :post].each do |request|
+      describe "#{request} request" do
+        subject { requests[request].call }
+
+        it 'raises a SocketError' do
+          expect { subject }.to raise_error SocketError
+        end
+        it 'raises a Puppet::Server::HttpClientError' do
+          expect { subject }.to raise_error Puppet::Server::HttpClientError
+        end
+        it 'raises an Error with a specific message' do
+          expect { subject }.to raise_error "Error executing http request"
+        end
       end
     end
   end

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -9,6 +9,15 @@ SyncHttpClient = com.puppetlabs.http.client.Sync
 java_import com.puppetlabs.http.client.SimpleRequestOptions
 java_import com.puppetlabs.http.client.ResponseBodyType
 
+class Puppet::Server::HttpClientError < SocketError
+  attr_reader :cause
+
+  def initialize(message, cause = nil)
+    super(message)
+    @cause = cause
+  end
+end
+
 class Puppet::Server::HttpClient
 
   OPTION_DEFAULTS = {
@@ -50,8 +59,8 @@ class Puppet::Server::HttpClient
       end
 
       # http://en.wikipedia.org/wiki/Basic_access_authentication#Client_side
-      headers["Authorization"] =
-          "Basic #{Base64.strict_encode64 "#{credentials[:user]}:#{credentials[:password]}"}"
+      encoded = Base64.strict_encode64("#{credentials[:user]}:#{credentials[:password]}")
+      headers["Authorization"] = "Basic #{encoded}"
     end
 
     request_options = SimpleRequestOptions.new(build_url(url))
@@ -60,7 +69,7 @@ class Puppet::Server::HttpClient
     request_options.set_body(body)
     configure_timeouts(request_options)
     configure_ssl(request_options)
-    response = SyncHttpClient.post(request_options)
+    response = client_post(request_options)
     ruby_response(response)
   end
 
@@ -70,11 +79,23 @@ class Puppet::Server::HttpClient
     request_options.set_as(ResponseBodyType::TEXT)
     configure_timeouts(request_options)
     configure_ssl(request_options)
-    response = SyncHttpClient.get(request_options)
+    response = client_get(request_options)
     ruby_response(response)
   end
 
   private
+
+  def client_get(request_options)
+    SyncHttpClient.get(request_options)
+  rescue Java::ComPuppetlabsHttpClient::HttpClientException => e
+    raise Puppet::Server::HttpClientError.new(e.inspect, e)
+  end
+
+  def client_post(request_options)
+    SyncHttpClient.post(request_options)
+  rescue Java::ComPuppetlabsHttpClient::HttpClientException => e
+    raise Puppet::Server::HttpClientError.new(e.inspect, e)
+  end
 
   def configure_timeouts(request_options)
     settings = self.class.settings

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -88,13 +88,13 @@ class Puppet::Server::HttpClient
   def client_get(request_options)
     SyncHttpClient.get(request_options)
   rescue Java::ComPuppetlabsHttpClient::HttpClientException => e
-    raise Puppet::Server::HttpClientError.new(e.inspect, e)
+    raise Puppet::Server::HttpClientError.new(e.message, e)
   end
 
   def client_post(request_options)
     SyncHttpClient.post(request_options)
   rescue Java::ComPuppetlabsHttpClient::HttpClientException => e
-    raise Puppet::Server::HttpClientError.new(e.inspect, e)
+    raise Puppet::Server::HttpClientError.new(e.message, e)
   end
 
   def configure_timeouts(request_options)


### PR DESCRIPTION
This commit changes the HTTP client so it catches underlying Java
exceptions and raises them as a Ruby Puppet::Server::HttpClientError
instead.

This change allows consumers of the HTTP client to catch errors using
only MRI Ruby and not require the use of JRuby.