### PR TITLE
(MAINT) Bump lein-ezbake dependency to 0.3.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.2"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.3"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
This commit bumps the puppet-server lein-ezbake dependency to 0.3.3,
needed to avoid Fedora 19 being used as a build target since that's now
been removed for our packaging jobs.