### PR TITLE
(SERVER-652) Changes to acceptance tests to support Windows

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -18,5 +18,8 @@ end
 
 def cleanup(studio)
   on(agents, "rm -rf #{studio}")
-  on(hosts, 'rm -rf $(puppet config print vardir)')
+  hosts.each do |host|
+    var_dir = on(host, puppet("config print vardir")).stdout.chomp
+    on(host, "rm -fr #{var_dir}")
+  end
 end

--- a/acceptance/suites/pre_suite/puppet3_compat/71_install_simmons_module.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/71_install_simmons_module.rb
@@ -1,4 +1,4 @@
-simmons_version = '0.3.1'
+simmons_version = '0.3.3'
 
 step "Install nwolfe-simmons module #{simmons_version}" do
   on(master, puppet("module install nwolfe-simmons --version #{simmons_version}"))

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'binary file resource'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('binary_file_test')
 
 teardown do
   cleanup(studio)
@@ -14,12 +14,12 @@ step "Apply simmons::binary_file to agent(s)" do
 end
 
 step "Validate binary-file" do
-  md5 = on(agent, "openssl dgst -md5 #{studio}/binary-file | awk '{print $2}'").stdout.chomp
+  md5 = on(agent, "md5sum #{studio}/binary-file | awk '{print $1}'").stdout.chomp
   assert_equal('7cfc2db80222ef224d99648716cea8e4', md5)
 end
 
 step "Validate binary-file filebucket backup" do
-  old_md5 = on(agent, "openssl dgst -md5 #{studio}/binary-file-old | awk '{print $2}'").stdout.chomp
+  old_md5 = on(agent, "md5sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
   on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5} --server #{master}"))
   diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
   assert_equal(0, diff, 'binary-file was not backed up to filebucket')

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'content file resource'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('content_file_test')
 
 teardown do
   cleanup(studio)

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'custom fact'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('custom_fact_output_test')
 
 teardown do
   cleanup(studio)

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
@@ -2,10 +2,13 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'executable external fact'
 
-skip_test 'Executable external facts broken until PUP-4420'
-
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+
+# This skip should be removed when executable external facts work for Puppet 4.x
+# on Linux-based platforms again (PUP-4420)
+skip_test unless agent['platform'] =~ /windows/
+
+studio = agent.tmpdir('external_fact_output_test')
 
 teardown do
   cleanup(studio)

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'binary file resource from custom mount point'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('mount_point_binary_file_test')
 
 teardown do
   cleanup(studio)
@@ -14,6 +14,6 @@ step "Apply simmons::mount_point_binary_file to agent(s)" do
 end
 
 step "Validate mount-point-binary-file" do
-  md5 = on(agent, "openssl dgst -md5 #{studio}/mount-point-binary-file | awk '{print $2}'").stdout.chomp
+  md5 = on(agent, "md5sum #{studio}/mount-point-binary-file | awk '{print $1}'").stdout.chomp
   assert_equal('4b392568e0c19886bf274663a63b7d18', md5)
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'source file resource from custom mount point'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('mount_point_source_file_test')
 
 teardown do
   cleanup(studio)

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'recursive directory file resource'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('recursive_directory_test')
 
 teardown do
   cleanup(studio)

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
@@ -2,8 +2,8 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'source file resource'
 
-studio = "/tmp/simmons-studio-#{Process.pid}"
 agent = nonmaster_agents().first
+studio = agent.tmpdir('source_file_test')
 
 teardown do
   cleanup(studio)
@@ -19,7 +19,7 @@ step "Validate source-file" do
 end
 
 step "Validate source-file filebucket backup" do
-  old_md5 = on(agent, "openssl dgst -md5 #{studio}/source-file-old | awk '{print $2}'").stdout.chomp
+  old_md5 = on(agent, "md5sum #{studio}/source-file-old | awk '{print $1}'").stdout.chomp
   on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5} --server #{master}"))
   diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
   assert_equal(0, diff, 'source-file was not backed up to filebucket')


### PR DESCRIPTION
This commit includes some changes to the Puppet 3.x acceptance tests to
support testing in a Windows environment.  These include:

1) Dynamically determine the temp directory to store synced simmons
   module content into.

2) Replace use of openssl with md5sum for performing md5 sums of files
   on the agent node.  md5sum is available on Windows nodes via cygwin.

3) Unskip external_fact_output_test for Windows since it is viable for
   Windows agents.