### PR TITLE
(SERVER-157) Use the keylength setting from puppet.conf

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -29,6 +29,7 @@
    :hostcert       schema/Str
    :hostprivkey    schema/Str
    :hostpubkey     schema/Str
+   :keylength      schema/Int
    :localcacert    schema/Str
    :requestdir     schema/Str
    :csr-attributes schema/Str})
@@ -56,6 +57,7 @@
    :ca-ttl                   schema/Int
    :cert-inventory           schema/Str
    :csrdir                   schema/Str
+   :keylength                schema/Int
    :ruby-load-path           [schema/Str]
    :signeddir                schema/Str
    :serial                   schema/Str})
@@ -162,6 +164,7 @@
           :autosign
           :ca-name
           :ca-ttl
+          :keylength
           :ruby-load-path))
 
 (schema/defn settings->ssldir-paths
@@ -169,7 +172,7 @@
    paths. These paths are necessary during initialization for determining what
    needs to be created and where."
   [master-settings :- MasterSettings]
-  (dissoc master-settings :dns-alt-names :csr-attributes))
+  (dissoc master-settings :dns-alt-names :csr-attributes :keylength))
 
 (defn path-to-cert
   "Return a path to the `subject`s certificate file under the `signeddir`."
@@ -348,15 +351,14 @@
 (schema/defn generate-ssl-files!
   "Given the CA settings, generate and write to disk all of the necessary
   SSL files for the CA. Any existing files will be replaced."
-  [ca-settings :- CaSettings
-   keylength :- schema/Int]
+  [ca-settings :- CaSettings]
   (log/debug (str "Initializing SSL for the CA; settings:\n"
                   (ks/pprint-to-string ca-settings)))
   (create-parent-directories! (vals (settings->cadir-paths ca-settings)))
   (-> ca-settings :csrdir fs/file ks/mkdirs!)
   (-> ca-settings :signeddir fs/file ks/mkdirs!)
   (initialize-serial-file! (:serial ca-settings))
-  (let [keypair     (utils/generate-key-pair keylength)
+  (let [keypair     (utils/generate-key-pair (:keylength ca-settings))
         public-key  (utils/get-public-key keypair)
         private-key (utils/get-private-key keypair)
         x500-name   (utils/cn (:ca-name ca-settings))
@@ -526,8 +528,7 @@
    the master. Any existing files will be replaced."
   [settings :- MasterSettings
    certname :- schema/Str
-   ca-settings :- CaSettings
-   keylength :- schema/Int]
+   ca-settings :- CaSettings]
   (log/debug (str "Initializing SSL for the Master; settings:\n"
                   (ks/pprint-to-string settings)))
   (create-parent-directories! (vals (settings->ssldir-paths settings)))
@@ -537,7 +538,7 @@
         ca-public-key  (.getPublicKey ca-cert)
         ca-private-key (utils/pem->private-key (:cakey ca-settings))
         next-serial    (next-serial-number! (:serial ca-settings))
-        keypair        (utils/generate-key-pair keylength)
+        keypair        (utils/generate-key-pair (:keylength settings))
         public-key     (utils/get-public-key keypair)
         extensions     (create-master-extensions certname
                                                  public-key
@@ -565,12 +566,9 @@
   "Given configuration settings, certname, and CA settings, ensure all
    necessary SSL files exist on disk by regenerating all of them if any
    are found to be missing."
-  ([settings certname ca-settings]
-     (initialize-master-ssl! settings certname ca-settings utils/default-key-length))
-  ([settings :- MasterSettings
+  [settings :- MasterSettings
     certname :- schema/Str
-    ca-settings :- CaSettings
-    keylength :- schema/Int]
+    ca-settings :- CaSettings]
      (let [required-files (-> (settings->ssldir-paths settings)
                               (select-keys required-master-files)
                               (vals))]
@@ -579,8 +577,8 @@
          (let [{found   true
                 missing false} (group-by fs/exists? required-files)]
            (if (= required-files missing)
-             (generate-master-ssl-files! settings certname ca-settings keylength)
-             (throw (partial-state-error "master" found missing))))))))
+             (generate-master-ssl-files! settings certname ca-settings)
+             (throw (partial-state-error "master" found missing)))))))
 
 (schema/defn ^:always-validate retrieve-ca-cert!
   "Given configuration settings and CA settings, ensure a local copy of the CA
@@ -892,25 +890,22 @@
 
 (schema/defn ^:always-validate
   initialize!
-  "Given the CA configuration settings and an optional keylength,
-   ensure that all required SSL files exist. If all files exist,
+  "Given the CA configuration settings, ensure that all
+   required SSL files exist. If all files exist,
    new ones will not be generated. If only some are found
    (but others are missing), an exception is thrown."
-  ([settings]
-     (initialize! settings utils/default-key-length))
-  ([settings :- CaSettings
-    keylength :- schema/Int]
-     (ensure-directories-exist! settings)
-     (let [required-files (-> (settings->cadir-paths settings)
-                              (select-keys required-ca-files)
-                              (vals))]
-       (if (every? fs/exists? required-files)
-         (log/info "CA already initialized for SSL")
-         (let [{found   true
-                missing false} (group-by fs/exists? required-files)]
-           (if (= required-files missing)
-             (generate-ssl-files! settings keylength)
-             (throw (partial-state-error "CA" found missing))))))))
+  [settings :- CaSettings]
+    (ensure-directories-exist! settings)
+    (let [required-files (-> (settings->cadir-paths settings)
+                            (select-keys required-ca-files)
+                            (vals))]
+     (if (every? fs/exists? required-files)
+       (log/info "CA already initialized for SSL")
+       (let [{found   true
+              missing false} (group-by fs/exists? required-files)]
+         (if (= required-files missing)
+           (generate-ssl-files! settings)
+           (throw (partial-state-error "CA" found missing)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; certificate_status endpoint

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -28,6 +28,7 @@
     :cert-inventory
     :certname
     :csrdir
+    :keylength
     :hostcert
     :hostprivkey
     :hostpubkey

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.puppetserver.certificate-authority-test
-  (:import (java.io StringReader ByteArrayInputStream ByteArrayOutputStream))
+  (:import (java.io StringReader ByteArrayInputStream ByteArrayOutputStream)
+           (java.security InvalidParameterException))
   (:require [puppetlabs.puppetserver.certificate-authority :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.ssl-utils.core :as utils]
@@ -346,7 +347,7 @@
 (deftest initialize!-test
   (let [settings (testutils/ca-settings (ks/temp-dir))]
 
-    (initialize! settings 512)
+    (initialize! settings)
 
     (testing "Generated SSL file"
       (doseq [file (vals (settings->cadir-paths settings))]
@@ -390,9 +391,22 @@
                       (dissoc :csrdir :signeddir)
                       (vals))]
         (doseq [f files] (spit f "testable string"))
-        (initialize! settings 512)
+        (initialize! settings)
         (doseq [f files] (is (= "testable string" (slurp f))
                              "File was replaced"))))))
+
+(deftest initialize!-test-with-keylength-in-settings
+  (let [settings (assoc (testutils/ca-settings (ks/temp-dir)) :keylength 768)]
+    (initialize! settings)
+    (testing "cakey with keylength"
+      (let [key (-> settings :cakey utils/pem->private-key)]
+        (is (utils/private-key? key))
+        (is (= 768 (utils/keylength key)))))
+
+    (testing "capub with keylength"
+      (let [key (-> settings :capub utils/pem->public-key)]
+        (is (utils/public-key? key))
+        (is (= 768 (utils/keylength key)))))))
 
 (deftest ca-fail-fast-test
   (testing "Directories not required but are created if absent"
@@ -400,13 +414,13 @@
       (testing dir
         (let [settings (testutils/ca-sandbox! cadir)]
           (fs/delete-dir (get settings dir))
-          (is (nil? (initialize! settings 512)))
+          (is (nil? (initialize! settings)))
           (is (true? (fs/exists? (get settings dir))))))))
 
   (testing "CA public key not required"
     (let [settings (testutils/ca-sandbox! cadir)]
       (fs/delete (:capub settings))
-      (is (nil? (initialize! settings 512)))))
+      (is (nil? (initialize! settings)))))
 
   (testing "Exception is thrown when required file is missing"
     (doseq [file required-ca-files]
@@ -417,7 +431,7 @@
           (is (thrown-with-msg?
                IllegalStateException
                (re-pattern (str "Missing:\n" path))
-               (initialize! settings 512))))))))
+               (initialize! settings))))))))
 
 (deftest retrieve-ca-cert!-test
   (testing "CA file copied when it doesn't already exist"
@@ -456,7 +470,7 @@
         ca-settings (testutils/ca-settings (str tmp-confdir "/ssl/ca"))]
 
     (retrieve-ca-cert! (:cacert ca-settings) (:localcacert settings))
-    (initialize-master-ssl! settings "master" ca-settings 512)
+    (initialize-master-ssl! settings "master" ca-settings)
 
     (testing "Generated SSL file"
       (doseq [file (vals (settings->ssldir-paths settings))]
@@ -495,7 +509,7 @@
                       (dissoc :certdir :requestdir)
                       (vals))]
         (doseq [f files] (spit f "testable string"))
-        (initialize-master-ssl! settings "master" ca-settings 512)
+        (initialize-master-ssl! settings "master" ca-settings)
         (doseq [f files] (is (= "testable string" (slurp f))
                              "File was replaced"))))
 
