### PR TITLE
(SERVER-390) Acceptance test for foreground subcmd

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
@@ -20,7 +20,7 @@ timeout_cmd = "timeout -s INT #{timout_length} #{foreground_cmd}"
 expected_messages = {
   /Initializing the JRuby service/ => "JRuby didn't initialize",
   /Starting web server/ => "Expected web server to start",
-  /Finished creating JRubyPuppet instance 4 of 4/ => "Expected to find 4 JRubyPuppet instances",
+  /Puppet Server has successfully started and is now ready to handle requests/ => "puppetserver never finished starting",
   /Finished shutdown sequence/ => "Test ended without puppetserver shutting down gracefully"
 }
 

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
@@ -1,23 +1,15 @@
 test_name "Puppetserver 'foreground' subcommand tests."
 
-# --------------------------------------------------------------------------
-# This behavior needs to be baked into Beaker but is not yet. SERVER-79 tracks
-# the need to fix this once Beaker has been modified to make the paths to these
-# commands available.
-#
-if master.is_pe?
-  cli = "pe-puppetserver"
-else
-  cli = "puppetserver"
-end
-# --------------------------------------------------------------------------
+cli = "puppetserver"
+service = "puppetserver"
 
 # puppetserver seems to take about 45s to start up
 timout_length = "60s"
-foreground_cmd = "#{cli} foreground"
+foreground_cmd = "#{cli} foreground --debug"
 timeout_cmd = "timeout -s INT #{timout_length} #{foreground_cmd}"
 
 expected_messages = {
+  / DEBUG .*Debug logging enabled/ => "Debug logging isn't enabled",
   /Initializing the JRuby service/ => "JRuby didn't initialize",
   /Starting web server/ => "Expected web server to start",
   /Puppet Server has successfully started and is now ready to handle requests/ => "puppetserver never finished starting",
@@ -26,7 +18,7 @@ expected_messages = {
 
 # Start of test
 step "Stop puppetserver"
-on(master, puppet("resource service #{cli} ensure=stopped"))
+on(master, puppet("resource service #{service} ensure=stopped"))
 
 step "Run #{cli} with foreground subcommand, wait for #{timout_length}"
 on(master, timeout_cmd, :acceptable_exit_codes => [124]) do |result|
@@ -40,5 +32,5 @@ end
 
 teardown do
   step "Teardown: Start puppetserver again"
-  on(master, puppet("resource service #{cli} ensure=running"))
+  on(master, puppet("resource service #{service} ensure=running"))
 end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
@@ -1,0 +1,44 @@
+test_name "Puppetserver 'foreground' subcommand tests."
+
+# --------------------------------------------------------------------------
+# This behavior needs to be baked into Beaker but is not yet. SERVER-79 tracks
+# the need to fix this once Beaker has been modified to make the paths to these
+# commands available.
+#
+if master.is_pe?
+  cli = "pe-puppetserver"
+else
+  cli = "puppetserver"
+end
+# --------------------------------------------------------------------------
+
+# puppetserver seems to take about 45s to start up
+timout_length = "60s"
+foreground_cmd = "#{cli} foreground"
+timeout_cmd = "timeout -s INT #{timout_length} #{foreground_cmd}"
+
+expected_messages = {
+  /Initializing the JRuby service/ => "JRuby didn't initialize",
+  /Starting web server/ => "Expected web server to start",
+  /Finished creating JRubyPuppet instance 4 of 4/ => "Expected to find 4 JRubyPuppet instances",
+  /Finished shutdown sequence/ => "Test ended without puppetserver shutting down gracefully"
+}
+
+# Start of test
+step "Stop puppetserver"
+on(master, puppet("resource service #{cli} ensure=stopped"))
+
+step "Run #{cli} with foreground subcommand, wait for #{timout_length}"
+on(master, timeout_cmd, :acceptable_exit_codes => [124]) do |result|
+  assert_no_match(/error:/i, result.stderr, "Unexpected error running puppetserver!")
+
+  step "Check that #{cli} ran successfully and shutdown gracefully"
+  expected_messages.each do |message, explanation|
+    assert_match(message, result.stdout, explanation)
+  end
+end
+
+teardown do
+  step "Teardown: Start puppetserver again"
+  on(master, puppet("resource service #{cli} ensure=running"))
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -3,17 +3,7 @@ require 'puppetserver/acceptance/gem_utils'
 
 test_name "Puppetserver 'gem' subcommand tests."
 
-# --------------------------------------------------------------------------
-# This behavior needs to be baked into Beaker but is not yet. SERVER-79 tracks
-# the need to fix this once Beaker has been modified to make the paths to these
-# commands available.
-#
-if master.is_pe?
-  cli = "pe-puppetserver"
-else
-  cli = "puppetserver"
-end
-# --------------------------------------------------------------------------
+cli = "puppetserver"
 
 # define gems to test
 gems = ['nokogiri', 'excon']


### PR DESCRIPTION
The test starts up puppetserver with the `foreground` subcommand, kills it after 60s, and examines the output for some expected text.

I tested it with beaker like so:

```bash
export PACKAGE_BUILD_VERSION=2.0.0
export PUPPET_VERSION=1.0.0

bundle exec beaker \
  --debug \
  --root-keys \
  --repo-proxy \
  --preserve-hosts always \
  --type foss \
  --pre-suite acceptance/suites/pre_suite/foss \
  --config acceptance/config/beaker/jenkins/el-6-x86_64-mdca.cfg \
  --tests acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb \
  --helper acceptance/lib/helper.rb \
  --options-file acceptance/config/beaker/options.rb \
  --load-path acceptance/lib
```