### PR TITLE
(MAINT) Bump version to 1.0.9-SNAPSHOT for next release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.0")
 (def tk-jetty-version "1.3.0")
 (def ks-version "1.0.0")
-(def ps-version "1.0.8")
+(def ps-version "1.0.9-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the puppetserver version in the project.clj file to
1.0.9-SNAPSHOT for the next release.