### PR TITLE
(SERVER-653) Skip foreground test on RHEL5

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
@@ -1,5 +1,9 @@
 test_name "Puppetserver 'foreground' subcommand tests."
 
+if (master['platform'] =~ /el-5/)
+  skip_test("RHEL5 is not supported by this test case. See SERVER-653")
+end
+
 cli = "puppetserver"
 service = "puppetserver"
 


### PR DESCRIPTION
The `timeout` command isn't available on RH5, so skip it