### PR TITLE
(SERVER-545) 3x->4x compatibility acceptance tests

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -1,0 +1,22 @@
+def nonmaster_agents()
+  agents.reject { |agent| agent == master }
+end
+
+def apply_simmons_class(agent, master, studio, classname)
+  sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
+  create_remote_file(master, sitepp, <<SITEPP)
+class { 'simmons':
+  studio    => "#{studio}",
+  exercises => [#{classname}],
+}
+SITEPP
+  on(master, "chmod 644 #{sitepp}")
+  with_puppet_running_on(master, {"master" => {"autosign" => true}}) do
+    on(agent, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2])
+  end
+end
+
+def cleanup(studio)
+  on(agents, "rm -rf #{studio}")
+  on(hosts, 'rm -rf $(puppet config print vardir)')
+end

--- a/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/70_install_puppet.rb
@@ -1,10 +1,9 @@
-# Agent running on the master is current, not legacy.
-legacy_agents = agents.reject { |agent| agent == master }
+require 'puppetserver/acceptance/compat_utils'
 
 step "Install Legacy Puppet Agents."
 
 tmp_hosts = hosts
-legacy_agents.each do |host|
+nonmaster_agents().each do |host|
   platform = host.platform
 
   puppet_version = ENV['PUPPET_LEGACY_VERSION']

--- a/acceptance/suites/pre_suite/puppet3_compat/71_install_simmons_module.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/71_install_simmons_module.rb
@@ -1,0 +1,15 @@
+simmons_version = '0.3.1'
+
+step "Install nwolfe-simmons module #{simmons_version}" do
+  on(master, puppet("module install nwolfe-simmons --version #{simmons_version}"))
+end
+
+step "Configure file serving" do
+  fileserverconf = on(master, puppet("config print fileserverconfig")).stdout.chomp
+  create_remote_file(master, fileserverconf, <<FILESERVERCONF)
+[simmons_custom_mount_point]
+path /etc/puppetlabs/code/environments/production/modules/simmons/mount-point-files
+allow *
+FILESERVERCONF
+  on(master, "chmod 644 #{fileserverconf}")
+end

--- a/acceptance/suites/pre_suite/puppet3_compat/72_disable_authconf.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/72_disable_authconf.rb
@@ -1,0 +1,9 @@
+step "Disable auth.conf" do
+  authconf = on(master, puppet("config print rest_authconfig")).stdout.chomp
+  create_remote_file(master, authconf, <<AUTHCONF)
+path /
+auth any
+allow *
+AUTHCONF
+  on(master, "chmod 644 #{authconf}")
+end

