### PR TITLE
(MAINT) Fix missed usages of renamed namespace

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -18,7 +18,7 @@
                        (.put "JARS_NO_REQUIRE" "true"))
         jruby-home   (.getJRubyHome jruby-config)
         load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir)
+                          (cons jruby-internal/ruby-code-dir)
                           (cons (str jruby-home "/lib/ruby/1.9"))
                           (cons (str jruby-home "/lib/ruby/shared"))
                           (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -7,7 +7,7 @@
 (defn new-jruby-main
   [config]
   (let [load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
-                          (cons jruby-puppet/ruby-code-dir))
+                          (cons jruby-internal/ruby-code-dir))
         gem-home     (get-in config [:jruby-puppet :gem-home])
         jruby-config (new RubyInstanceConfig)
         env          (doto (HashMap. (.getEnvironment jruby-config))


### PR DESCRIPTION
The alias was changed in the namespace declaration but a couple usages
were missed.