### PR TITLE
(SERVER-325) reorganize code for max requests

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -2,7 +2,7 @@
   (:import (org.jruby Main RubyInstanceConfig CompatVersion)
            (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (defn run!
   [config args]
@@ -18,7 +18,7 @@
                        (.put "JARS_NO_REQUIRE" "true"))
         jruby-home   (.getJRubyHome jruby-config)
         load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir)
+                          (cons jruby-internal/ruby-code-dir)
                           (cons (str jruby-home "/lib/ruby/1.9"))
                           (cons (str jruby-home "/lib/ruby/shared"))
                           (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -2,12 +2,12 @@
   (:import (org.jruby Main RubyInstanceConfig CompatVersion)
            (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (defn new-jruby-main
   [config]
   (let [load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir))
+                          (cons jruby-internal/ruby-code-dir))
         gem-home     (get-in config [:jruby-puppet :gem-home])
         jruby-config (new RubyInstanceConfig)
         env          (doto (HashMap. (.getEnvironment jruby-config))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.services.jruby.jruby-puppet-agents
-  (:import (clojure.lang IFn Agent)
+  (:import (clojure.lang IFn)
            (com.puppetlabs.puppetserver PuppetProfiler)
            (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill))
   (:require [schema.core :as schema]
@@ -8,28 +8,14 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Schemas
-
-(def JRubyPoolAgent
-  "An agent configured for use in managing JRuby pools"
-  (schema/both Agent
-               (schema/pred
-                 (fn [a]
-                   (let [state @a]
-                     (and
-                       (map? state)
-                       (ifn? (:shutdown-on-error state))))))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (schema/defn ^:always-validate
-  send-agent :- JRubyPoolAgent
+  send-agent :- jruby-schemas/JRubyPoolAgent
   "Utility function; given a JRubyPoolAgent, send the specified function.
   Ensures that the function call is wrapped in a `shutdown-on-error`."
-  [jruby-agent :- JRubyPoolAgent
+  [jruby-agent :- jruby-schemas/JRubyPoolAgent
    f :- IFn]
   (letfn [(agent-fn [agent-ctxt]
                     (let [shutdown-on-error (:shutdown-on-error agent-ctxt)]
@@ -113,23 +99,21 @@
 ;;; Public
 
 (schema/defn ^:always-validate
-  pool-agent :- JRubyPoolAgent
+  pool-agent :- jruby-schemas/JRubyPoolAgent
   "Given a shutdown-on-error function, create an agent suitable for use in managing
   JRuby pools."
-  [shutdown-on-error-fn :- IFn]
+  [shutdown-on-error-fn :- (schema/maybe (schema/pred ifn?))]
   (agent {:shutdown-on-error shutdown-on-error-fn}))
 
 (schema/defn ^:always-validate
-  send-prime-pool! :- JRubyPoolAgent
+  send-prime-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends a request to the agent to prime the pool using the given pool context."
-  [pool-context :- jruby-schemas/PoolContext
-   pool-agent :- JRubyPoolAgent]
-  (let [{:keys [pool-state config profiler]} pool-context]
+  [pool-context :- jruby-schemas/PoolContext]
+  (let [{:keys [pool-state pool-agent config profiler]} pool-context]
     (send-agent pool-agent #(prime-pool! pool-state config profiler))))
 
 (schema/defn ^:always-validate
-  send-flush-pool! :- JRubyPoolAgent
+  send-flush-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends requests to the agent to flush the existing pool and create a new one."
-  [pool-context :- jruby-schemas/PoolContext
-   pool-agent :- JRubyPoolAgent]
-  (send-agent pool-agent #(flush-pool! pool-context)))
+  [pool-context :- jruby-schemas/PoolContext]
+  (send-agent (:pool-agent pool-context) #(flush-pool! pool-context)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -83,7 +83,10 @@
     (doseq [i (range count)]
       (try
         (let [id        (inc i)
-              instance  (jruby-internal/borrow-from-pool (:pool old-pool))]
+              instance  (jruby-internal/borrow-from-pool!*
+                          jruby-internal/borrow-without-timeout-fn
+                          (:pool old-pool)
+                          pool-context)]
           (flush-instance! instance new-pool id config profiler)
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
                      id count))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -56,7 +56,7 @@
                        id count))))
       (catch Exception e
         (.clear pool)
-        (.put pool (PoisonPill. e))
+        (.putFirst pool (PoisonPill. e))
         (throw (IllegalStateException. "There was a problem adding a JRubyPuppet instance to the pool." e))))))
 
 (schema/defn ^:always-validate
@@ -91,7 +91,7 @@
                      id count)
           (catch Exception e
             (.clear new-pool)
-            (.put new-pool (PoisonPill. e))
+            (.putFirst new-pool (PoisonPill. e))
             (throw (IllegalStateException.
                      "There was a problem adding a JRubyPuppet instance to the pool."
                      e))))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -80,21 +80,21 @@
     (reset! pool-state new-pool-state)
     (log/info "Swapped JRuby pools, beginning cleanup of old pool.")
     (doseq [i (range count)]
-      (let [id (inc i)
-            instance (jruby-core/borrow-from-pool (:pool old-pool))]
-        (try
+      (try
+        (let [id (inc i)
+              instance (jruby-core/borrow-from-pool (:pool old-pool))]
           (.terminate (:scripting-container instance))
           (log/infof "Cleaned up old JRuby instance %s of %s, creating replacement."
                      id count)
           (jruby-core/create-pool-instance! new-pool id config profiler)
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
-                     id count)
-          (catch Exception e
-            (.clear new-pool)
-            (.putFirst new-pool (PoisonPill. e))
-            (throw (IllegalStateException.
-                     "There was a problem adding a JRubyPuppet instance to the pool."
-                     e))))))
+                     id count))
+        (catch Exception e
+          (.clear new-pool)
+          (.putFirst new-pool (PoisonPill. e))
+          (throw (IllegalStateException.
+                   "There was a problem adding a JRubyPuppet instance to the pool."
+                   e)))))
     (jruby-core/return-to-pool (RetryPoisonPill. (:pool old-pool)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -3,8 +3,10 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
-  (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents])
+  (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)
+           (com.puppetlabs.puppetserver PuppetProfiler)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
@@ -104,9 +106,12 @@
   create-pool-context :- jruby-schemas/PoolContext
   "Creates a new JRubyPuppet pool context with an empty pool. Once the JRubyPuppet
   pool object has been created, it will need to be filled using `prime-pool!`."
-  [config profiler]
+  [config :- jruby-schemas/JRubyPuppetConfig
+   profiler :- (schema/maybe PuppetProfiler)
+   agent-shutdown-fn :- (schema/maybe (schema/pred ifn?))]
   {:config     config
    :profiler   profiler
+   :pool-agent (jruby-agents/pool-agent agent-shutdown-fn)
    :pool-state (atom (jruby-internal/create-pool-from-config config))})
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -55,13 +55,13 @@
   get-pool-state :- jruby-schemas/PoolState
   "Gets the PoolState from the pool context."
   [context :- jruby-schemas/PoolContext]
-  @(:pool-state context))
+  (jruby-internal/get-pool-state context))
 
 (schema/defn ^:always-validate
   get-pool :- jruby-schemas/pool-queue-type
   "Gets the JRubyPuppet pool object from the pool context."
   [context :- jruby-schemas/PoolContext]
-  (:pool (get-pool-state context)))
+  (jruby-internal/get-pool context))
 
 (schema/defn ^:always-validate
   pool->vec :- [JRubyPuppetInstance]
@@ -139,8 +139,8 @@
   borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool :- jruby-schemas/pool-queue-type]
-  (jruby-internal/borrow-from-pool pool))
+  [pool-context :- jruby-schemas/PoolContext]
+  (jruby-internal/borrow-from-pool pool-context))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
@@ -150,10 +150,10 @@
   waiting for an instance to be free for the number of milliseconds given in
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (jruby-internal/borrow-from-pool-with-timeout pool timeout))
+  (jruby-internal/borrow-from-pool-with-timeout pool-context timeout))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -330,13 +330,24 @@
   [borrow-fn :- (schema/pred ifn?)
    pool :- pool-queue-type]
   (let [instance (borrow-fn pool)]
-    (when (instance? PoisonPill instance)
-      (.putFirst pool instance)
-      (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
-                                     (:err instance))))
-    (when (jruby-puppet-instance? instance)
-      (swap! (:state instance) (fn [m] (update-in m [:request-count] inc))))
-    instance))
+    (cond (instance? PoisonPill instance)
+          (do
+            (.putFirst pool instance)
+            (throw (IllegalStateException.
+                     "Unable to borrow JRuby instance from pool"
+                     (:err instance))))
+
+          (jruby-puppet-instance? instance)
+          (do
+            (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
+            instance)
+
+          ((some-fn nil? retry-poison-pill?) instance)
+          instance
+
+          :else
+          (throw (IllegalStateException.
+                   (str "Borrowed unrecognized object from pool!: " instance))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -233,7 +233,7 @@
                                                            JRubyPuppet)
                         :scripting-container  scripting-container
                         :environment-registry env-registry})]
-        (.put pool instance)
+        (.putLast pool instance)
         instance))))
 
 (schema/defn ^:always-validate
@@ -293,7 +293,7 @@
   Otherwise returns the instance that was passed in."
   [instance pool]
   (when (instance? PoisonPill instance)
-    (.put pool instance)
+    (.putFirst pool instance)
     (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
                                    (:err instance))))
   instance)
