### PR TITLE
(PE-8645) use comidi for routes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(def tk-version "1.1.0")
-(def tk-jetty-version "1.3.0")
-(def ks-version "1.0.0")
+(def tk-version "1.1.1")
+(def tk-jetty-version "1.3.1")
+(def ks-version "1.1.0")
 (def ps-version "1.0.9-SNAPSHOT")
 
 (defn deploy-info
@@ -17,7 +17,7 @@
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.0"]
-                 [puppetlabs/http-client "0.4.3"]
+                 [puppetlabs/http-client "0.4.4"]
                  [org.jruby/jruby-core "1.7.19"
                   :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  [com.github.jnr/jffi "1.2.7"]
@@ -27,13 +27,14 @@
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
                  [org.jruby/jruby-stdlib "1.7.19"]
+                 [org.clojure/data.json "0.2.3"]
+                 [org.clojure/tools.macro "0.1.5"]
                  [joda-time "2.5"]
                  [clj-time "0.6.0"]
-                 [ring/ring-core "1.3.2"]
-                 [compojure "1.1.8" :exclusions [org.clojure/tools.macro]]
                  [liberator "0.12.0"]
+                 [puppetlabs/comidi "0.1.1"]
                  [me.raynes/fs "1.4.5"]
-                 [prismatic/schema "0.2.2"]
+                 [prismatic/schema "0.4.0"]
                  [commons-lang "2.6"]
                  [commons-io "2.4"]
                  [commons-codec "1.9"]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -803,7 +803,9 @@
   [subject :- schema/Str
    csr :- CertificateRequest
    csrdir :- schema/Str]
-  (utils/obj->pem! csr (path-to-cert-request csrdir subject)))
+  (let [csr-path (path-to-cert-request csrdir subject)]
+    (log/debugf "Saving CSR to '%s'" csr-path)
+    (utils/obj->pem! csr csr-path)))
 
 (schema/defn validate-duplicate-cert-policy!
   "Throw a slingshot exception if allow-duplicate-certs is false

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.ca.certificate-authority-core
-  (:import  [java.io InputStream])
+  (:import [java.io InputStream]
+           (clojure.lang IFn))
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.puppetserver.liberator-utils :as utils]
@@ -11,6 +12,7 @@
             [schema.core :as schema]
             [cheshire.core :as cheshire]
             [liberator.core :refer [defresource]]
+            ;[liberator.dev :as liberator-dev]
             [liberator.representation :as representation]
             [ring.util.response :as rr]))
 
@@ -253,8 +255,9 @@
          (handle-get-certificate-revocation-list ca-settings))))
 
 (schema/defn ^:always-validate
-  wrap-middleware
-  [handler puppet-version]
+  wrap-middleware :- IFn
+  [handler :- IFn
+   puppet-version :- schema/Str]
   (-> handler
     ;(liberator-dev/wrap-trace :header)           ; very useful for debugging!
     (ringutils/wrap-with-puppet-version-header puppet-version)

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -3,16 +3,15 @@
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.puppetserver.liberator-utils :as utils]
+            [puppetlabs.comidi :as comidi :refer [GET ANY PUT]]
             [slingshot.slingshot :as sling]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io]
             [clojure.string :as string]
             [schema.core :as schema]
             [cheshire.core :as cheshire]
-            [compojure.core :as compojure :refer [GET ANY PUT]]
             [liberator.core :refer [defresource]]
             [liberator.representation :as representation]
-            [liberator.dev :as liberator-dev]
             [ring.util.response :as rr]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -53,7 +52,7 @@
       (rr/content-type "text/plain")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Compojure app
+;;; Web app
 
 (defn try-to-parse
   [body]
@@ -236,29 +235,27 @@
       (ca/get-certificate-statuses settings)
       (as-json-or-pson context))))
 
