### PR TITLE
(SERVER-555) Update branching strategy document post 2.0.0

### DIFF
--- a/README_BRANCHING.md
+++ b/README_BRANCHING.md
@@ -18,7 +18,8 @@ OSS Puppet Server releases.  These releases are compatible with Puppet 3.x.
 The `master` branch maps to the 2.x series of OSS Puppet Server releases.  The
 2.0 release is compatible with Puppet 4.x as part of Puppet Collection 1 (PC1).
 The 2.1 release and later are intended to be compatible with Puppet 3.x and
-Puppet 4.x.
+Puppet 4.x.  Puppet 3.x is supported for remote agents only, only Puppet 4.x
+satisfies the package dependency between Puppet Server and Puppet.
 
 ## Important Notes About Upcoming Releases
 

--- a/README_BRANCHING.md
+++ b/README_BRANCHING.md
@@ -15,42 +15,47 @@ only be two branches that are relevant at all in the puppetlabs github repo:
 In the case of Puppet Server, the `stable` branch maps to the 1.x series of
 OSS Puppet Server releases.  These releases are compatible with Puppet 3.x.
 
-The `master` branch maps to the 2.x series of OSS Puppet Server releases.  These
-releases are compatible with Puppet 4.x.
+The `master` branch maps to the 2.1.x series of OSS Puppet Server releases.
+These releases are compatible with Puppet 4.x and Puppet 3.x.
 
 ## Important Notes About Upcoming Releases
 