@@ -330,7 +330,7 @@
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool :- pool-queue-type]
-  (let [instance (.take pool)]
+  (let [instance (.takeFirst pool)]
     (validate-instance-from-pool! instance pool)))
 
 (schema/defn ^:always-validate
@@ -344,11 +344,11 @@
   [pool :- pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (let [instance (.poll pool timeout TimeUnit/MILLISECONDS)]
+  (let [instance (.pollFirst pool timeout TimeUnit/MILLISECONDS)]
     (validate-instance-from-pool! instance pool)))
 
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
   [instance :- JRubyPuppetInstanceOrRetry]
-  (.put (:pool instance) instance))
+  (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:import (java.util.concurrent ArrayBlockingQueue BlockingQueue TimeUnit)
+  (:import (java.util.concurrent LinkedBlockingDeque BlockingDeque TimeUnit)
            (java.util HashMap)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (org.jruby.embed ScriptingContainer LocalContextScope)
@@ -18,7 +18,7 @@
 (def pool-queue-type
   "The Java datastructure type used to store JRubyPuppet instances which are
   free to be borrowed."
-  BlockingQueue)
+  BlockingDeque)
 
 (def jruby-puppet-env
   "The environment variables that should be passed to the Puppet JRuby interpreters.
@@ -260,7 +260,7 @@
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
   {:post [(instance? pool-queue-type %)]}
-  (ArrayBlockingQueue. size))
+  (LinkedBlockingDeque. size))
 
 (defn verify-config-found!
   [config]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,16 +1,16 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:import (java.util.concurrent LinkedBlockingDeque BlockingDeque TimeUnit)
+  (:require [me.raynes.fs :as fs]
+            [schema.core :as schema]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [clojure.tools.logging :as log])
+  (:import (java.util.concurrent LinkedBlockingDeque TimeUnit BlockingDeque)
            (java.util HashMap)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (org.jruby.embed ScriptingContainer LocalContextScope)
-           (clojure.lang Atom)
-           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet
-                                        EnvironmentRegistry))
-  (:require [clojure.tools.logging :as log]
-            [me.raynes.fs :as fs]
-            [schema.core :as schema]
-            [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]))
+           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill JRubyPuppetInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Constants
@@ -33,11 +33,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
 
-(def pool-queue-type
-  "The Java datastructure type used to store JRubyPuppet instances which are
-  free to be borrowed."
-  BlockingDeque)
-
 (def jruby-puppet-env
   "The environment variables that should be passed to the Puppet JRuby interpreters.
   We don't want them to read any ruby environment variables, like $GEM_HOME or
@@ -49,132 +44,6 @@
   "The name of the directory containing the ruby code in this project.
   This directory lives under src/ruby/"
   "puppet-server-lib")
