### PR TITLE
(maint) Pessimistically pin to beaker 2.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || 'git@github.com:puppetlabs/beaker.git#8909e35a97b8c30b11b77b784a47c8d175cd4ec8')
+  gem 'beaker', *location_for(ENV['BEAKER_LOCATION'] || '~> 2.9.0')
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '~> 0.11'
   end


### PR DESCRIPTION
Without this patch puppetserver is pinned to a specific GIT sha of beaker.
This is a problem because using a Git checkout has the side effect of transient
false positive failures as described in QENG-2138.  This patch addresses the
problem by updating the dependency expression to so-called pessimistic
dependency that pins beaker to released versions installed via rubygems, not
git, in the 2.9.x series.