### PR TITLE
(SERVER-545) Fix CI failure in post_suite log copy

### DIFF
--- a/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
+++ b/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
@@ -12,3 +12,9 @@ step "Check that Puppet Server has Puppet 4.x installed"
 on(master, puppet("--version")) do
   assert(stdout.start_with? "4.", "puppet --version does not start with major version 4.")
 end
+
+step "Check that the agent on the master runs against the master"
+with_puppet_running_on(master, {}) do
+  agent_cmd = puppet("agent --test --server #{master}")
+  on(master, agent_cmd, :acceptable_exit_codes => [0,2])
+end


### PR DESCRIPTION
Without this patch the post suite is failing in the new CI job created
as part of QENG-2227.  The post suite fails trying to copy the server
logs because the server has never started.  This patch addresses the
problem by doing a single agent run against the server, which was the
original behavior of the basic testtest file.