### PR TITLE
(SERVER-655) Fix Bouncy Castle jar load failure

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -9,7 +9,9 @@
     (.setEnvironment
       (hash-map
         "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
-        "JARS_NO_REQUIRE" "true"))
+        "JARS_NO_REQUIRE" "true"
+        "JARS_REQUIRE" "false"))
+    (.runScriptlet "require 'jar-dependencies'")
     (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))
 
 (defn -main

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -15,7 +15,8 @@
         gem-home     (get-in config [:jruby-puppet :gem-home])
         env          (doto (HashMap. (.getEnvironment jruby-config))
                        (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true"))
+                       (.put "JARS_NO_REQUIRE" "true")
+                       (.put "JARS_REQUIRE" "false"))
         jruby-home   (.getJRubyHome jruby-config)
         load-path    (->> (get-in config [:os-settings :ruby-load-path])
                           (cons jruby-internal/ruby-code-dir)
@@ -26,8 +27,9 @@
       (.setEnvironment env)
       (.setLoadPaths load-path)
       (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (-> (Main. jruby-config)
-        (.run args))))
+    (doto (Main. jruby-config)
+      (.run (into-array String ["-e" "require 'jar-dependencies'"]))
+      (.run args))))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -12,7 +12,8 @@
         jruby-config (new RubyInstanceConfig)
         env          (doto (HashMap. (.getEnvironment jruby-config))
                        (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true"))]
+                       (.put "JARS_NO_REQUIRE" "true")
+                       (.put "JARS_REQUIRE" "false"))]
     (doto jruby-config
       (.setEnvironment env)
       (.setLoadPaths load-path)
@@ -21,7 +22,8 @@
 
 (defn run!
   [config ruby-args]
-  (-> (new-jruby-main config)
+  (doto (new-jruby-main config)
+    (.run (into-array String ["-e" "require 'jar-dependencies'"]))
     (.run (into-array String ruby-args))))
 
 (defn -main

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -52,4 +52,5 @@
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
 
       ; $HOME and $PATH are left in by `jruby-puppet-env`
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE"} (set (keys jruby-env)))))))
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE"}
+            (set (keys jruby-env)))))))


### PR DESCRIPTION
This commit has changes which allow Puppet Server to boot without
JRuby's jopenssl trying to load its own Bouncy Castle jar.

Prior to JRuby 1.7.20, we set the JARS_NO_REQUIRE environment variable
onto the ScriptingContainer in order to instruct JRuby's
jar-dependencies to not try to load the Bouncy Castle jar - which we
intentionally exclude from the Puppet Server uberjar so that
'jvm-ssl-utils' can pull in its own version.

In JRuby 1.7.20's jopenssl, jar-dependencies was not being required
implicitly and so the JARS_NO_REQUIRE variable was ignored.  This
led Puppet Server to fail to boot because the Bouncy Castle jar
could not be loaded.

This commit has Puppet Server do an explicit require of
jar-dependencies so that the JARS_NO_REQUIRE variable can be honored
properly again.  It also sets JARS_REQUIRE, as that appears to be
the environment variable which jar-dependencies will eventually
replace JARS_NO_REQUIRE with.