### PR TITLE
(QENG-2385) Use install_puppet to install puppet.

### DIFF
--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -2,6 +2,8 @@
 legacy_agents = agents.reject { |agent| agent == master }
 
 step "Install Legacy Puppet Agents."
+
+tmp_hosts = hosts
 legacy_agents.each do |host|
   platform = host.platform
 
@@ -9,8 +11,10 @@ legacy_agents.each do |host|
   if not puppet_version
     fail "PUPPET_LEGACY_VERSION is not set, e.g. '3.7.5'"
   end
-  install_package host, 'puppet', puppet_version
+  hosts = [host]
+  install_puppet({:version => puppet_version})
 end
+hosts = tmp_hosts
 
 step "Install Puppet Server."
 install_puppet_server master


### PR DESCRIPTION
As recommended by the Beaker developers.