-(schema/defn routes
+(schema/defn ^:always-validate web-routes :- comidi/BidiRoute
   [ca-settings :- ca/CaSettings]
-  (compojure/context "/:environment" [environment]
-    (compojure/routes
-      (ANY "/certificate_status/:subject" [subject]
-        (certificate-status subject ca-settings))
-      (ANY "/certificate_statuses/:ignored-but-required" [do-not-use]
-        (certificate-statuses ca-settings)))
-      (GET "/certificate/:subject" [subject]
-        (handle-get-certificate subject ca-settings))
-      (compojure/context "/certificate_request/:subject" [subject]
-        (GET "/" []
-          (handle-get-certificate-request subject ca-settings))
-        (PUT "/" {body :body}
-          (handle-put-certificate-request! subject body ca-settings)))
-      (GET "/certificate_revocation_list/:ignored-node-name" []
-        (handle-get-certificate-revocation-list ca-settings))))
+  (comidi/context ["/" :environment]
+    (ANY ["/certificate_status/" :subject] [subject]
+         (certificate-status subject ca-settings))
+    (ANY ["/certificate_statuses/" :ignored-but-required] []
+         (certificate-statuses ca-settings))
+    (GET ["/certificate/" :subject] [subject]
+         (handle-get-certificate subject ca-settings))
+    (comidi/context ["/certificate_request/" :subject]
+      (GET [""] [subject]
+           (handle-get-certificate-request subject ca-settings))
+      (PUT [""] [subject :as {body :body}]
+           (handle-put-certificate-request! subject body ca-settings)))
+    (GET ["/certificate_revocation_list/" :ignored-node-name] []
+         (handle-get-certificate-revocation-list ca-settings))))
 
 (schema/defn ^:always-validate
-  build-ring-handler
-  [ca-settings :- ca/CaSettings
-   puppet-version :- schema/Str]
-  (-> (routes ca-settings)
-      ;(liberator-dev/wrap-trace :header)           ; very useful for debugging!
-      (ringutils/wrap-with-puppet-version-header puppet-version)
-      (ringutils/wrap-response-logging)))
+  wrap-middleware
+  [handler puppet-version]
+  (-> handler
+    ;(liberator-dev/wrap-trace :header)           ; very useful for debugging!
+    (ringutils/wrap-with-puppet-version-header puppet-version)
+    (ringutils/wrap-response-logging)))

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -4,8 +4,7 @@
             [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.services.ca.certificate-authority-core :as core]
             [puppetlabs.services.protocols.ca :refer [CaService]]