-At the time of this writing, we've just released OSS 1.0.8.  This was a bugfix
-release and will be the OSS version of Puppet Server that is included in PE 3.8.
-
-The next release of Puppet Server, temporally, will be version 2.0.  It will
-be released in concert with the release of Puppet 4.0.  This release should be
-considered roughly equivalent to the Puppet Server 1.0.2 release in terms of
-functionality, and will largely only contain changes related to Puppet 4.0
-compatibility.
-
-Immediately following the 2.0 release, we'll merge up the 1.0.8 tag into master
-for inclusion in the next 2.x release, and begin work on a quick turnaround for
-a 2.1 release.  This release will be 2.0, plus the bugfixes from 1.0.8, plus
-a URL compatibility layer that will allow Puppet 3.x agents to talk to Puppet
-Server 2.x (for more info see https://tickets.puppetlabs.com/browse/SERVER-526 ).
-
-NOTE: once 2.0 has been released, and the 1.0.8 tag has been merged up from stable
-to master, *we'll still be under a merge freeze from stable to master until 2.1
-ships*.
-
-Some time following that, we'll do a 1.1 and 2.2 release, hopefully in close
-proximity to one another.  These will be the next major feature releases (as
-opposed to 2.0 and 2.1, which are mostly just compatibility releases), and will contain
-several new features, tuning improvements, etc.
+At the time of this writing, we've just released OSS 2.0.0.  This release
+should be considered roughly equivalent to the Puppet Server 1.0.2 release in
+terms of functionality, and will largely only contain changes related to Puppet
+4.0 compatibility.
 
 The changes for 1.1 have started to land in the `stable` branch now.  Some of
 them are too risky to introduce into the `master` branch given our proximity to
 the 2.1 release.  Therefore, it is critical that we do *not* do any merges from
 `stable` to `master` until after 2.1 has shipped.
 
+Work on new functionality intended for the 2.1 release has commenced prior to
+the 2.0 release.  The `master` branch is where active development on 2.1
+functionality needs to land during the period before the 2.1.0 release.
+
+There will be a quick turnaround for a 2.1 release following the 2.0 release.
+This 2.1 release will be 2.0, plus the bugfixes in 1.0.8, plus a URL
+compatibility layer that will allow Puppet 3.x agents to talk to Puppet Server
+2.x (for more info see https://tickets.puppetlabs.com/browse/SERVER-526).
+
+NOTE: once 2.0 has been released *we'll still be under a merge freeze from
+stable to `master` and `2.1.x` until 2.1 ships*.
+
+Some time following the release of 2.1, we'll do a 1.1 and 2.2 release,
+hopefully in close proximity to one another.  These will be the next major
+feature releases (as opposed to 2.0 and 2.1, which are mostly just
+compatibility releases), and will contain several new features, tuning
+improvements, etc.
+
 We'll update this document to reflect changes to that restriction as things
 progress.
+
+In summary:
+
+ * `stable` is for 1.1.x and too risky to merge up into master until after 2.1
+   ships.
+ * `master` is for 2.1.x and frozen ahead of the 2.1.0 release.
 
 ## "Normal" branching workflow
 
@@ -70,5 +75,4 @@ Server for some period of time.  If we find ourselves in a situation where we
 need three branches (e.g. a stable branch for 1.x and another stable branch for 2.x),
 we may introduce a third branch (e.g. we might have `1.x`, `stable`->2.0.x, and
 `master`->2.1.x, or something along those lines).  We will update this document as
-the plans solidify.  
-
+the plans solidify.

--- a/README_BRANCHING.md
+++ b/README_BRANCHING.md
@@ -3,8 +3,8 @@ for Puppet Server.  This information is up-to-date as of 2015-03-06.
 
 ## THE MOST IMPORTANT THING TO KNOW
 
-tl;dr: we are putting a freeze on merging up changes from `stable` to `master`
-until Puppet Server 2.0 ships.
+tl;dr: *we are putting a freeze on merging up changes from `stable` to `master`
+until Puppet Server 2.1 ships.*
 
 ## Puppet Server Branches
 
@@ -15,8 +15,10 @@ only be two branches that are relevant at all in the puppetlabs github repo:
 In the case of Puppet Server, the `stable` branch maps to the 1.x series of
 OSS Puppet Server releases.  These releases are compatible with Puppet 3.x.
 
-The `master` branch maps to the 2.1.x series of OSS Puppet Server releases.
-These releases are compatible with Puppet 4.x and Puppet 3.x.
+The `master` branch maps to the 2.x series of OSS Puppet Server releases.  The
+2.0 release is compatible with Puppet 4.x as part of Puppet Collection 1 (PC1).
+The 2.1 release and later are intended to be compatible with Puppet 3.x and
+Puppet 4.x.
 
 ## Important Notes About Upcoming Releases
 
@@ -30,17 +32,19 @@ them are too risky to introduce into the `master` branch given our proximity to
 the 2.1 release.  Therefore, it is critical that we do *not* do any merges from
 `stable` to `master` until after 2.1 has shipped.
 
-Work on new functionality intended for the 2.1 release has commenced prior to
-the 2.0 release.  The `master` branch is where active development on 2.1
-functionality needs to land during the period before the 2.1.0 release.
+The `master` branch is where active development on 2.1 functionality needs to
+land during the period before the 2.1.0 release.
 
 There will be a quick turnaround for a 2.1 release following the 2.0 release.
 This 2.1 release will be 2.0, plus the bugfixes in 1.0.8, plus a URL
 compatibility layer that will allow Puppet 3.x agents to talk to Puppet Server
 2.x (for more info see https://tickets.puppetlabs.com/browse/SERVER-526).
 
-NOTE: once 2.0 has been released *we'll still be under a merge freeze from
-stable to `master` and `2.1.x` until 2.1 ships*.
+Other than a one-time merge up from stable to master of the changes which landed
+in the 1.0.8 release, *we'll still be under a merge freeze from the stable to
+master branches until 2.1 ships*. Prior to 2.1 shipping, changes not related to
+enabling Puppet 3.x agents to talk to Puppet Server 2.x should generally be
+targeted at the stable branch.
 
 Some time following the release of 2.1, we'll do a 1.1 and 2.2 release,
 hopefully in close proximity to one another.  These will be the next major


### PR DESCRIPTION
Without this patch the branching document is out of date because we've released
2.0.0 and master is now taking over responsibility for 2.1.x.

Conflicts:
	README_BRANCHING.md