### PR TITLE
(SERVER-480) Test against puppet-agent 1.0.0

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -27,10 +27,9 @@ module PuppetServerExtensions
 
     # SERVER-339, SERVER-386 - puppet-agent version corresponds to packaged
     # development version located at http://builds.puppetlabs.lan/puppet-agent/
-    # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "1166ad687883061f8f7133634144759d2b9eb37b")
+                         "PUPPET_BUILD_VERSION", "1.0.0")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
Without this patch puppetserver 2.0.0 is testing against a development build of
puppet agent.  This patch addresses the problem by moving the pin from a
development build to the real deal 1.0.0 version of the puppet-agent packages.