### PR TITLE
(SERVER-571) Add puppet-agent libdir to ruby-load-path

### DIFF
--- a/acceptance/resources/environments/server571/manifests/site.pp
+++ b/acceptance/resources/environments/server571/manifests/site.pp
@@ -1,0 +1,3 @@
+node default {
+  include hiera_test
+}

--- a/acceptance/resources/environments/server571/modules/hiera_test/lib/hiera/backend/dummy_backend.rb
+++ b/acceptance/resources/environments/server571/modules/hiera_test/lib/hiera/backend/dummy_backend.rb
@@ -1,0 +1,11 @@
+Puppet.debug "Loaded dummy_backend! 8B06E7B6-8930-4CAB-B229-9A40A3F41AB8"
+class Hiera
+  module Backend
+   class Dummy_backend
+     def lookup(key, scope, order_override, resolution_type)
+       Puppet.debug "Lookup called! key=#{key} 8B06E7B6-8930-4CAB-B229-9A40A3F41AB8"
+       return "4EB0033A-FC4E-4D7D-9453-5A9938B6FF61"
+     end
+   end
+  end
+end

--- a/acceptance/resources/environments/server571/modules/hiera_test/manifests/init.pp
+++ b/acceptance/resources/environments/server571/modules/hiera_test/manifests/init.pp
@@ -1,0 +1,4 @@
+class hiera_test {
+  $foo=hiera('val', 'not set')
+  notify { "hiera value=$foo": }
+}

--- a/acceptance/resources/environments/server571/modules/hiera_test/metadata.json
+++ b/acceptance/resources/environments/server571/modules/hiera_test/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "jeffmccune-hiera_test",
+  "version": "0.1.0",
+  "author": "jeffmccune",
+  "summary": "Module for SERVER-571 investigation",
+  "license": "Apache-2.0",
+  "source": "https://github.com/jeffmccune/hiera_test",
+  "project_page": "https://github.com/jeffmccune/hiera_test",
+  "issues_url": "https://github.com/jeffmccune/hiera_test/issues",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
+}
+

--- a/acceptance/resources/files/server571/hiera.yaml
+++ b/acceptance/resources/files/server571/hiera.yaml
@@ -1,0 +1,3 @@
+--- 
+:backends:
+  - dummy

--- a/acceptance/suites/tests/020_regression_tests/SERVER-571_hiera_backends_in_modules.rb
+++ b/acceptance/suites/tests/020_regression_tests/SERVER-571_hiera_backends_in_modules.rb
@@ -1,0 +1,53 @@
+test_name "(SERVER-571) Test hiera backend plugins located in modules"
+
+# The way this "works" is that the user installs a module on the server, the
+# agent run synchronizes the module lib/ plugins to the [Puppet Installation
+# Layout][layout] `libdir` path of /opt/puppetlabs/puppet/cache/lib  The
+# master then loads the synchronized plugin file using a ruby `require` which
+# searches the $LOAD_PATH
+#
+# [layout]: http://goo.gl/BWyXpo
+
+this_file = __FILE__
+# The local directory where resources are located, e.g. an environment directory
+rsrc_dir = File.expand_path('../../../../resources', this_file)
+
+# The target directory to place whole environments.
+# e.g. /etc/puppetlabs/code/environments
+env_path = on(master, puppet("config print environmentpath")).stdout.chomp
+target_dir = env_path.split(master['pathseparator']).first
+
+scp_options = {}
+step "Install hiera_test module in server571 environment on the master"
+Dir.chdir("#{rsrc_dir}/environments") do
+  # Create /etc/puppetlabs/code/environments/server571
+  # so that agents can run against this environment to sync plugins
+  master.do_scp_to "server571", target_dir, scp_options
+end
+
+# Save the hiera configuration
+step "Save hiera_config file to restore in teardown"
+hiera_config = on(master, puppet('config print hiera_config')).stdout.chomp
+on(master, "cp -p #{hiera_config} #{hiera_config}.bak")
+
+step "Write hiera configuration that uses the backend from the module"
+Dir.chdir("#{rsrc_dir}/files/server571") do
+  master.do_scp_to "hiera.yaml", hiera_config, scp_options
+end
+
+teardown do
+  on(master, "mv -f #{hiera_config}.bak #{hiera_config}")
+end
+
+with_puppet_running_on(master, {}) do
+  step "Run puppet agent on the master to pluginsync the hiera backend"
+  agent_run_cmd = "agent --test --server #{master} --environment=server571"
+  on(master, puppet(agent_run_cmd), :acceptable_exit_codes => [0,2])
+
+  # Assert the hiera backend returns a value
+  step "Verify data from the hiera backend is in the compiled catalog"
+  on(master, puppet(agent_run_cmd), :acceptable_exit_codes => [0,2]) do |result|
+    assert_match /4EB0033A-FC4E-4D7D-9453-5A9938B6FF61/, result.stdout,
+      "The agent output should contain the value from the Hiera backend"
+  end
+end

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -2,7 +2,7 @@
 jruby-puppet: {
     # Where the puppet-agent dependency places puppet, facter, etc...
     # Puppet server expects to load Puppet from this location
-    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby]
+    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby, /opt/puppetlabs/puppet/cache/lib]
 
     # This setting determines where JRuby will look for gems.  It is also
     # used by the `puppetserver gem` command line tool.


### PR DESCRIPTION
Without this patch Hiera backend plugins distributed as modules are not
functioning as expected in Puppet Server 2.0.  The expected behavior is that
the plugin is usable in puppetserver after a successful agent run that has
synchronized plugins.

This patch addresses the problem by adding the
`/opt/puppetlabs/puppet/cache/lib` path to the ruby-load-path setting
which lines up with the [Puppet Installation Layout][layout].

[layout]: http://goo.gl/BWyXpo