### PR TITLE
(SERVER-614) Initialize timeouts from ClientOptions

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/http_client_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 require 'puppet/server/http_client'
 require 'java'
-java_import com.puppetlabs.http.client.SimpleRequestOptions
 
 describe 'Puppet::Server::HttpClient' do
   let :client do
@@ -22,9 +21,7 @@ describe 'Puppet::Server::HttpClient' do
     end
 
     subject do
-      request_options = SimpleRequestOptions.new("http://i.love.ruby")
-      client.send(:configure_timeouts, request_options)
-      request_options
+      Puppet::Server::HttpClient.create_client_options
     end
 
     it 'then get_socket_timeout_milliseconds is 24' do

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -71,7 +71,6 @@ class Puppet::Server::HttpClient
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
     request_options.set_body(body)
-    configure_timeouts(request_options)
     response = self.class.client_post(request_options)
     ruby_response(response)
   end
@@ -83,7 +82,6 @@ class Puppet::Server::HttpClient
     request_options = RequestOptions.new(build_url(url))
     request_options.set_headers(headers)
     request_options.set_as(ResponseBodyType::TEXT)
-    configure_timeouts(request_options)
     response = self.class.client_get(request_options)
     ruby_response(response)
   end
@@ -96,8 +94,8 @@ class Puppet::Server::HttpClient
 
   private
 
-  def configure_timeouts(request_options)
-    settings = self.class.settings
+  def self.configure_timeouts(request_options)
+    settings = self.settings
 
     if settings.has_key?("http_connect_timeout_milliseconds")
       request_options.set_connect_timeout_milliseconds(settings["http_connect_timeout_milliseconds"])
@@ -151,9 +149,15 @@ class Puppet::Server::HttpClient
     result
   end
 
-  def self.create_client
+  def self.create_client_options
     client_options = ClientOptions.new
+    self.configure_timeouts(client_options)
     self.configure_ssl(client_options)
+    client_options
+  end
+
+  def self.create_client
+    client_options = create_client_options
     SyncHttpClient.createClient(client_options)
   end
 


### PR DESCRIPTION
This commit corrects a problem with the initialization of HTTP client
options which had been introduced by SERVER-530, the merge-up of
changes from 1.0.8 into the 2.1.x branch.  The merge-up had caused
HTTP requests to try to call the `setConnectTimeoutMilliseconds` and
`setIdleTimeoutMilliseconds` methods on the `RequestOptions` class.
`RequestOptions` does not support those methods; they can only
be configured at the client and not a per-request level.  To adjust
for this, this PR moves the invocation of the timeout methods to the
client level via `ClientOptions`.