### PR TITLE
(MAINT) Add simple beaker test run scripts.

### DIFF
--- a/acceptance/scripts/generic/testrun-full.sh
+++ b/acceptance/scripts/generic/testrun-full.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -x
+
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+
+export GENCONFIG_LAYOUT="${GENCONFIG_LAYOUT:-redhat6-64ma-debian6-64a-windows2008r2-64a}"
+export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/tests/00_smoke}"
+export BEAKER_PRESUITE="${BEAKER_PRESUITE:-acceptance/suites/pre_suite/foss}"
+export BEAKER_POSTSUITE="acceptance/suites/post_suite/"
+export BEAKER_OPTIONS="acceptance/config/beaker/options.rb"
+export BEAKER_CONFIG="acceptance/scripts/hosts.cfg"
+export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
+export BEAKER_HELPER="acceptance/lib/helper.rb"
+
+bundle install --path vendor/bundle
+
+bundle exec genconfig2 $GENCONFIG_LAYOUT > $BEAKER_CONFIG
+
+bundle exec beaker \
+  --config $BEAKER_CONFIG \
+  --type aio \
+  --helper $BEAKER_HELPER \
+  --options-file $BEAKER_OPTIONS \
+  --tests $BEAKER_TESTSUITE \
+  --post-suite $BEAKER_POSTSUITE \
+  --pre-suite $BEAKER_PRESUITE \
+  --keyfile $BEAKER_KEYFILE \
+  --load-path "acceptance/lib" \
+  --preserve-hosts always \
+  --debug \
+  --timeout 360

--- a/acceptance/scripts/generic/testrun-noprovision.sh
+++ b/acceptance/scripts/generic/testrun-noprovision.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -x
+
+# command line parameters
+export BEAKER_CONFIG="${2:-acceptance/scripts/hosts.cfg}"
+export BEAKER_TESTSUITE="${1:-acceptance/tests/}"
+
+export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
+export BEAKER_HELPER="acceptance/lib/helper.rb"
+export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
+
+bundle install --path vendor/bundle
+
+bundle exec beaker \
+  --config $BEAKER_CONFIG \
+  --type aio \
+  --helper $BEAKER_HELPER \
+  --tests $BEAKER_TESTSUITE \
+  --keyfile $BEAKER_KEYFILE \
+  --load-path "acceptance/lib" \
+  --preserve-hosts onfail \
+  --no-provision \
+  --no-validate \
+  --no-configure \
+  --debug \
+  --timeout 360

--- a/acceptance/scripts/test-full-puppet3compat.sh
+++ b/acceptance/scripts/test-full-puppet3compat.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+
+# command line parameters
+export GENCONFIG_LAYOUT="${1:-redhat6-64ma-debian6-64a-windows2008r2-64a}"
+export BEAKER_TESTSUITE="${2:-acceptance/suites/puppet3_tests}"
+export BEAKER_PRESUITE="acceptance/suites/pre_suite/puppet3_compat"
+
+bash ./acceptance/scripts/generic/testrun-full.sh

--- a/acceptance/scripts/test-noprovision-puppet3compat.sh
+++ b/acceptance/scripts/test-noprovision-puppet3compat.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+
+export BEAKER_TESTSUITE="acceptance/suites/puppet3_tests/"
+
+bash ./acceptance/scripts/generic/testrun-noprovisions.sh ${1:-}


### PR DESCRIPTION
These scripts are what I used to fix the puppet3compat presuite, I know there has been reservation expressed regarding the use of genconfig since it isn't yet open source but they probably generally need a little additional work anyway. Just opening the PR in case anyone is interested in an alternate approach that makes it quite a bit easier to test against different platforms.