### PR TITLE
(SERVER-545) Add ability to test Puppet 3.x agents

### DIFF
--- a/acceptance/nodes/redhat7-64m-64a.yaml
+++ b/acceptance/nodes/redhat7-64m-64a.yaml
@@ -1,0 +1,30 @@
+---
+HOSTS:
+  redhat7-64-1:
+    roles:
+    - agent
+    - master
+    hypervisor: vcloud
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+  redhat7-64-2:
+    roles:
+    - agent
+    hypervisor: vcloud
+    pe_dir: 
+    pe_ver: 
+    pe_upgrade_dir: 
+    pe_upgrade_ver: 
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/redhat-7-x86_64
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/acceptance/suites/pre_suite/puppet3_compat/00_setup_environment.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/00_setup_environment.rb
@@ -1,0 +1,2 @@
+step "Initialize Test Config"
+  PuppetServerExtensions.initialize_config options

--- a/acceptance/suites/pre_suite/puppet3_compat/10_install_release_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/10_install_release_repos.rb
@@ -1,0 +1,7 @@
+confine :except, :platform => ['windows']
+
+step "Setup Puppet Labs Release repositories" do
+  hosts.each do |host|
+    install_puppetlabs_release_repo host
+  end
+end

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -1,0 +1,21 @@
+case test_config[:puppetserver_install_type]
+when :package
+  step "Setup Puppet Server dev repository on the master." do
+    package_build_version = ENV['PACKAGE_BUILD_VERSION']
+    if package_build_version
+      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version
+    else
+      abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
+    end
+  end
+
+  puppet_build_version = test_config[:puppet_build_version]
+  if puppet_build_version
+    confine_block :except, :platform => ['windows'] do
+      step "Setup Puppet dev repository on the master." do
+        install_puppetlabs_dev_repo master, 'puppet-agent', puppet_build_version
+      end
+    end
+  end
+end
+

--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -1,0 +1,22 @@
+# Agent running on the master is current, not legacy.
+legacy_agents = agents.reject { |agent| agent == master }
+
+step "Install Legacy Puppet Agents."
+legacy_agents.each do |host|
+  platform = host.platform
+
+  puppet_version = ENV['PUPPET_LEGACY_VERSION']
+  if not puppet_version
+    fail "PUPPET_LEGACY_VERSION is not set, e.g. '3.7.5'"
+  end
+  install_package host, 'puppet', puppet_version
+end
+
+step "Install Puppet Server."
+make_env = {
+  "prefix"  => "/usr",
+  "confdir" => "/etc/",
+  "rundir"  => "/var/run/puppetserver",
+  "initdir" => "/etc/init.d",
+}
+install_puppet_server master, make_env

--- a/acceptance/suites/pre_suite/puppet3_compat/README.markdown
+++ b/acceptance/suites/pre_suite/puppet3_compat/README.markdown
@@ -1,0 +1,4 @@
+# Puppet 3 Compatibility
+
+This directory contains tests which exercises puppet 3 against puppet server
+2.0 which includes Puppet 4.

--- a/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
+++ b/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
@@ -1,0 +1,14 @@
+test_name "Testing Master/Agent backwards compatibility"
+
+# Agent running on the master is current, not legacy.
+legacy_agents = agents.reject { |agent| agent == master }
+
+step "Check that legacy agents have Puppet 3.x installed"
+on(legacy_agents, puppet("--version")) do
+  assert(stdout.start_with? "3.", "puppet --version does not start with major version 3.")
+end
+
+step "Check that Puppet Server has Puppet 4.x installed"
+on(master, puppet("--version")) do
+  assert(stdout.start_with? "4.", "puppet --version does not start with major version 4.")
+end

--- a/acceptance/suites/puppet3_tests/README.markdown
+++ b/acceptance/suites/puppet3_tests/README.markdown
@@ -1,0 +1,4 @@
+# Puppet 3 Compatibility
+
+This directory contains tests which exercises puppet 3 against puppet server
+2.0 which includes Puppet 4.

--- a/dev/scripts/server545_puppet3_compaitiblity.sh
+++ b/dev/scripts/server545_puppet3_compaitiblity.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+# This script is expected to be run with a PWD of the root of the puppet-server
+# project.
+
+
+# Puppet Server package version (from http://builds.puppetlabs.lan/puppetserver/)
+export PACKAGE_BUILD_VERSION='2.1.0.SNAPSHOT.2015.04.17T0057'
+# Legacy means pre-aio (4.0) in this case
+export PUPPET_LEGACY_VERSION='3.7.5'
+
+  # --post-suite acceptance/suites/post_suite_backwards_compatibility \
+bundle exec beaker \
+  --debug \
+  --root-keys \
+  --no-color \
+  --repo-proxy \
+  --preserve-hosts never \
+  --type aio \
+  --config acceptance/nodes/redhat7-64m-64a.yaml \
+  --pre-suite acceptance/suites/pre_suite/backwards_compatibility \
+  --tests acceptance/suites/backwards_compatibility/010_hello_world \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --helper acceptance/lib/helper.rb \
+  --options-file acceptance/config/beaker/options.rb \
+  --load-path acceptance/lib

--- a/dev/scripts/server545_puppet3_compatibility.sh
+++ b/dev/scripts/server545_puppet3_compatibility.sh
@@ -18,8 +18,8 @@ bundle exec beaker \
   --preserve-hosts never \
   --type aio \
   --config acceptance/nodes/redhat7-64m-64a.yaml \
-  --pre-suite acceptance/suites/pre_suite/backwards_compatibility \
-  --tests acceptance/suites/backwards_compatibility/010_hello_world \
+  --pre-suite acceptance/suites/pre_suite/puppet3_compat \
+  --tests acceptance/suites/puppet3_tests \
   --keyfile ~/.ssh/id_rsa-acceptance \
   --helper acceptance/lib/helper.rb \
   --options-file acceptance/config/beaker/options.rb \


### PR DESCRIPTION
Without this patch there is no location to add acceptance tests that exercise
Puppet 3.x agents against Puppet Server 2.0.  This patch addresses the problem
by creating a new suite that maps to a new Jenkins job.  The pre_suite for this
new job will install Puppet 3.x legacy agents specified by the
PUPPET_LEGACY_VERSION environment variable.