### PR TITLE
(SERVER-544) stop duplicating request body for jruby

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,9 @@
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
                  [org.jruby/jruby-stdlib "1.7.19"]
-                 [clj-time "0.5.1" :exclusions [joda-time]]
+                 [joda-time "2.5"]
+                 [clj-time "0.6.0"]
+                 [ring/ring-core "1.3.2"]
                  [compojure "1.1.8" :exclusions [org.clojure/tools.macro]]
                  [liberator "0.12.0"]
                  [me.raynes/fs "1.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,6 @@
                  [commons-codec "1.9"]
                  [clj-yaml "0.4.0" :exclusions [org.yaml/snakeyaml]]
                  [slingshot "0.10.3"]
-                 [ring/ring-codec "1.0.0"]
                  [cheshire "5.3.1"]
                  [trptcolin/versioneer "0.1.0"]]
 

--- a/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
+++ b/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
@@ -1,0 +1,59 @@
+(ns puppetlabs.puppetserver.ring.middleware.params
+  (:require [ring.util.codec :as codec]
+            [ring.util.request :as req]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; COPY OF RELEVANT FUNCTIONS FROM UPSTREAM ring.middleware.params LIBRARY
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn parse-params [params encoding]
+  (let [params (codec/form-decode params encoding)]
+    (if (map? params) params {})))
+
+(defn content-type
+  "Return the content-type of the request, or nil if no content-type is set."
+  [request]
+  (if-let [type (get-in request [:headers "content-type"])]
+    (second (re-find #"^(.*?)(?:;|$)" type))))
+
+(defn urlencoded-form?
+  "True if a request contains a urlencoded form in the body."
+  [request]
+  (if-let [^String type (content-type request)]
+    (.startsWith type "application/x-www-form-urlencoded")))
+
+(defn assoc-query-params
+  "Parse and assoc parameters from the query string with the request."
+  [request encoding]
+  (merge-with merge request
+              (if-let [query-string (:query-string request)]
+                (let [params (parse-params query-string encoding)]
+                  {:query-params params, :params params})
+                {:query-params {}, :params {}})))
+
+(defn assoc-form-params
+  "Parse and assoc parameters from the request body with the request."
+  [request encoding]
+  (merge-with merge request
+              (if-let [body (and (urlencoded-form? request) (:body request))]
+                (let [params (parse-params (slurp body :encoding encoding) encoding)]
+                  {:form-params params, :params params})
+                {:form-params {}, :params {}})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(defn params-request
+  "Adds parameters from the query string and the request body to the request
+  map. See: wrap-params."
+  {:arglists '([request] [request options])}
+  [request & [opts]]
+  (let [encoding (or (:encoding opts)
+                     (req/character-encoding request)
+                     "UTF-8")
+        request  (if (:form-params request)
+                   request
+                   (assoc-form-params request encoding))]
+    (if (:query-params request)
+      request
+      (assoc-query-params request encoding))))

--- a/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
+++ b/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
@@ -5,6 +5,27 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; COPY OF RELEVANT FUNCTIONS FROM UPSTREAM ring.middleware.params LIBRARY
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This namespace is basically just here to provide an implementation of
+;; the `params-request` middleware function that supports a String representation
+;; of the body of a request.  The upstream library requires the body to be of
+;; a type that is compatible with Clojure's IOFactory, which forces us to read
+;; the request body into memory twice for requests that we have to pass down
+;; into the JRuby layer.  (Technically, the Ring specification states that the
+;; body must be an InputStream, so the maintainer of the upstream library was
+;; reluctant to accept any sort of upstream PR to work around this issue.)
+;;
+;; All of this code is copied from the upstream library, and there is just
+;; one very slight modification (see comment in `assoc-form-params` function)
+;; that allows us to avoid reading the body into memory twice.
+;;
+;; In the future, if we can handle the query parameter parsing strictly on the
+;; Clojure side and remove that code from the Ruby side, we should be able to
+;; get rid of this.  That will be much easier to consider doing once we're able
+;; to get rid of the Rack/Webrick support.
+;;
+;; If that happens, we should delete this namespace :)
+;;
 
 (defn parse-params [params encoding]
   (let [params (codec/form-decode params encoding)]
@@ -13,7 +34,11 @@
 (defn content-type
   "Return the content-type of the request, or nil if no content-type is set."
   [request]
-  (if-let [type (get-in request [:headers "content-type"])]
+  ;; NOTE: in the latest version of ring-core, they only look in
+  ;;  the headers map for the content type.  They no longer fall
+  ;;  back to looking for it in the main request map.
+  (if-let [type (or (get-in request [:headers "content-type"])
+                    (get request :content-type))]
     (second (re-find #"^(.*?)(?:;|$)" type))))
 
 (defn urlencoded-form?
@@ -36,7 +61,16 @@
   [request encoding]
   (merge-with merge request
               (if-let [body (and (urlencoded-form? request) (:body request))]
-                (let [params (parse-params (slurp body :encoding encoding) encoding)]
+                (let [params (parse-params
+                               ;; NOTE: this is the main difference between our
+                               ;;  copy of this code and the upstream version:
+                               ;;  the upstream always does a slurp here, while
+                               ;;  we only do a slurp if the body is not already
+                               ;;  a string.
+                               (if (string? body)
+                                 body
+                                 (slurp body :encoding encoding))
+                               encoding)]
                   {:form-params params, :params params})
                 {:form-params {}, :params {}})))
 

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -6,10 +6,10 @@
             [clojure.string :as string]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.ssl-utils.core :as ssl-utils]
-            [ring.middleware.params :as ring-params]
             [ring.util.codec :as ring-codec]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
+            [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -92,22 +92,10 @@
    body into the ring request map.  Includes some special processing for
    a request destined for JRubyPuppet."
   [request]
-  ; Need to slurp the request body before invoking any of the ring
-  ; middleware functions because a handle to the body payload needs to be passed
-  ; through to JRubyPuppet and the body won't be around to slurp if any of
-  ; the ring functions happen to slurp it up first.  This would happen for a
-  ; 'application/x-www-form-urlencoded' form post where ring needs to slurp
-  ; in the body of the request in order to parse out parameters from the form.
   (let [body-for-jruby (body-for-jruby request)]
     (->
       request
-      ; Leave the slurped content under an alternate key so that it
-      ; is available to be proxied on to the JRubyPuppet request.
-      (assoc :body-for-jruby body-for-jruby)
-      ; Body content has been slurped already so wrap it in a new reader
-      ; so that a copy of it can be obtained by ring middleware functions,
-      ; if needed.
-      (assoc :body (if (string? body-for-jruby) (StringReader. body-for-jruby)))
+      (assoc :body body-for-jruby)
       ; Compojure request may have destructured parameters from subportions
       ; of the URL into the params map by this point.  Clear this out
       ; before invoking the ring middleware param functions so that keys
@@ -116,7 +104,7 @@
       (assoc :params {})
       ; Defer to ring middleware to pull out parameters from the query
       ; string and/or form body.
-      ring-params/params-request)))
+      pl-ring-params/params-request)))
 
 (def unauthenticated-client-info
   "Return a map with default info for an unauthenticated client"
@@ -238,7 +226,7 @@
                    :params         (:params request)
                    :remote-addr    (:remote-addr request)
                    :headers        headers
-                   :body           (:body-for-jruby request)
+                   :body           (:body request)
                    :request-method (-> (:request-method request)
                                        name
                                        string/upper-case)}]

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -51,7 +51,7 @@
                              :content-type "text/plain"})]
       (is (= {} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body-for-jruby wrapped-request))
+      (is (= "" (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
   (testing "get with query parameters returns expected values"
     (let [wrapped-request (core/wrap-params-for-jruby
@@ -62,7 +62,7 @@
       (is (= {"one" "1 1", "two" "2", "arr[]" ["3", "4"]}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= "" (:body-for-jruby wrapped-request))
+      (is (= "" (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with form parameters returns expected values"
     (let [body-string "one=1&two=2%202&arr[]=3&arr[]=4"
@@ -73,7 +73,7 @@
       (is (= {"one" "1", "two" "2 2", "arr[]" ["3" "4"]}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string (:body-for-jruby wrapped-request))
+      (is (= body-string (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with plain text in default encoding returns expected values"
     (let [body-string "some random text"
@@ -83,7 +83,7 @@
                              :params       {:bogus ""}})]
       (is (= {} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string (:body-for-jruby wrapped-request))
+      (is (= body-string (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
   (testing "post with plain text in UTF-16 returns expected values"
     (let [body-string-from-utf16 (String. (.getBytes
@@ -99,7 +99,7 @@
                              :params             {:bogus ""}})]
       (is (= {} (:params wrapped-request))
           "Unexpected params in wrapped request")
-      (is (= body-string-from-utf16 (:body-for-jruby wrapped-request))
+      (is (= body-string-from-utf16 (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
   (testing "request with binary content type does not consume body"
     (let [body-string "some random text"]
@@ -109,7 +109,7 @@
               wrapped-request (core/wrap-params-for-jruby
                                 {:body         body-reader
                                  :content-type content-type})]
-          (is (identical? body-reader (:body-for-jruby wrapped-request))
+          (is (identical? body-reader (:body wrapped-request))
               "Unexpected body for jruby instance in wrapped request")
           (is (= body-string (slurp body-reader))
               "Unexpected body for jruby content in wrapped request"))))))


### PR DESCRIPTION


Due to some conflicting opinions about how request bodies should be processed between the Ruby Puppet code and ring's 'params' middleware, our current code has the unfortunate behavior of reading the body of the HTTP request into memory twice for any requests that are routed into the JRuby layer.

We can prevent this by duplicating a few functions from the ring middleware library in our own code base, which isn't awesome, but seems preferable to the unnecessary extra memory usage (which can be a pretty big chunk of RAM for requests like catalog/report).
