### PR TITLE
(maint) Update acceptance helper for new beaker layout -- WAIT TO MERGE

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -1,5 +1,4 @@
 require 'beaker/dsl/install_utils'
-require 'beaker/dsl/ezbake_utils'
 
 module PuppetServerExtensions
 


### PR DESCRIPTION
Previously we were requiring 'beaker/dsl/ezbake_utils' directly, with a
reorganization of the beaker code projects should simply require
'beaker/dsl/install_utils' and all other dsl installation helpers
(including ezbake helpers) will get installed.