### PR TITLE
[Do not merge] (SERVER-506) Set repo-target to PC1 for 2.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.1"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.2"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}

--- a/project.clj
+++ b/project.clj
@@ -70,7 +70,8 @@
                        :group "puppet"
                        :start-timeout "120"
                        :build-type "foss"
-                       :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"}
+                       :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"
+                       :repo-target "PC1"}
                 :resources {:dir "tmp/ezbake-resources"}
                 :config-dir "ezbake/config"}
 


### PR DESCRIPTION
For the 2.0.0 release of puppetserver, it will be shipped to a repo
named PC1 alongside the new agent. This commit adds the repo-target
option to the ezbake config to ensure that it is shipped to the correct
repo.