-
-(defrecord PoisonPill
-  ;; A sentinel object to put into a pool in case an error occurs while we're trying
-  ;; to populate it.  This can be used by the `borrow` functions to detect error
-  ;; state in a thread-safe manner.
-  [err])
-
-(defrecord RetryPoisonPill
-  ;; A sentinel object to put into an old pool when we swap in a new pool.
-  ;; This can be used to build `borrow` functionality that will detect the
-  ;; case where we're trying to borrow from an old pool, so that we can retry
-  ;; with the new pool.
-  [pool])
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Schemas
-
-(def JRubyPuppetConfig
-  "Schema defining the config map for the JRubyPuppet pooling functions.
-
-  The keys should have the following values:
-
-    * :ruby-load-path - a vector of file paths, containing the locations of puppet source code.
-
-    * :gem-home - The location that JRuby gems are stored
-
-    * :master-conf-dir - file path to puppetmaster's conf dir;
-        if not specified, will use the puppet default.
-
-    * :master-var-dir - path to the puppetmaster' var dir;
-        if not specified, will use the puppet default.
-
-    * :max-active-instances - The maximum number of JRubyPuppet instances that
-        will be pooled.
-
-    * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
-        when https client requests are made.
-
-    * :http-client-cipher-suites - A list of legal SSL cipher suites that may
-        be used when https client requests are made.
-
-    * :http-client-connect-timeout-milliseconds - The amount of time, in
-        milliseconds, that an outbound HTTP connection will wait to connect
-        before giving up. Defaults to 2 minutes if not set. If 0, the timeout is
-        infinite and if negative, the value is undefined in the application and
-        governed by the system default behavior.
-
-    * :http-client-idle-timeout-milliseconds - The amount of time, in
-        milliseconds, that an outbound HTTP connection will wait for data to be
-        available after a request is sent before closing the socket. Defaults to
-        2 minutes. If 0, the timeout is infinite and if negative, the value is
-        undefined by the application and is governed by the default system
-        behavior.
-
-    * :borrow-timeout - The timeout when borrowing instances from the JRuby Pool
-        in milliseconds. Defaults to 1200000."
-  {:ruby-load-path                                                 [schema/Str]
-   :gem-home                                                       schema/Str
-   (schema/optional-key :master-conf-dir)                          schema/Str
-   (schema/optional-key :master-var-dir)                           schema/Str
-   (schema/optional-key :max-active-instances)                     schema/Int
-   (schema/optional-key :http-client-ssl-protocols)                [schema/Str]
-   (schema/optional-key :http-client-cipher-suites)                [schema/Str]
-   (schema/optional-key :http-client-connect-timeout-milliseconds) schema/Int
-   (schema/optional-key :http-client-idle-timeout-milliseconds)    schema/Int
-   (schema/optional-key :borrow-timeout)                           schema/Int
-   :max-requests-per-instance   schema/Int})
-
-(def PoolState
-  "A map that describes all attributes of a particular JRubyPuppet pool."
-  {:pool         pool-queue-type
-   :size         schema/Int})
-
-(def PoolStateContainer
-  "An atom containing the current state of all of the JRubyPuppet pool."
-  (schema/pred #(and (instance? Atom %)
-                     (nil? (schema/check PoolState @%)))
-               'PoolStateContainer))
-
-(def PoolContext
-  "The data structure that stores all JRubyPuppet pools and the original configuration."
-  {:config     JRubyPuppetConfig
-   :profiler   (schema/maybe PuppetProfiler)
-   :pool-state PoolStateContainer})
-
-(def JRubyInstanceState
-  "State metadata for an individual JRubyPuppet instance"
-  {:request-count schema/Int})
-
-(def JRubyInstanceStateContainer
-  "An atom containing the current state of a given JRubyPuppet instance."
-  (schema/pred #(and (instance? Atom %)
-                     (nil? (schema/check JRubyInstanceState @%)))
-               'JRubyInstanceState))
-
-;; A record representing an individual entry in the JRubyPuppet pool.
-(schema/defrecord JRubyPuppetInstance
-  [pool :- pool-queue-type
-   id :- schema/Int
-   state :- JRubyInstanceStateContainer
-   jruby-puppet :- JRubyPuppet
-   scripting-container :- ScriptingContainer
-   environment-registry :- (schema/both
-                             EnvironmentRegistry
-                             (schema/pred
-                               #(satisfies? puppet-env/EnvironmentStateContainer %)))]
-  Object
-  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
-                           "puppetlabs.services.jruby.jruby_puppet_core.JRubyPuppetInstance"
-                           (Integer/toHexString (.hashCode this))
-                           id
-                           @state)))
-
-(defn jruby-puppet-instance?
-  [x]
-  (instance? JRubyPuppetInstance x))
-
-(defn retry-poison-pill?
-  [x]
-  (instance? RetryPoisonPill x))
-
-(def JRubyPuppetInstanceOrRetry
-  (schema/conditional
-    jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
-    retry-poison-pill? (schema/pred retry-poison-pill?)))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -226,9 +95,9 @@
 (schema/defn ^:always-validate
   create-pool-instance! :- JRubyPuppetInstance
   "Creates a new JRubyPuppet instance and adds it to the pool."
-  [pool     :- pool-queue-type
+  [pool     :- jruby-schemas/pool-queue-type
    id       :- schema/Int
-   config   :- JRubyPuppetConfig
+   config   :- jruby-schemas/JRubyPuppetConfig
    profiler :- (schema/maybe PuppetProfiler)]
   (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
                 http-client-ssl-protocols http-client-cipher-suites
@@ -258,7 +127,7 @@
       (.put puppet-server-config "http_idle_timeout_milliseconds"
             http-client-idle-timeout-milliseconds)
 
-      (let [instance (map->JRubyPuppetInstance
+      (let [instance (jruby-schemas/map->JRubyPuppetInstance
                        {:pool                 pool
                         :id                   id
                         :state                (atom {:request-count 0})
@@ -274,20 +143,20 @@
         instance))))
 
 (schema/defn ^:always-validate
-  get-pool-state :- PoolState
+  get-pool-state :- jruby-schemas/PoolState
   "Gets the PoolState from the pool context."
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   @(:pool-state context))
 
 (schema/defn ^:always-validate
-  get-pool :- pool-queue-type
+  get-pool :- jruby-schemas/pool-queue-type
   "Gets the JRubyPuppet pool object from the pool context."
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (:pool (get-pool-state context)))
 
 (schema/defn ^:always-validate
   pool->vec :- [JRubyPuppetInstance]
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (-> (get-pool context)
       .iterator
       iterator-seq
@@ -296,7 +165,7 @@
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
-  {:post [(instance? pool-queue-type %)]}
+  {:post [(instance? jruby-schemas/pool-queue-type %)]}
   (LinkedBlockingDeque. size))
 
 (defn verify-config-found!
@@ -307,9 +176,9 @@
                                            "you did not specify the --config option?")))))
 
 (schema/defn ^:always-validate
-  create-pool-from-config :- PoolState
+  create-pool-from-config :- jruby-schemas/PoolState
   "Create a new PoolData based on the config input."
-  [{size :max-active-instances} :- JRubyPuppetConfig]
+  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
   (let [size (if size
                size
                (let [default-size (default-pool-size (ks/num-cpus))]
@@ -322,13 +191,13 @@
     {:pool         (instantiate-free-pool size)
      :size         size}))
 
-(schema/defn borrow-from-pool!* :- (schema/maybe JRubyPuppetInstanceOrRetry)
+(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
   If successful, updates the state information and returns the JRuby instance.
   Returns nil if the borrow function returns nil; throws an exception if
   the borrow function's return value indicates an error condition."
   [borrow-fn :- (schema/pred ifn?)
-   pool :- pool-queue-type]
+   pool :- jruby-schemas/pool-queue-type]
   (let [instance (borrow-fn pool)]
     (cond (instance? PoisonPill instance)
           (do
@@ -337,12 +206,12 @@
                      "Unable to borrow JRuby instance from pool"
                      (:err instance))))
 
-          (jruby-puppet-instance? instance)
+          (jruby-schemas/jruby-puppet-instance? instance)
           (do
             (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
             instance)
 
-          ((some-fn nil? retry-poison-pill?) instance)
+          ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
           instance
 
           :else
@@ -353,7 +222,7 @@
 ;;; Public
 
 (schema/defn ^:always-validate
-  initialize-config :- JRubyPuppetConfig
+  initialize-config :- jruby-schemas/JRubyPuppetConfig
   [config :- {schema/Keyword schema/Any}]
   (-> (get-in config [:jruby-puppet])
       (assoc :ruby-load-path (get-in config [:os-settings :ruby-load-path]))
@@ -374,7 +243,7 @@
       (update-in [:max-requests-per-instance] #(or % 0))))
 
 (schema/defn ^:always-validate
-  create-pool-context :- PoolContext
+  create-pool-context :- jruby-schemas/PoolContext
   "Creates a new JRubyPuppet pool context with an empty pool. Once the JRubyPuppet
   pool object has been created, it will need to be filled using `prime-pool!`."
   [config profiler]
@@ -385,41 +254,41 @@
 (schema/defn ^:always-validate
   free-instance-count
   "Returns the number of JRubyPuppet instances available in the pool."
-  [pool :- pool-queue-type]
+  [pool :- jruby-schemas/pool-queue-type]
   {:post [(>= % 0)]}
   (.size pool))
 
 (schema/defn ^:always-validate
-  instance-state :- JRubyInstanceState
+  instance-state :- jruby-schemas/JRubyInstanceState
   "Get the state metadata for a JRubyPuppet instance."
-  [jruby-puppet :- (schema/pred jruby-puppet-instance?)]
+  [jruby-puppet :- (schema/pred jruby-schemas/jruby-puppet-instance?)]
   @(:state jruby-puppet))
 
 (schema/defn ^:always-validate
   mark-all-environments-expired!
-  [context :- PoolContext]
+  [context :- jruby-schemas/PoolContext]
   (doseq [jruby-instance (pool->vec context)]
     (-> jruby-instance
         :environment-registry
         puppet-env/mark-all-environments-expired!)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool :- JRubyPuppetInstanceOrRetry
+  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
-  [pool :- pool-queue-type]
+  [pool :- jruby-schemas/pool-queue-type]
   (let [borrow-fn #(.takeFirst %)]
     (borrow-from-pool!* borrow-fn pool)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool-with-timeout :- (schema/maybe JRubyPuppetInstanceOrRetry)
+  borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
   blocking timeout is provided. If an instance is available then it will be
   immediately returned to the caller, if not then this function will block
   waiting for an instance to be free for the number of milliseconds given in
   timeout. If the timeout runs out then nil will be returned, indicating that
   there were no instances available."
-  [pool :- pool-queue-type
+  [pool :- jruby-schemas/pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
   (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
@@ -428,5 +297,5 @@
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
-  [instance :- JRubyPuppetInstanceOrRetry]
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
   (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -115,16 +115,33 @@
    :profiler   (schema/maybe PuppetProfiler)
    :pool-state PoolStateContainer})
 
+(def JRubyInstanceState
+  "State metadata for an individual JRubyPuppet instance"
+  {:request-count schema/Int})
+
+(def JRubyInstanceStateContainer
+  "An atom containing the current state of a given JRubyPuppet instance."
+  (schema/pred #(and (instance? Atom %)
+                     (nil? (schema/check JRubyInstanceState @%)))
+               'JRubyInstanceState))
+
 ;; A record representing an individual entry in the JRubyPuppet pool.
 (schema/defrecord JRubyPuppetInstance
   [pool :- pool-queue-type
    id :- schema/Int
+   state :- JRubyInstanceStateContainer
    jruby-puppet :- JRubyPuppet
    scripting-container :- ScriptingContainer
    environment-registry :- (schema/both
                              EnvironmentRegistry
                              (schema/pred
-                               #(satisfies? puppet-env/EnvironmentStateContainer %)))])
+                               #(satisfies? puppet-env/EnvironmentStateContainer %)))]
+  Object
+  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
+                           "puppetlabs.services.jruby.jruby_puppet_core.JRubyPuppetInstance"
+                           (Integer/toHexString (.hashCode this))
+                           id
+                           @state)))
 
 (defn jruby-puppet-instance?
   [x]
@@ -225,6 +242,7 @@
       (let [instance (map->JRubyPuppetInstance
                        {:pool                 pool
                         :id                   id
+                        :state                (atom {:request-count 0})
                         :jruby-puppet         (.callMethod scripting-container
                                                            ruby-puppet-class
                                                            "new"
@@ -285,18 +303,21 @@
     {:pool         (instantiate-free-pool size)
      :size         size}))
 
-(schema/defn validate-instance-from-pool! :- (schema/maybe JRubyPuppetInstanceOrRetry)
-  "Validate an instance.  The main purpose of this function is to check for
-  a poison pill, which indicates that there was an error when initializing the
-  pool.  If the poison pill is found, returns it to the pool (so that it will
-  be available to other callers) and throws the poison pill's exception.
-  Otherwise returns the instance that was passed in."
-  [instance pool]
-  (when (instance? PoisonPill instance)
-    (.putFirst pool instance)
-    (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
-                                   (:err instance))))
-  instance)
+(schema/defn borrow-from-pool!* :- (schema/maybe JRubyPuppetInstanceOrRetry)
+  "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
+  If successful, updates the state information and returns the JRuby instance.
+  Returns nil if the borrow function returns nil; throws an exception if
+  the borrow function's return value indicates an error condition."
+  [borrow-fn :- (schema/pred ifn?)
+   pool :- pool-queue-type]
+  (let [instance (borrow-fn pool)]
+    (when (instance? PoisonPill instance)
+      (.putFirst pool instance)
+      (throw (IllegalStateException. "Unable to borrow JRuby instance from pool"
+                                     (:err instance))))
+    (when (jruby-puppet-instance? instance)
+      (swap! (:state instance) (fn [m] (update-in m [:request-count] inc))))
+    instance))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -318,6 +339,12 @@
   (.size pool))
 
 (schema/defn ^:always-validate
+  instance-state :- JRubyInstanceState
+  "Get the state metadata for a JRubyPuppet instance."
+  [jruby-puppet :- (schema/pred jruby-puppet-instance?)]
+  @(:state jruby-puppet))
+
+(schema/defn ^:always-validate
   mark-all-environments-expired!
   [context :- PoolContext]
   (doseq [jruby-instance (pool->vec context)]
@@ -330,8 +357,8 @@
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool :- pool-queue-type]
-  (let [instance (.takeFirst pool)]
-    (validate-instance-from-pool! instance pool)))
+  (let [borrow-fn #(.takeFirst %)]
+    (borrow-from-pool!* borrow-fn pool)))
 
 (schema/defn ^:always-validate
   borrow-from-pool-with-timeout :- (schema/maybe JRubyPuppetInstanceOrRetry)
@@ -344,8 +371,8 @@
   [pool :- pool-queue-type
    timeout :- schema/Int]
   {:pre  [(>= timeout 0)]}
-  (let [instance (.pollFirst pool timeout TimeUnit/MILLISECONDS)]
-    (validate-instance-from-pool! instance pool)))
+  (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
+    (borrow-from-pool!* borrow-fn pool)))
 
 (schema/defn ^:always-validate
   return-to-pool

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -1,0 +1,178 @@
+(ns puppetlabs.services.jruby.jruby-puppet-internal
+  (:require [schema.core :as schema]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [me.raynes.fs :as fs])
+  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+           (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
+           (java.util HashMap)
+           (org.jruby CompatVersion RubyInstanceConfig$CompileMode)
+           (org.jruby.embed ScriptingContainer LocalContextScope)
+           (java.util.concurrent LinkedBlockingDeque TimeUnit)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Definitions
+
+(def jruby-puppet-env
+  "The environment variables that should be passed to the Puppet JRuby interpreters.
+  We don't want them to read any ruby environment variables, like $GEM_HOME or
+  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
+  Puppet needs HOME and PATH for facter resolution, so leave those."
+  (select-keys (System/getenv) ["HOME" "PATH"]))
+
+(def ruby-code-dir
+  "The name of the directory containing the ruby code in this project.
+  This directory lives under src/ruby/"
+  "puppet-server-lib")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(defn instantiate-free-pool
+  "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
+  [size]
+  {:post [(instance? jruby-schemas/pool-queue-type %)]}
+  (LinkedBlockingDeque. size))
+
+(schema/defn ^:always-validate
+             create-pool-from-config :- jruby-schemas/PoolState
+  "Create a new PoolData based on the config input."
+  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
+  {:pool (instantiate-free-pool size)
+   :size size})
+
+(defn prep-scripting-container
+  [scripting-container ruby-load-path gem-home]
+  (doto scripting-container
+    (.setLoadPaths (cons ruby-code-dir
+                         (map fs/absolute-path ruby-load-path)))
+    (.setCompatVersion (CompatVersion/RUBY1_9))
+    (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
+    (.setEnvironment (merge {"GEM_HOME" gem-home
+                             "JARS_NO_REQUIRE" "true"}
+                            jruby-puppet-env))))
+
+(defn empty-scripting-container
+  "Creates a clean instance of `org.jruby.embed.ScriptingContainer` with no code loaded."
+  [ruby-load-path gem-home]
+  {:pre [(sequential? ruby-load-path)
+         (every? string? ruby-load-path)
+         (string? gem-home)]
+   :post [(instance? ScriptingContainer %)]}
+  (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
+      (prep-scripting-container ruby-load-path gem-home)))
+
+(defn create-scripting-container
+  "Creates an instance of `org.jruby.embed.ScriptingContainer` and loads up the
+  puppet and facter code inside it."
+  [ruby-load-path gem-home]
+  {:pre [(sequential? ruby-load-path)
+         (every? string? ruby-load-path)
+         (string? gem-home)]
+   :post [(instance? ScriptingContainer %)]}
+  ;; for information on other legal values for `LocalContextScope`, there
+  ;; is some documentation available in the JRuby source code; e.g.:
+  ;; https://github.com/jruby/jruby/blob/1.7.11/core/src/main/java/org/jruby/embed/LocalContextScope.java#L58
+  ;; I'm convinced that this is the safest and most reasonable value
+  ;; to use here, but we could potentially explore optimizations in the future.
+  (doto (empty-scripting-container ruby-load-path gem-home)
+    (.runScriptlet "require 'puppet/server/master'")))
+
+(schema/defn ^:always-validate
+  create-pool-instance! :- JRubyPuppetInstance
+  "Creates a new JRubyPuppet instance and adds it to the pool."
+  [pool     :- jruby-schemas/pool-queue-type
+   id       :- schema/Int
+   config   :- jruby-schemas/JRubyPuppetConfig
+   profiler :- (schema/maybe PuppetProfiler)]
+  (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
+                http-client-ssl-protocols http-client-cipher-suites]} config]
+    (when-not ruby-load-path
+      (throw (Exception.
+               "JRuby service missing config value 'ruby-load-path'")))
+    (let [scripting-container   (create-scripting-container ruby-load-path gem-home)
+          env-registry          (puppet-env/environment-registry)
+          ruby-puppet-class     (.runScriptlet scripting-container "Puppet::Server::Master")
+          puppet-config         (HashMap.)
+          puppet-server-config  (HashMap.)]
+      (when master-conf-dir
+        (.put puppet-config "confdir" (fs/absolute-path master-conf-dir)))
+      (when master-var-dir
+        (.put puppet-config "vardir" (fs/absolute-path master-var-dir)))
+
+      (when http-client-ssl-protocols
+        (.put puppet-server-config "ssl_protocols" (into-array String http-client-ssl-protocols)))
+      (when http-client-cipher-suites
+        (.put puppet-server-config "cipher_suites" (into-array String http-client-cipher-suites)))
+      (.put puppet-server-config "profiler" profiler)
+      (.put puppet-server-config "environment_registry" env-registry)
+
+      (let [instance (jruby-schemas/map->JRubyPuppetInstance
+                       {:pool                 pool
+                        :id                   id
+                        :state                (atom {:request-count 0})
+                        :jruby-puppet         (.callMethod scripting-container
+                                                           ruby-puppet-class
+                                                           "new"
+                                                           (into-array Object
+                                                                       [puppet-config puppet-server-config])
+                                                           JRubyPuppet)
+                        :scripting-container  scripting-container
+                        :environment-registry env-registry})]
+        (.putLast pool instance)
+        instance))))
+
+(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+  "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
+  If successful, updates the state information and returns the JRuby instance.
+  Returns nil if the borrow function returns nil; throws an exception if
+  the borrow function's return value indicates an error condition."
+  [borrow-fn :- (schema/pred ifn?)
+   pool :- jruby-schemas/pool-queue-type]
+  (let [instance (borrow-fn pool)]
+    (cond (instance? PoisonPill instance)
+          (do
+            (.putFirst pool instance)
+            (throw (IllegalStateException.
+                     "Unable to borrow JRuby instance from pool"
+                     (:err instance))))
+
+          (jruby-schemas/jruby-puppet-instance? instance)
+          (do
+            (swap! (:state instance) (fn [m] (update-in m [:request-count] inc)))
+            instance)
+
+          ((some-fn nil? jruby-schemas/retry-poison-pill?) instance)
+          instance
+
+          :else
+          (throw (IllegalStateException.
+                   (str "Borrowed unrecognized object from pool!: " instance))))))
+
+(schema/defn ^:always-validate
+  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
+  left in the pool then this function will block until there is one available."
+  [pool :- jruby-schemas/pool-queue-type]
+  (let [borrow-fn #(.takeFirst %)]
+    (borrow-from-pool!* borrow-fn pool)))
+
+(schema/defn ^:always-validate
+  borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+  "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
+  blocking timeout is provided. If an instance is available then it will be
+  immediately returned to the caller, if not then this function will block
+  waiting for an instance to be free for the number of milliseconds given in
+  timeout. If the timeout runs out then nil will be returned, indicating that
+  there were no instances available."
+  [pool :- jruby-schemas/pool-queue-type
+   timeout :- schema/Int]
+  {:pre  [(>= timeout 0)]}
+  (let [borrow-fn #(.pollFirst % timeout TimeUnit/MILLISECONDS)]
+    (borrow-from-pool!* borrow-fn pool)))
+
+(schema/defn ^:always-validate
+  return-to-pool
+  "Return a borrowed pool instance to its free pool."
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
+  (.putFirst (:pool instance) instance))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -123,6 +123,10 @@
   [x]
   (instance? JRubyPuppetInstance x))
 
+(defn poison-pill?
+  [x]
+  (instance? PoisonPill x))
+
 (defn retry-poison-pill?
   [x]
   (instance? RetryPoisonPill x))
@@ -131,4 +135,10 @@
   (schema/conditional
     jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
     retry-poison-pill? (schema/pred retry-poison-pill?)))
+
+(def JRubyPuppetBorrowResult
+  (schema/pred (some-fn nil?
+                        poison-pill?
+                        retry-poison-pill?
+                        jruby-puppet-instance?)))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -1,0 +1,123 @@
+(ns puppetlabs.services.jruby.jruby-puppet-schemas
+  (:require [schema.core :as schema]
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env])
+  (:import (java.util.concurrent BlockingDeque)
+           (clojure.lang Atom)
+           (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
+           (org.jruby.embed ScriptingContainer)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def pool-queue-type
+  "The Java datastructure type used to store JRubyPuppet instances which are
+  free to be borrowed."
+  BlockingDeque)
+
+(defrecord PoisonPill
+  ;; A sentinel object to put into a pool in case an error occurs while we're trying
+  ;; to populate it.  This can be used by the `borrow` functions to detect error
+  ;; state in a thread-safe manner.
+  [err])
+
+(defrecord RetryPoisonPill
+  ;; A sentinel object to put into an old pool when we swap in a new pool.
+  ;; This can be used to build `borrow` functionality that will detect the
+  ;; case where we're trying to borrow from an old pool, so that we can retry
+  ;; with the new pool.
+  [pool])
+
+(def JRubyPuppetConfig
+  "Schema defining the config map for the JRubyPuppet pooling functions.
+
+  The keys should have the following values:
+
+    * :ruby-load-path - a vector of file paths, containing the locations of puppet source code.
+
+    * :gem-home - The location that JRuby gems are stored
+
+    * :master-conf-dir - file path to puppetmaster's conf dir;
+        if not specified, will use the puppet default.
+
+    * :master-var-dir - path to the puppetmaster' var dir;
+        if not specified, will use the puppet default.
+
+    * :max-active-instances - The maximum number of JRubyPuppet instances that
+        will be pooled. If not specified, the system's
+        number of CPUs+2 will be used.
+
+    * :http-client-ssl-protocols - A list of legal SSL protocols that may be used
+        when https client requests are made.
+
+    * :http-client-cipher-suites - A list of legal SSL cipher suites that may
+        be used when https client requests are made."
+  {:ruby-load-path              (schema/both [schema/Str] (schema/pred vector?))
+   :gem-home                    schema/Str
+   :master-conf-dir             (schema/maybe schema/Str)
+   :master-var-dir              (schema/maybe schema/Str)
+   :http-client-ssl-protocols   [schema/Str]
+   :http-client-cipher-suites   [schema/Str]
+   :http-client-connect-timeout-milliseconds schema/Int
+   :http-client-idle-timeout-milliseconds    schema/Int
+   :borrow-timeout              schema/Int
+   :max-active-instances        schema/Int
+   :max-requests-per-instance   schema/Int})
+
+(def PoolState
+  "A map that describes all attributes of a particular JRubyPuppet pool."
+  {:pool         pool-queue-type
+   :size schema/Int})
+
+(def PoolStateContainer
+  "An atom containing the current state of all of the JRubyPuppet pool."
+  (schema/pred #(and (instance? Atom %)
+                     (nil? (schema/check PoolState @%)))
+               'PoolStateContainer))
+
+(def PoolContext
+  "The data structure that stores all JRubyPuppet pools and the original configuration."
+  {:config     JRubyPuppetConfig
+   :profiler   (schema/maybe PuppetProfiler)
+   :pool-state PoolStateContainer})
+
+(def JRubyInstanceState
+  "State metadata for an individual JRubyPuppet instance"
+  {:request-count schema/Int})
+
+(def JRubyInstanceStateContainer
+  "An atom containing the current state of a given JRubyPuppet instance."
+  (schema/pred #(and (instance? Atom %)
+                     (nil? (schema/check JRubyInstanceState @%)))
+               'JRubyInstanceState))
+
+;; A record representing an individual entry in the JRubyPuppet pool.
+(schema/defrecord JRubyPuppetInstance
+                  [pool :- pool-queue-type
+                   id :- schema/Int
+                   state :- JRubyInstanceStateContainer
+                   jruby-puppet :- JRubyPuppet
+                   scripting-container :- ScriptingContainer
+                   environment-registry :- (schema/both
+                                             EnvironmentRegistry
+                                             (schema/pred
+                                               #(satisfies? puppet-env/EnvironmentStateContainer %)))]
+                  Object
+                  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
+                                           "puppetlabs.services.jruby.jruby_puppet_core.JRubyPuppetInstance"
+                                           (Integer/toHexString (.hashCode this))
+                                           id
+                                           @state)))
+
+(defn jruby-puppet-instance?
+  [x]
+  (instance? JRubyPuppetInstance x))
+
+(defn retry-poison-pill?
+  [x]
+  (instance? RetryPoisonPill x))
+
+(def JRubyPuppetInstanceOrRetry
+  (schema/conditional
+    jruby-puppet-instance? (schema/pred jruby-puppet-instance?)
+    retry-poison-pill? (schema/pred retry-poison-pill?)))
+

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -35,10 +35,9 @@
 
   (borrow-instance
     [this]
-    (let [pool-context   (:pool-context (tk-services/service-context this))
-          pool           (core/get-pool pool-context)
+    (let [pool-context (:pool-context (tk-services/service-context this))
           borrow-timeout (:borrow-timeout (tk-services/service-context this))]
-      (core/borrow-from-pool-with-timeout pool borrow-timeout)))
+      (core/borrow-from-pool-with-timeout pool-context borrow-timeout)))
 
   (return-instance
     [this jruby-instance]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -5,7 +5,8 @@
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -80,7 +81,7 @@
      (if (nil? pool-instance#)
        (throw (IllegalStateException.
                 "Error: Attempt to borrow a JRuby instance from the pool timed out")))
-     (if (core/retry-poison-pill? pool-instance#)
+     (if (jruby-schemas/retry-poison-pill? pool-instance#)
        (do
          (jruby-core/return-to-pool pool-instance#)
          (recur (jruby/borrow-instance ~jruby-service)))

--- a/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_int_test.clj
@@ -1,6 +1,4 @@
 (ns puppetlabs.puppetserver.bootstrap-int-test
-  (:import (java.io IOException)
-           (org.apache.http ConnectionClosedException))
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -59,7 +59,7 @@
                          ssl-request-options)]
           (is (= 204 (:status response))))
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [new-pool (jruby-core/get-pool pool-context)]
           (is (every? true?
                       (jruby-testutils/reduce-over-jrubies!

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -48,11 +48,10 @@
        :jruby-puppet {:max-active-instances 4}}
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
-            pool-context (:pool-context context)
-            pool (jruby-core/get-pool pool-context)]
-        (jruby-testutils/reduce-over-jrubies! pool 4 #(format "InstanceID = %s" %))
+            pool-context (:pool-context context)]
+        (jruby-testutils/reduce-over-jrubies! pool-context 4 #(format "InstanceID = %s" %))
         (is (= #{0 1 2 3}
-               (-> (jruby-testutils/reduce-over-jrubies! pool 4 (constantly "InstanceID"))
+               (-> (jruby-testutils/reduce-over-jrubies! pool-context 4 (constantly "InstanceID"))
                    set)))
         (let [response (http-client/delete
                          "https://localhost:8140/puppet-admin-api/v1/jruby-pool"
@@ -60,10 +59,11 @@
           (is (= 204 (:status response))))
         ; wait until the flush is complete
         (await (:pool-agent pool-context))
-        (let [new-pool (jruby-core/get-pool pool-context)]
-          (is (every? true?
-                      (jruby-testutils/reduce-over-jrubies!
-                        new-pool
-                        4
-                        (constantly
-                          "begin; InstanceID; false; rescue NameError; true; end")))))))))
+        (is (every? true?
+                    (jruby-testutils/reduce-over-jrubies!
+                      pool-context
+                      4
+                      (constantly
+                        "begin; InstanceID; false; rescue NameError; true; end"))))))))
+
+;; TODO: test flush instance while pool flush is in progress

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -7,7 +7,8 @@
             [cheshire.core :as json]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/puppet_environments_int_test")
@@ -24,6 +25,8 @@
 
 (def localhost-key
   (bootstrap/pem-file "private_keys" "localhost.pem"))
+
+(def num-jrubies 2)
 
 (defn write-site-pp-file
   [site-pp-contents]
@@ -61,7 +64,7 @@
       service-id))
 
 (defn wait-for-jrubies
-  [app num-jrubies]
+  [app]
   (let [pool-context (-> (service-context app :JRubyPuppetService)
                          :pool-context)]
     (while (< (count (jruby-core/pool->vec pool-context))
@@ -69,12 +72,48 @@
       (Thread/sleep 100))))
 
 (defn get-catalog
+  "Make an HTTP request to get a catalog."
   []
   (-> (http-client/get
         "https://localhost:8140/production/catalog/localhost"
         catalog-request-options)
       :body
       json/parse-string))
+
+(defn get-catalog-and-borrow-jruby
+  "Gets a catalog, and then borrows a JRuby instance from a pool to ensure that
+  a subsequent catalog request will be directed to a different JRuby.  Returns a
+  map containing both the catalog and the JRuby instance.  This function
+  relies on the fact that we are using a LIFO algorithm for allocating JRuby
+  instances to handle requests."
+  [borrow-jruby-fn]
+  (let [catalog (get-catalog)
+        jruby   (borrow-jruby-fn)]
+    {:catalog catalog
+     :jruby   jruby}))
+
+(defn get-catalog-and-return-jruby
+  "Given a map containing a catalog and a JRuby instance, return the JRuby
+  instance to the pool and return the catalog."
+  [return-jruby-fn m]
+  (return-jruby-fn (:jruby m))
+  (:catalog m))
+
+(defn get-catalog-from-each-jruby
+  "Iterates through all of the JRuby instances and gets a catalog from each of
+  them.  Returns the sequence of catalogs."
+  [borrow-jruby-fn return-jruby-fn]
+  ;; iterate over all of the jrubies and call get-catalog-and-borrow-jruby.  It's
+  ;; important that this is not done lazily, otherwise the jrubies could be returned
+  ;; to the pool before the next borrow occurs.
+  (let [jrubies-and-catalogs (doall
+                               (repeatedly
+                                 num-jrubies
+                                (partial get-catalog-and-borrow-jruby borrow-jruby-fn)))]
+    ;; now we can return the jrubies to the pool, and return the seq of catalogs
+    ;; to our caller
+    (map (partial get-catalog-and-return-jruby return-jruby-fn)
+         jrubies-and-catalogs)))
 
 (defn resource-matches?
   [resource-type resource-title resource]
@@ -85,6 +124,10 @@
   [catalog resource-type resource-title]
   (let [resources (get-in catalog ["data" "resources"])]
     (some (partial resource-matches? resource-type resource-title) resources)))
+
+(defn num-catalogs-containing
+  [catalogs resource-type resource-title]
+  (count (filter #(catalog-contains? % resource-type resource-title) catalogs)))
 
 ;; This test is written in a way that relies on knowledge about
 ;; the underlying implementation of the JRuby pool. That is admittedly
@@ -110,46 +153,43 @@
     ;; two of them so that we can illustrate that the cache can
     ;; be out of sync between the two of them.
     (bootstrap/with-puppetserver-running app {:jruby-puppet
-                                               {:max-active-instances 2}}
-      ;; if we start making requests before we know that all of the
-      ;; jruby instances are ready, we won't be able to predict which
-      ;; instance is handling our request, so we need to wait for them.
-      (wait-for-jrubies app 2)
-      ;; Now we grab a catalog from the first jruby instance.  This
-      ;; catalog should contain the 'hello1' notify, and will cause
-      ;; the first jruby instance to cache the manifests.
-      (let [catalog1 (get-catalog)]
-        (is (catalog-contains? catalog1 "Notify" "hello1"))
-        (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
-      ;; Now we modify the class definition to have a 'hello2' notify,
-      ;; instead of 'hello1'.
-      (write-foo-pp-file "class foo { notify {'hello2': } }")
-      ;; Retrieving the catalog a second time will route us to the
-      ;; second jruby instance, which hasn't cached the manifest yet,
-      ;; so we should get 'hello2'.
-      (let [catalog2 (get-catalog)]
-        (is (not (catalog-contains? catalog2 "Notify" "hello1")))
-        (is (catalog-contains? catalog2 "Notify" "hello2")))
-      ;; The next catalog request goes back to the first jruby instance,
-      ;; which still has 'hello1' cached.
-      (let [catalog1 (get-catalog)]
-        (is (catalog-contains? catalog1 "Notify" "hello1"))
-        (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
-      ;; Now, make a DELETE request to the /environment-cache endpoint.
-      ;; This flushes Puppet's cache for all environments.
-      (let [response (http-client/delete
-                       "https://localhost:8140/puppet-admin-api/v1/environment-cache"
-                       ssl-request-options)]
-        (testing "A successful DELETE request to /environment-cache returns an HTTP 204"
-          (is (= 204 (:status response))
-              (ks/pprint-to-string response))))
-      ;; Next catalog request goes to the second jruby instance,
-      ;; where we should see 'hello2' regardless of caching.
-      (let [catalog2 (get-catalog)]
-        (is (not (catalog-contains? catalog2 "Notify" "hello1")))
-        (is (catalog-contains? catalog2 "Notify" "hello2")))
-      ;; And the final catalog request goes back to the first jruby instance,
-      ;; where we expect the cache to have been cleared so that we will get 'hello2'.
-      (let [catalog1 (get-catalog)]
-        (is (not (catalog-contains? catalog1 "Notify" "hello1")))
-        (is (catalog-contains? catalog1 "Notify" "hello2"))))))
+                                              {:max-active-instances num-jrubies}}
+      (let [jruby-service   (tk-app/get-service app :JRubyPuppetService)
+            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service)
+            return-jruby-fn (partial jruby-protocol/return-instance jruby-service)]
+        ;; wait for all of the jrubies to be ready so that we can
+        ;; validate cache state differences between them.
+        (wait-for-jrubies app)
+
+        ;;; Now we grab a catalog from the first jruby instance.  This
+        ;;; catalog should contain the 'hello1' notify, and will cause
+        ;;; the first jruby instance to cache the manifests.
+        (let [catalog1 (get-catalog)]
+          (is (catalog-contains? catalog1 "Notify" "hello1"))
+          (is (not (catalog-contains? catalog1 "Notify" "hello2"))))
+
+        ;; Now we modify the class definition to have a 'hello2' notify,
+        ;; instead of 'hello1'.
+        (write-foo-pp-file "class foo { notify {'hello2': } }")
+
+        ;; Now we grab a catalog from both of the jrubies.  One should have the
+        ;; old, cached state, and one should have the new state.
+        (let [catalogs (get-catalog-from-each-jruby borrow-jruby-fn return-jruby-fn)]
+          (is (= 1 (num-catalogs-containing catalogs "Notify" "hello1")))
+          (is (= 1 (num-catalogs-containing catalogs "Notify" "hello2"))))
+
+        ;; Now, make a DELETE request to the /environment-cache endpoint.
+        ;; This flushes Puppet's cache for all environments.
+        (let [response (http-client/delete
+                         "https://localhost:8140/puppet-admin-api/v1/environment-cache"
+                         ssl-request-options)]
+          (testing "A successful DELETE request to /environment-cache returns an HTTP 204"
+            (is (= 204 (:status response))
+                (ks/pprint-to-string response))))
+
+        ;; Now if we get catalogs from both of the JRubies again, we should get
+        ;; the 'hello2' catalog from both, since the cache should have been
+        ;; cleared.
+        (let [catalogs (get-catalog-from-each-jruby borrow-jruby-fn return-jruby-fn)]
+          (is (= 0 (num-catalogs-containing catalogs "Notify" "hello1")))
+          (is (= 2 (num-catalogs-containing catalogs "Notify" "hello2"))))))))

--- a/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
+++ b/test/unit/puppetlabs/puppetserver/ruby/http_client_test.clj
@@ -9,9 +9,9 @@
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
             [puppetlabs.trapperkeeper.testutils.webserver.common :refer [http-get]]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [ring.middleware.basic-authentication :as auth]))
+            [ring.middleware.basic-authentication :as auth]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 ;; NOTE: this namespace is pretty disgusting.  It'd be much nicer to test this
 ;; ruby code via ruby spec tests, but since we need to stand up a webserver to
@@ -56,7 +56,7 @@
                                 (select-keys options [:ssl-protocols :cipher-suites]))
          sc                   (ScriptingContainer. LocalContextScope/SINGLETHREAD
                                                    LocalVariableBehavior/PERSISTENT)]
-     (jruby-puppet/prep-scripting-container sc
+     (jruby-internal/prep-scripting-container sc
                                             jruby-testutils/ruby-load-path
                                             jruby-testutils/gem-home)
      (.runScriptlet sc "require 'puppet/server/http_client'")

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -4,15 +4,14 @@
             [puppetlabs.services.config.puppet-server-config-service :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-puppet-core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-testutils]
             [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (def service-and-deps
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
@@ -86,7 +85,7 @@
              "Providing config values that should be read from Puppet results "
              "in an error that mentions all offending config keys.")
     (with-redefs
-      [jruby-puppet-core/create-pool-instance!
+      [jruby-internal/create-pool-instance!
          jruby-testutils/create-mock-pool-instance]
       (with-test-logging
         (is (thrown-with-msg?

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -3,10 +3,9 @@
             [puppetlabs.services.jruby.jruby-testutils :as testutils]
             [puppetlabs.kitchensink.core :as ks]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.jruby-puppet-core :refer :all
-             :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (use-fixtures :once
               (jruby-testutils/with-puppet-conf
@@ -20,8 +19,8 @@
                                           :master-conf-dir testutils/conf-dir
                                           :master-var-dir  testutils/var-dir}
                            :os-settings  {:ruby-load-path testutils/ruby-load-path}})
-          pool          (instantiate-free-pool 1)
-          pool-instance (create-pool-instance! pool 1 config testutils/default-profiler)
+          pool          (jruby-internal/instantiate-free-pool 1)
+          pool-instance (jruby-internal/create-pool-instance! pool 1 config testutils/default-profiler)
           jruby-puppet  (:jruby-puppet pool-instance)
           var-dir       (.getSetting jruby-puppet "vardir")]
       (is (not (nil? var-dir)))))
@@ -45,7 +44,7 @@
 
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
-    (let [jruby-interpreter (create-scripting-container
+    (let [jruby-interpreter (jruby-internal/create-scripting-container
                               jruby-testutils/ruby-load-path
                               jruby-testutils/gem-home)
           jruby-env (.runScriptlet jruby-interpreter "ENV")]

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -5,7 +5,8 @@
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-puppet-core :refer :all
              :as core]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (use-fixtures :once
               (jruby-testutils/with-puppet-conf
@@ -14,9 +15,11 @@
 (deftest create-jruby-instance-test
 
   (testing "Var dir is not required."
-    (let [config        {:ruby-load-path  testutils/ruby-load-path
-                         :gem-home        testutils/gem-home
-                         :master-conf-dir testutils/conf-dir}
+    (let [config        (jruby-core/initialize-config
+                          {:jruby-puppet {:gem-home        testutils/gem-home
+                                          :master-conf-dir testutils/conf-dir
+                                          :master-var-dir  testutils/var-dir}
+                           :os-settings  {:ruby-load-path testutils/ruby-load-path}})
           pool          (instantiate-free-pool 1)
           pool-instance (create-pool-instance! pool 1 config testutils/default-profiler)
           jruby-puppet  (:jruby-puppet pool-instance)

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -18,8 +18,8 @@
   (testing "malformed configuration fails"
     (let [malformed-config {:illegal-key [1 2 3]}]
       (is (thrown-with-msg? ExceptionInfo
-                            #"Input to create-pool-from-config does not match schema"
-                            (create-pool-context malformed-config nil)))))
+                            #"Input to create-pool-context does not match schema"
+                            (create-pool-context malformed-config nil nil)))))
   (let [minimal-config {:jruby-puppet {:gem-home "/dev/null"
                                        :master-conf-dir "/dev/null"
                                        :master-var-dir "/dev/null"}
@@ -39,7 +39,7 @@
   (let [pool-size        2
         config           (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size})
         profiler         jruby-testutils/default-profiler
-        pool-context     (create-pool-context config profiler)
+        pool-context     (create-pool-context config profiler nil)
         pool             (get-pool pool-context)]
 
     (testing "The pool should not yet be full as it is being primed in the
@@ -96,7 +96,7 @@
   (let [pool-size 2
         config        (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size})
         profiler      jruby-testutils/default-profiler
-        pool-context  (create-pool-context config profiler)
+        pool-context  (create-pool-context config profiler nil)
         pool          (get-pool pool-context)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
     (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
@@ -120,7 +120,7 @@
   (logutils/with-test-logging
     (let [config (jruby-testutils/jruby-puppet-config)
           profiler jruby-testutils/default-profiler
-          pool (create-pool-context config profiler)
+          pool (create-pool-context config profiler nil)
           pool-state @(:pool-state pool)]
       (is (= (core/default-pool-size (ks/num-cpus)) (:size pool-state))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -6,7 +6,7 @@
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
-            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -99,7 +99,7 @@
         pool-context  (create-pool-context config profiler)
         pool          (get-pool pool-context)
         err-msg       (re-pattern "Unable to borrow JRuby instance from pool")]
-    (with-redefs [core/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
+    (with-redefs [jruby-internal/create-pool-instance! (fn [_] (throw (IllegalStateException. "BORK!")))]
                  (is (thrown? IllegalStateException (jruby-agents/prime-pool! (:pool-state pool-context) config profiler))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -5,6 +5,8 @@
             [puppetlabs.services.jruby.jruby-puppet-core :refer :all :as core]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -56,7 +58,25 @@
     (testing "Removing an instance decrements the pool size by 1."
       (let [jruby-instance (borrow-from-pool pool)]
         (is (= (free-instance-count pool) (dec pool-size)))
-        (return-to-pool jruby-instance)))))
+        (return-to-pool jruby-instance)))
+
+    (testing "Borrowing an instance increments its request count."
+      (let [drain-via   (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
+            assoc-count (fn [acc jruby]
+                          (assoc acc (:id jruby)
+                                     (:request-count @(:state jruby))))
+            get-counts  (fn [jrubies] (reduce assoc-count {} jrubies))]
+        (doseq [drain-fn [#(jruby-core/borrow-from-pool pool)
+                          #(jruby-core/borrow-from-pool-with-timeout pool 20000)]]
+          (let [jrubies (drain-via drain-fn)
+                counts  (get-counts jrubies)]
+            (jruby-testutils/fill-drained-pool jrubies)
+            (let [jrubies    (drain-via drain-fn)
+                  new-counts (get-counts jrubies)]
+              (jruby-testutils/fill-drained-pool jrubies)
+              (is (= (ks/keyset counts) (ks/keyset new-counts)))
+              (doseq [k (keys counts)]
+                (is (= (inc (counts k)) (new-counts k)))))))))))
 
 (deftest prime-pools-failure
   (let [pool-size 2

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -9,7 +9,8 @@
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
            (java.util.concurrent LinkedBlockingDeque)))
@@ -27,22 +28,20 @@
             (jruby-testutils/jruby-puppet-config {:max-active-instances 4})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
             context (tk-services/service-context jruby-service)
-            pool-context (:pool-context context)
-            pool (jruby-core/get-pool pool-context)]
-        (jruby-testutils/reduce-over-jrubies! pool 4 #(format "InstanceID = %s" %))
+            pool-context (:pool-context context)]
+        (jruby-testutils/reduce-over-jrubies! pool-context 4 #(format "InstanceID = %s" %))
         (is (= #{0 1 2 3}
-               (-> (jruby-testutils/reduce-over-jrubies! pool 4 (constantly "InstanceID"))
+               (-> (jruby-testutils/reduce-over-jrubies! pool-context 4 (constantly "InstanceID"))
                    set)))
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until the flush is complete
         (await (:pool-agent pool-context))
-        (let [new-pool (jruby-core/get-pool pool-context)]
-          (is (every? true?
-                      (jruby-testutils/reduce-over-jrubies!
-                        new-pool
-                        4
-                        (constantly
-                          "begin; InstanceID; false; rescue NameError; true; end")))))))))
+        (is (every? true?
+                    (jruby-testutils/reduce-over-jrubies!
+                      pool-context
+                      4
+                      (constantly
+                        "begin; InstanceID; false; rescue NameError; true; end"))))))))
 
 (deftest retry-poison-pill-test
   (testing "Flush puts a retry poison pill into the old pool"
@@ -69,7 +68,10 @@
         @pool-state-swapped
         ; wait until the flush is complete
         (await (:pool-agent pool-context))
-        (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
+        (let [old-pool-instance (jruby-internal/borrow-from-pool!*
+                                  jruby-internal/borrow-without-timeout-fn
+                                  old-pool
+                                  pool-context)]
           (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 
 (deftest with-jruby-retry-test-via-mock-get-pool
@@ -91,7 +93,7 @@
             get-mock-pool (fn [_] (let [result (nth mock-pools @num-borrows)]
                                     (swap! num-borrows inc)
                                     result))]
-        (with-redefs [jruby-core/get-pool get-mock-pool]
+        (with-redefs [jruby-internal/get-pool get-mock-pool]
           (jruby/with-jruby-puppet
             jruby-puppet
             jruby-service

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -35,7 +35,7 @@
                    set)))
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [new-pool (jruby-core/get-pool pool-context)]
           (is (every? true?
                       (jruby-testutils/reduce-over-jrubies!
@@ -68,7 +68,7 @@
         ; wait until we know the new pool has been swapped in
         @pool-state-swapped
         ; wait until the flush is complete
-        (await (:pool-agent context))
+        (await (:pool-agent pool-context))
         (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
           (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -11,7 +11,7 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol])
   (:import (puppetlabs.services.jruby.jruby_puppet_core RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
-           (java.util.concurrent ArrayBlockingQueue)))
+           (java.util.concurrent LinkedBlockingDeque)))
 
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -83,7 +83,7 @@
             real-pool     (-> (tk-services/service-context jruby-service)
                               :pool-context
                               (jruby-core/get-pool))
-            retry-pool    (ArrayBlockingQueue. 1)
+            retry-pool    (LinkedBlockingDeque. 1)
             _             (-> retry-pool (RetryPoisonPill.) jruby-core/return-to-pool)
             mock-pools    [retry-pool retry-pool retry-pool real-pool]
             num-borrows   (atom 0)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -8,8 +8,9 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
-            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol])
-  (:import (puppetlabs.services.jruby.jruby_puppet_core RetryPoisonPill)
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
+  (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
            (com.puppetlabs.puppetserver JRubyPuppet)
            (java.util.concurrent LinkedBlockingDeque)))
 
@@ -69,7 +70,7 @@
         ; wait until the flush is complete
         (await (:pool-agent context))
         (let [old-pool-instance (jruby-core/borrow-from-pool old-pool)]
-          (is (jruby-core/retry-poison-pill? old-pool-instance)))))))
+          (is (jruby-schemas/retry-poison-pill? old-pool-instance)))))))
 
 (deftest with-jruby-retry-test-via-mock-get-pool
   (testing "with-jruby-puppet retries if it encounters a RetryPoisonPill"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -116,9 +116,8 @@
         config
         (let [service (app/get-service app :JRubyPuppetService)
               context (services/service-context service)
-              pool-context (:pool-context context)
-              pool (jruby-puppet-core/get-pool pool-context)]
-          (jruby-testutils/drain-pool pool pool-size)
+              pool-context (:pool-context context)]
+          (jruby-testutils/drain-pool pool-context pool-size)
           (let [test-start-in-millis (System/currentTimeMillis)]
             (is (nil? (jruby-protocol/borrow-instance service)))
             (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -13,7 +13,8 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -31,7 +32,7 @@
       (str "If there as an exception while putting a JRubyPuppet instance in "
            "the pool the application should shut down.")
     (logging/with-test-logging
-      (with-redefs [jruby-puppet-core/create-pool-instance!
+      (with-redefs [jruby-internal/create-pool-instance!
                     (fn [& _] (throw (Exception. "42")))]
                    (let [got-expected-exception (atom false)]
                      (try

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -12,7 +12,8 @@
             [clojure.stacktrace :as stacktrace]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]))
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
@@ -98,7 +99,9 @@
           service
           (is (instance? JRubyPuppet jruby-puppet))
           (is (= 0 (jruby-protocol/free-instance-count service))))
-        (is (= 1 (jruby-protocol/free-instance-count service)))))))
+        (is (= 1 (jruby-protocol/free-instance-count service)))
+        (let [jruby (jruby-protocol/borrow-instance service)]
+          (is (= 2 (:request-count (jruby-core/instance-state jruby)))))))))
 
 (deftest test-borrow-timeout-configuration
   (testing "configured :borrow-timeout is honored by the borrow-instance service function"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -123,14 +123,14 @@
             (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout))
             (is (= (:borrow-timeout context) timeout)))))))
 
-  (testing (str ":borrow-timeout defaults to " default-borrow-timeout " milliseconds")
+  (testing (str ":borrow-timeout defaults to " jruby-core/default-borrow-timeout " milliseconds")
     (bootstrap/with-app-with-config
       app
       [jruby-puppet-pooled-service profiler/puppet-profiler-service]
       jruby-service-test-config
       (let [service (app/get-service app :JRubyPuppetService)
             context (services/service-context service)]
-        (is (= (:borrow-timeout context) default-borrow-timeout))))))
+        (is (= (:borrow-timeout context) jruby-core/default-borrow-timeout))))))
 
 (deftest timeout-settings-applied
   (testing "timeout settings are properly plumbed"
@@ -154,7 +154,7 @@
       (let [service          (app/get-service app :JRubyPuppetService)
             context          (services/service-context service)
             pool-context-cfg (get-in context [:pool-context :config])]
-        (is (= default-http-connect-timeout
+        (is (= jruby-core/default-http-connect-timeout
                (:http-client-connect-timeout-milliseconds pool-context-cfg)))
-        (is (= default-http-socket-timeout
+        (is (= jruby-core/default-http-socket-timeout
                (:http-client-idle-timeout-milliseconds pool-context-cfg)))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -81,10 +81,11 @@
       (Object.))))
 
 (defn create-mock-pool-instance
-  [pool _ _ _]
+  [pool id _ _]
   (let [instance (jruby-core/map->JRubyPuppetInstance
                    {:pool                 pool
-                    :id                   1
+                    :id                   id
+                    :state                (atom {:request-count 0})
                     :jruby-puppet         (create-mock-jruby-instance)
                     :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
                     :environment-registry (puppet-env/environment-registry)})]

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -4,7 +4,8 @@
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -68,8 +69,8 @@
   ([]
    (create-pool-instance (jruby-puppet-config {:max-active-instances 1})))
   ([config]
-   (let [pool (jruby-core/instantiate-free-pool 1)]
-     (jruby-core/create-pool-instance! pool 1 config default-profiler))))
+   (let [pool (jruby-internal/instantiate-free-pool 1)]
+     (jruby-internal/create-pool-instance! pool 1 config default-profiler))))
 
 (defn create-mock-jruby-instance
   "Creates a mock implementation of the JRubyPuppet interface."
@@ -97,7 +98,7 @@
   mock JRubyPuppet instances."
   [f]
   (with-redefs
-    [jruby-core/create-pool-instance! create-mock-pool-instance]
+    [jruby-internal/create-pool-instance! create-mock-pool-instance]
     (f)))
 
 (defn drain-pool

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -103,8 +103,8 @@
 
 (defn drain-pool
   "Drains the JRubyPuppet pool and returns each instance in a vector."
-  [pool size]
-  (mapv (fn [_] (jruby-core/borrow-from-pool pool)) (range size)))
+  [pool-context size]
+  (mapv (fn [_] (jruby-core/borrow-from-pool pool-context)) (range size)))
 
 (defn fill-drained-pool
   "Returns a list of JRubyPuppet instances back to their pool."
@@ -120,8 +120,8 @@
 
   Returns a vector containing the results of executing the scripts against the
   JRuby instances."
-  [pool size f]
-  (let [jrubies (drain-pool pool size)
+  [pool-context size f]
+  (let [jrubies (drain-pool pool-context size)
         result  (reduce
                   (fn [acc jruby-offset]
                     (let [sc (:scripting-container (nth jrubies jruby-offset))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -2,9 +2,9 @@
   (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse)
            (org.jruby.embed ScriptingContainer LocalContextScope))
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
-            [puppetlabs.services.puppet-profiler.puppet-profiler-core :as profiler-core]
             [me.raynes.fs :as fs]
-            [puppetlabs.services.jruby.puppet-environments :as puppet-env]))
+            [puppetlabs.services.jruby.puppet-environments :as puppet-env]
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -82,7 +82,7 @@
 
 (defn create-mock-pool-instance
   [pool id _ _]
-  (let [instance (jruby-core/map->JRubyPuppetInstance
+  (let [instance (jruby-schemas/map->JRubyPuppetInstance
                    {:pool                 pool
                     :id                   id
                     :state                (atom {:request-count 0})

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -12,6 +12,7 @@
 (def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"])
 
 (def conf-dir "./target/master-conf")
+(def var-dir "./target/master-var")
 
 (def gem-home "./target/jruby-gem-home")
 
@@ -52,14 +53,13 @@
   JRubyPuppet pool size with be included with the config, otherwise no size
   will be specified."
   ([]
-   {:ruby-load-path  ruby-load-path
-    :gem-home        gem-home
-    :master-conf-dir conf-dir})
+   (jruby-core/initialize-config
+     {:jruby-puppet {:gem-home        gem-home
+                     :master-conf-dir conf-dir
+                     :master-var-dir  var-dir}
+      :os-settings  {:ruby-load-path ruby-load-path}}))
   ([options]
    (merge (jruby-puppet-config) options)))
-
-(def default-config-no-size
-  (jruby-puppet-config))
 
 (def default-profiler
   nil)


### PR DESCRIPTION
This PR is a pre-cursor to the real implementation details for SERVER-325.  The goal of that ticket is to introduce a new setting that allows users to configure JRuby instances to be flushed after being used for a certain number of requests.

There was a lot of code clean-up / reorganization necessary in order to make it possible to implement that functionality.  The main issue was that there were some circular dependencies between some of the namespaces that make up the JRuby pool functionality, and we needed to break those namespaces up into smaller units in order to be able to wire everything together without circular dependencies.

The commits related to that code reorganization are very susceptible to merge conflicts if any other work is being done related to the JRuby scripting containers.  Therefore, in the interest of minimizing conflicts, I'm submitting this PR to go ahead and get all of the re-organization out of the way.

This should hopefully be in a mergeable state as-is, and if we can get it in, that should allow us to unblock other JRuby-related changes while I finish up the flushing implementation.