@@ -508,8 +522,46 @@
             (is (thrown-with-msg?
                  IllegalStateException
                  (re-pattern (str "Missing:\n" path))
-                 (initialize-master-ssl! settings "master" ca-settings 512)))
+                 (initialize-master-ssl! settings "master" ca-settings)))
             (fs/copy copy path)))))))
+
+(deftest initialize-master-ssl!-test-with-keylength-settings
+  (let [tmp-confdir (fs/copy-dir confdir (ks/temp-dir))
+        settings (-> (testutils/master-settings tmp-confdir)
+                     (assoc :keylength 768))
+        ca-settings (assoc (testutils/ca-settings (str tmp-confdir "/ssl/ca")) :keylength 768)]
+
+  (retrieve-ca-cert! (:cacert ca-settings) (:localcacert settings))
+  (initialize-master-ssl! settings "master" ca-settings)
+
+  (testing "hostprivkey should have correct keylength"
+    (let [key (-> settings :hostprivkey utils/pem->private-key)]
+      (is (utils/private-key? key))
+      (is (= 768 (utils/keylength key)))))
+
+  (testing "hostpubkey should have correct keylength"
+    (let [key (-> settings :hostpubkey utils/pem->public-key)]
+      (is (utils/public-key? key))
+      (is (= 768 (utils/keylength key)))))))
+
+(deftest initialize-master-ssl!-test-with-incorrect-keylength
+  (let [tmp-confdir (fs/copy-dir confdir (ks/temp-dir))
+        settings (testutils/master-settings tmp-confdir)
+        ca-settings (testutils/ca-settings (str tmp-confdir "/ssl/ca"))]
+
+    (retrieve-ca-cert! (:cacert ca-settings) (:localcacert settings))
+
+    (testing "should throw an error message with too short keylength"
+      (is (thrown-with-msg?
+        InvalidParameterException
+        #".*RSA keys must be at least 512 bits long.*"
+          (initialize-master-ssl! (assoc settings :keylength 128) "master" ca-settings))))
+
+    (testing "should throw an error message with too large keylength"
+      (is (thrown-with-msg?
+        InvalidParameterException
+        #".*RSA keys must be no longer than 16384 bits.*"
+          (initialize-master-ssl! (assoc settings :keylength 32768) "master" ca-settings))))))
 
 (deftest parse-serial-number-test
   (is (= (parse-serial-number "0001") 1))

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -22,7 +22,8 @@
         :hostpubkey     (str ssldir "/public_keys/" hostname ".pem")
         :localcacert    (str ssldir "/certs/ca.pem")
         :requestdir     (str ssldir "/certificate_requests")
-        :csr-attributes (str confdir "/csr_attributes.yaml")})))
+        :csr-attributes (str confdir "/csr_attributes.yaml")
+        :keylength      512})))
 
 (defn ca-settings
   "CA configuration settings with defaults appropriate for testing.
@@ -40,6 +41,7 @@
    :capub                 (str cadir "/ca_pub.pem")
    :cert-inventory        (str cadir "/inventory.txt")
    :csrdir                (str cadir "/requests")
+   :keylength             512
    :signeddir             (str cadir "/signed")
    :serial                (str cadir "/serial")
    :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib"]})


### PR DESCRIPTION
If none are provided, it will resort to the default puppet
value.

Note that if the keylength is not correct (too small or
too high) the underlying java security code will throw
an InvalidParameterSecurity message about RSA key size,
but not a puppet specific message.

Signed-off-by: Brice Figureau <brice-puppet@daysofwonder.com>

Conflicts:
	test/unit/puppetlabs/puppetserver/certificate_authority_test.clj