-            [compojure.core :as compojure]
-            [me.raynes.fs :as fs]))
+            [puppetlabs.comidi :as comidi]))
 
 (tk/defservice certificate-authority-service
   CaService
@@ -20,7 +19,10 @@
      (log/info "CA Service adding a ring handler")
      (add-ring-handler
        this
-      (compojure/context path [] (core/build-ring-handler settings puppet-version))))
+       (-> (core/web-routes settings)
+           (#(comidi/context path %))
+           comidi/routes->handler
+           (core/wrap-middleware puppet-version))))
    context)
 
   (initialize-master-ssl!

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1,37 +1,37 @@
 (ns puppetlabs.services.master.master-core
   (:import (java.io FileInputStream))
-  (:require [compojure.core :as compojure]
-            [me.raynes.fs :as fs]
-            [puppetlabs.puppetserver.ringutils :as ringutils]))
+  (:require [me.raynes.fs :as fs]
+            [puppetlabs.puppetserver.ringutils :as ringutils]
+            [puppetlabs.comidi :as comidi]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
 
 (defn v2_0-routes
-  "Creates the compojure routes to handle the master's '/v2.0' routes."
+  "Creates the web routes to handle the master's '/v2.0' routes."
   [request-handler]
-  (compojure/routes
-    (compojure/GET "/environments" request
+  (comidi/routes
+    (comidi/GET "/environments" request
                    (request-handler request))))
 
 (defn legacy-routes
-  "Creates the compojure routes to handle the master's 'legacy' routes
+  "Creates the web routes to handle the master's 'legacy' routes
    - ie, any route without a version in its path (eg, /v2.0/whatever) - but
    excluding the CA-related endpoints, which are handled separately by the
    CA service."
   [request-handler]
-  (compojure/routes
-    (compojure/GET "/node/*" request
+  (comidi/routes
+    (comidi/GET ["/node/" :node] request
                    (request-handler request))
-    (compojure/GET "/facts/*" request
+    (comidi/GET ["/facts/" :node] request
                    (request-handler request))
-    (compojure/GET "/file_content/*" request
+    (comidi/GET ["/file_content/" [#".*" :rest]] request
                    (request-handler request))
-    (compojure/GET "/file_metadatas/*" request
+    (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
                    (request-handler request))
-    (compojure/GET "/file_metadata/*" request
+    (comidi/GET ["/file_metadata/" [#".*" :rest]] request
                    (request-handler request))
-    (compojure/GET "/file_bucket_file/*" request
+    (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
                    (request-handler request))
 
     ;; TODO: file_bucket_file request PUTs from Puppet agents currently use a
@@ -44,38 +44,30 @@
     ;; Content-Type to describe the input payload - see PUP-3812 for the core
     ;; Puppet work and SERVER-294 for the related Puppet Server work that
     ;; would be done.
-    (compojure/PUT "/file_bucket_file/*" request
+    (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
                    (request-handler (assoc request
                                            :content-type
                                            "application/octet-stream")))
 
-    (compojure/HEAD "/file_bucket_file/*" request
+    (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
                    (request-handler request))
-    (compojure/GET "/catalog/*" request
+
+    (comidi/GET ["/catalog/" :node] request
                    (request-handler request))
-    (compojure/POST "/catalog/*" request
+    (comidi/POST ["/catalog/" :node] request
                     (request-handler request))
-    (compojure/PUT "/report/*" request
+    (comidi/PUT ["/report/" :node] request
                    (request-handler request))
-    (compojure/GET "/resource_type/*" request
+    (comidi/GET ["/resource_type/" [#".*" :rest]] request
                    (request-handler request))
-    (compojure/GET "/resource_types/*" request
+    (comidi/GET ["/resource_types/" [#".*" :rest]] request
                    (request-handler request))
 
     ;; TODO: when we get rid of the legacy dashboard after 3.4, we should remove
     ;; this endpoint as well.  It makes more sense for this type of query to be
     ;; directed to PuppetDB.
-    (compojure/GET "/facts_search/*" request
+    (comidi/GET ["/facts_search/" [#".*" :rest]] request
                    (request-handler request))))
-
-(defn root-routes
-  "Creates all of the compojure routes for the master."
-  [request-handler]
-  (compojure/routes
-    (compojure/context "/v2.0" request
-                       (v2_0-routes request-handler))
-    (compojure/context "/:environment" [environment]
-                       (legacy-routes request-handler))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions
@@ -106,11 +98,19 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
-(defn build-ring-handler
-  "Creates the entire compojure application (all routes and middleware)."
-  [request-handler puppet-version]
-  {:pre [(fn? request-handler)]}
-  (-> (root-routes request-handler)
+(defn root-routes
+  "Creates all of the web routes for the master."
+  [request-handler]
+  (comidi/routes
+    (comidi/context "/v2.0"
+                     (v2_0-routes request-handler))
+    (comidi/context ["/" :environment]
+                     (legacy-routes request-handler))))
+
+(defn wrap-middleware
+  [handler puppet-version]
+  (-> handler
       ringutils/wrap-request-logging
       ringutils/wrap-response-logging
       (ringutils/wrap-with-puppet-version-header puppet-version)))
+

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -23,9 +23,9 @@
    CA service."
   [request-handler]
   (comidi/routes
-    (comidi/GET ["/node/" :node] request
+    (comidi/GET ["/node/" [#".*" :rest]] request
                    (request-handler request))
-    (comidi/GET ["/facts/" :node] request
+    (comidi/GET ["/facts/" [#".*" :rest]] request
                    (request-handler request))
     (comidi/GET ["/file_content/" [#".*" :rest]] request
                    (request-handler request))
@@ -54,11 +54,11 @@
     (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
                    (request-handler request))
 
-    (comidi/GET ["/catalog/" :node] request
+    (comidi/GET ["/catalog/" [#".*" :rest]] request
                    (request-handler request))
-    (comidi/POST ["/catalog/" :node] request
+    (comidi/POST ["/catalog/" [#".*" :rest]] request
                     (request-handler request))
-    (comidi/PUT ["/report/" :node] request
+    (comidi/PUT ["/report/" [#".*" :rest]] request
                    (request-handler request))
     (comidi/GET ["/resource_type/" [#".*" :rest]] request
                    (request-handler request))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -1,8 +1,10 @@
 (ns puppetlabs.services.master.master-core
-  (:import (java.io FileInputStream))
+  (:import (java.io FileInputStream)
+           (clojure.lang IFn))
   (:require [me.raynes.fs :as fs]
             [puppetlabs.puppetserver.ringutils :as ringutils]
-            [puppetlabs.comidi :as comidi]))
+            [puppetlabs.comidi :as comidi]
+            [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
@@ -107,8 +109,10 @@
     (comidi/context ["/" :environment]
                      (legacy-routes request-handler))))
 
-(defn wrap-middleware
-  [handler puppet-version]
+(schema/defn ^:always-validate
+  wrap-middleware :- IFn
+  [handler :- IFn
+   puppet-version :- schema/Str]
   (-> handler
       ringutils/wrap-request-logging
       ringutils/wrap-response-logging

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -38,8 +38,8 @@
 (defn build-ring-handler
   [settings puppet-version]
   (-> (web-routes settings)
-       (comidi/routes->handler)
-       (wrap-middleware puppet-version)))
+      (comidi/routes->handler)
+      (wrap-middleware puppet-version)))
 
 (defn wrap-with-ssl-client-cert
   "Wrap a compojure app so all requests will include the

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -1,7 +1,6 @@
 (ns puppetlabs.services.ca.certificate-authority-core-test
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.test :refer :all]
             [me.raynes.fs :as fs]
             [puppetlabs.ssl-utils.core :as utils]
@@ -11,7 +10,8 @@
             [puppetlabs.services.ca.certificate-authority-core :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [ring.mock.request :as mock]
-            [schema.test :as schema-test]))
+            [schema.test :as schema-test]
+            [puppetlabs.comidi :as comidi]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -34,6 +34,12 @@
 
 (def localhost-cert
   (utils/pem->cert (test-pem-file "localhost-cert.pem")))
+
+(defn build-ring-handler
+  [settings puppet-version]
+  (-> (web-routes settings)
+       (comidi/routes->handler)
+       (wrap-middleware puppet-version)))
 
 (defn wrap-with-ssl-client-cert
   "Wrap a compojure app so all requests will include the

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -2,9 +2,16 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.master.master-core :refer :all]
             [ring.mock.request :as mock]
-            [schema.test :as schema-test]))
+            [schema.test :as schema-test]
+            [puppetlabs.comidi :as comidi]))
 
 (use-fixtures :once schema-test/validate-schemas)
+
+(defn build-ring-handler
+  [request-handler puppet-version]
+  (-> (root-routes request-handler)
+      (comidi/routes->handler)
+      (wrap-middleware puppet-version)))
 
 (deftest test-master-routes
   (let [handler     (fn ([req] {:request req}))


### PR DESCRIPTION
This PR ports our web routing library over from compojure to comidi.  This will allow us to introspect our web routes for things like metrics, middleware, documentation, etc. in the future.
