### PR TITLE
(maint) Pin 2.1.x against puppet-agent 1.0.0

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     # TODO: This build version needs to be updated to a released version
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "1166ad687883061f8f7133634144759d2b9eb37b")
+                         "PUPPET_BUILD_VERSION", "1.0.0")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
Without this patch the smoke tests are failing in the 2.1.x branch, presumably
because the pinned version of the puppet-agent dependency has been pruned from
the builds server.  This patch addresses the problem by pinning to 1.0.0 which
is a released version and should not be pruned.