### PR TITLE
(QENG-2385) Fix Puppet 3 Compatibility job for Deb platforms

### DIFF
--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -5,9 +5,15 @@ step "Install Legacy Puppet Agents."
 legacy_agents.each do |host|
   platform = host.platform
 
-  puppet_version = ENV['PUPPET_LEGACY_VERSION']
-  if not puppet_version
+  if not ENV['PUPPET_LEGACY_VERSION']
     fail "PUPPET_LEGACY_VERSION is not set, e.g. '3.7.5'"
+  else
+    if platform =~ /(ubuntu|debian|cumulus)/
+      # Recommendation from QE in QENG-2385
+      puppet_version = "#{ENV['PUPPET_LEGACY_VERSION']}-1puppetlabs1"
+    else
+      puppet_version = ENV['PUPPET_LEGACY_VERSION']
+    end
   end
   install_package host, 'puppet', puppet_version
 end


### PR DESCRIPTION
Without this patch the Puppet 3 Compatibility job is failing on Debian
platforms.  The root cause of this failure is that the underlying package
manager does not accept a version of `3.7.5`.  Working with QE, they recommend
we solve this issue by appending `-1puppetlabs1` to the version coming from the
PUPPET_LEGACY_VERSION environment variable, set by the Job parameters.  This
patch implements the recommendation.

I've verified the beaker command the job executes now passes successfully for
Ubuntu 14.04 hosts.