--- a/acceptance/suites/pre_suite/puppet3_compat/80_configure_agents.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/80_configure_agents.rb
@@ -1,0 +1,13 @@
+require 'puppetserver/acceptance/compat_utils'
+
+step "Perform agent upgrade steps" do
+  step "Enable structured facts" do
+    on(agents, puppet("config set stringify_facts false --section agent"))
+  end
+end
+
+# Legacy agents have $ssldir under $vardir, and tests
+# need to be able to blow away $vardir after each run
+step "Relocate legacy agent $ssldir" do
+  on(nonmaster_agents(), puppet("config set ssldir \$confdir/ssl --section agent"))
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
@@ -1,0 +1,26 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'binary file resource'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::binary_file to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::binary_file')
+end
+
+step "Validate binary-file" do
+  md5 = on(agent, "openssl dgst -md5 #{studio}/binary-file | awk '{print $2}'").stdout.chomp
+  assert_equal('7cfc2db80222ef224d99648716cea8e4', md5)
+end
+
+step "Validate binary-file filebucket backup" do
+  old_md5 = on(agent, "openssl dgst -md5 #{studio}/binary-file-old | awk '{print $2}'").stdout.chomp
+  on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5} --server #{master}"))
+  diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
+  assert_equal(0, diff, 'binary-file was not backed up to filebucket')
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
@@ -1,0 +1,19 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'content file resource'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::content_file to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::content_file')
+end
+
+step "Validate content-file" do
+  contents = on(agent, "cat #{studio}/content-file").stdout.chomp
+  assert_equal('Static content defined in manifest', contents)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
@@ -1,0 +1,20 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'custom fact'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::custom_fact_output to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::custom_fact_output')
+end
+
+step "Validate custom-fact-output" do
+  expected = on(agent, "hostname").stdout.chomp
+  content = on(agent, "cat #{studio}/custom-fact-output").stdout.chomp
+  assert_equal(expected, content)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
@@ -1,0 +1,22 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'executable external fact'
+
+skip_test 'Executable external facts broken until PUP-4420'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::external_fact_output to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::external_fact_output')
+end
+
+step "Validate external-fact-output" do
+  expected = on(agent, "hostname").stdout.chomp
+  content = on(agent, "cat #{studio}/external-fact-output").stdout.chomp
+  assert_equal(expected, content)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
@@ -1,0 +1,19 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'binary file resource from custom mount point'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::mount_point_binary_file to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::mount_point_binary_file')
+end
+
+step "Validate mount-point-binary-file" do
+  md5 = on(agent, "openssl dgst -md5 #{studio}/mount-point-binary-file | awk '{print $2}'").stdout.chomp
+  assert_equal('4b392568e0c19886bf274663a63b7d18', md5)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
@@ -1,0 +1,19 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'source file resource from custom mount point'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::mount_point_source_file to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::mount_point_source_file')
+end
+
+step "Validate mount-point-source-file" do
+  contents = on(agent, "cat #{studio}/mount-point-source-file").stdout.chomp
+  assert_equal('File served from custom mount point', contents)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
@@ -1,0 +1,31 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'recursive directory file resource'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::recursive_directory to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::recursive_directory')
+end
+
+step "Validate recursive-directory" do
+  directory_exists = on(agent, "test -d #{studio}/recursive-directory").exit_code
+  assert_equal(0, directory_exists)
+
+  file1_contents = on(agent, "cat #{studio}/recursive-directory/file1").stdout.chomp
+  assert_equal('recursive file 1', file1_contents)
+
+  file2_contents = on(agent, "cat #{studio}/recursive-directory/file2").stdout.chomp
+  assert_equal('recursive file 2', file2_contents)
+
+  subdir_exists = on(agent, "test -d #{studio}/recursive-directory/subdir").exit_code
+  assert_equal(0, subdir_exists)
+
+  subfile_contents = on(agent, "cat #{studio}/recursive-directory/subdir/subfile").stdout.chomp
+  assert_equal('recursive subfile contents', subfile_contents)
+end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
@@ -1,0 +1,26 @@
+require 'puppetserver/acceptance/compat_utils'
+
+test_name 'source file resource'
+
+studio = "/tmp/simmons-studio-#{Process.pid}"
+agent = nonmaster_agents().first
+
+teardown do
+  cleanup(studio)
+end
+
+step "Apply simmons::source_file to agent(s)" do
+  apply_simmons_class(agent, master, studio, 'simmons::source_file')
+end
+
+step "Validate source-file" do
+  contents = on(agent, "cat #{studio}/source-file").stdout.chomp
+  assert_equal('Static source file contents', contents)
+end
+
+step "Validate source-file filebucket backup" do
+  old_md5 = on(agent, "openssl dgst -md5 #{studio}/source-file-old | awk '{print $2}'").stdout.chomp
+  on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5} --server #{master}"))
+  diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
+  assert_equal(0, diff, 'source-file was not backed up to filebucket')
+end

--- a/dev/scripts/server545_puppet3_compatibility.sh
+++ b/dev/scripts/server545_puppet3_compatibility.sh
@@ -5,7 +5,7 @@
 
 
 # Puppet Server package version (from http://builds.puppetlabs.lan/puppetserver/)
-export PACKAGE_BUILD_VERSION='2.1.0.SNAPSHOT.2015.04.17T0057'
+export PACKAGE_BUILD_VERSION='2.1.0.SNAPSHOT.2015.05.14T1222'
 # Legacy means pre-aio (4.0) in this case
 export PUPPET_LEGACY_VERSION='3.7.5'
 
@@ -15,7 +15,7 @@ bundle exec beaker \
   --root-keys \
   --no-color \
   --repo-proxy \
-  --preserve-hosts never \
+  --preserve-hosts onfail \
   --type aio \
   --config acceptance/config/beaker/jenkins/redhat7-64m-64a.cfg \
   --pre-suite acceptance/suites/pre_suite/puppet3_compat \


### PR DESCRIPTION
This commit adds a suite of acceptance tests using the nwolfe-simmons
module to exercise various parts of the master/server HTTP API.

----

module: https://github.com/nwolfe/puppet-simmons/tree/0.3.1