### PR TITLE
(SERVER-535) Fix several bugs in j-p-service-test

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -51,7 +51,11 @@
 
     * :http-client-cipher-suites - A list of legal SSL cipher suites that may
         be used when https client requests are made."
-  {:ruby-load-path              (schema/both [schema/Str] (schema/pred vector?))
+  ;; NOTE: there is a bug in the version of schema we're using, which causes
+  ;; the order of things that you put into a `both` to be very important.
+  ;; The `vector?` pred here MUST come before the `[schema/Str]`.  For more info
+  ;; see https://github.com/Prismatic/schema/issues/68
+  {:ruby-load-path              (schema/both (schema/pred vector?) [schema/Str])
    :gem-home                    schema/Str
    :master-conf-dir             (schema/maybe schema/Str)
    :master-var-dir              (schema/maybe schema/Str)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -125,7 +125,7 @@
               pool-context (:pool-context context)]
           (let [jrubies (jruby-testutils/drain-pool pool-context pool-size)]
             (is (= 1 (count jrubies)))
-            (is (every? #(jruby-schemas/jruby-puppet-instance? %) jrubies)))
+            (is (every? jruby-schemas/jruby-puppet-instance? jrubies)))
           (let [test-start-in-millis (System/currentTimeMillis)]
             (is (nil? (jruby-protocol/borrow-instance service)))
             (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -1,11 +1,13 @@
 (ns puppetlabs.services.jruby.jruby-testutils
-  (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse)
-           (org.jruby.embed ScriptingContainer LocalContextScope))
   (:require [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [schema.core :as schema])
+  (:import (com.puppetlabs.puppetserver JRubyPuppet JRubyPuppetResponse PuppetProfiler)
+           (org.jruby.embed ScriptingContainer LocalContextScope)
+           (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -41,7 +43,10 @@
 
 (defn jruby-puppet-tk-config
   "Create a JRubyPuppet pool config with the given pool config.  Suitable for use
-  in bootstrapping trapperkeeper."
+  in bootstrapping trapperkeeper (in other words, returns a representation of the
+  config that matches what would be read directly from the config files on disk,
+  as opposed to a version that has been processed and transformed to comply
+  with the JRubyPuppetConfig schema)."
   [pool-config]
   {:os-settings  {:ruby-load-path ruby-load-path}
    :product     {:name "puppet-server"
@@ -49,10 +54,14 @@
    :jruby-puppet pool-config
    :certificate-authority {:certificate-status {:client-whitelist []}}})
 
-(defn jruby-puppet-config
+(schema/defn ^:always-validate
+  jruby-puppet-config :- jruby-schemas/JRubyPuppetConfig
   "Create a JRubyPuppet pool config. If `pool-size` is provided then the
   JRubyPuppet pool size with be included with the config, otherwise no size
-  will be specified."
+  will be specified.  (This function differs from `jruby-puppet-tk-config` in
+  that it returns a map that complies with the JRubyPuppetConfig schema, which
+  differs slightly from the raw format that would be read from config files
+  on disk.)"
   ([]
    (jruby-core/initialize-config
      {:jruby-puppet {:gem-home        gem-home
@@ -81,8 +90,12 @@
     (getSetting [_ _]
       (Object.))))
 
-(defn create-mock-pool-instance
-  [pool id _ _]
+(schema/defn ^:always-validate
+  create-mock-pool-instance :- JRubyPuppetInstance
+  [pool :- jruby-schemas/pool-queue-type
+   id :- schema/Int
+   config :- jruby-schemas/JRubyPuppetConfig
+   profiler :- (schema/maybe PuppetProfiler)]
   (let [instance (jruby-schemas/map->JRubyPuppetInstance
                    {:pool                 pool
                     :id                   id

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -56,9 +56,9 @@
 
 (schema/defn ^:always-validate
   jruby-puppet-config :- jruby-schemas/JRubyPuppetConfig
-  "Create a JRubyPuppet pool config. If `pool-size` is provided then the
-  JRubyPuppet pool size with be included with the config, otherwise no size
-  will be specified.  (This function differs from `jruby-puppet-tk-config` in
+  "Create a JRubyPuppetConfig for testing. The optional map argument `options` may
+  contain a map, which, if present, will be merged into the final JRubyPuppetConfig
+  map.  (This function differs from `jruby-puppet-tk-config` in
   that it returns a map that complies with the JRubyPuppetConfig schema, which
   differs slightly from the raw format that would be read from config files
   on disk.)"


### PR DESCRIPTION
Many (most?) of the configuration maps that were being used
in the jruby-puppet-service-tests were invalid, but this wasn't
surfacing in the test runs because of the way the mock
JRuby instances were being created.  This commit improves
the validation of the input to the mock fixture, and fixes all
of the test configurations.