### PR TITLE
(SERVER-564) Re-enable legacy Puppet status endpoint

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -64,6 +64,8 @@
                    (request-handler request))
     (comidi/GET ["/resource_types/" [#".*" :rest]] request
                    (request-handler request))
+    (comidi/GET ["/status/" [#".*" :rest]] request
+                   (request-handler request))
 
     ;; TODO: when we get rid of the legacy dashboard after 3.4, we should remove
     ;; this endpoint as well.  It makes more sense for this type of query to be

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -32,6 +32,7 @@
                    "file_bucket_file"
                    "resource_type"
                    "resource_types"
+                   "status"
                    "facts_search"]
              :post ["catalog"]
              :put ["file_bucket_file"


### PR DESCRIPTION
This commit re-enables the legacy Puppet Ruby status endpoint.  It
simply whitelists the endpoint in Puppet Server code so that the request
can be passed through to Ruby Puppet code.