### PR TITLE
(MAINT) Add 2.1.x to version string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.0")
 (def tk-jetty-version "1.3.0")
 (def ks-version "1.0.0")
-(def ps-version "2.1.0-SNAPSHOT")
+(def ps-version "2.1.0-2.1.x-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit adds "2.1.x" to the puppetserver project's name in
project.clj - resulting in 2.1.0-2.1.x-SNAPSHOT instead of
2.1.0-SNAPSHOT. The motivation for this change is that it appears
that with race conditions around the CI packaging jobs that
packages being built for the master branch, also currently using the
name 2.1.0-SNAPSHOT, end up being built with some artifacts from one
branch and some from another when the jobs are built around the same
time on the same machine. The inclusion of a branch name in the version
should allow for these to be unique per branch without forcing us to
commit to what the real next version needs to be for either branch.