### PR TITLE
(SERVER-541) Bump lein-ezbake dependency to 0.3.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -98,7 +98,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.3"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.4"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
This commit bumps the puppet-server lein-ezbake dependency to 0.3.4.
The primary change the new release has that Puppet Server is interested
in is quiet debug output by default during package installation.