### PR TITLE
(SERVER-647) Make master-{code,run,log}-dir settings optional

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -85,21 +85,21 @@
   initialize-config :- jruby-schemas/JRubyPuppetConfig
   [config :- {schema/Keyword schema/Any}]
   (-> (get-in config [:jruby-puppet])
-      (assoc :http-client-ssl-protocols
-             (get-in config [:http-client :ssl-protocols]))
-      (assoc :http-client-cipher-suites
-             (get-in config [:http-client :cipher-suites]))
-      (assoc :http-client-connect-timeout-milliseconds
-             (get-in config [:http-client :connect-timeout-milliseconds]
-                            default-http-connect-timeout))
-      (assoc :http-client-idle-timeout-milliseconds
-             (get-in config [:http-client :idle-timeout-milliseconds]
-                            default-http-socket-timeout))
-      (update-in [:borrow-timeout] #(or % default-borrow-timeout))
-      (update-in [:master-conf-dir] #(or % nil))
-      (update-in [:master-var-dir] #(or % nil))
-      (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
-      (update-in [:max-requests-per-instance] #(or % 0))))
+    (assoc :http-client-ssl-protocols
+      (get-in config [:http-client :ssl-protocols]))
+    (assoc :http-client-cipher-suites
+      (get-in config [:http-client :cipher-suites]))
+    (assoc :http-client-connect-timeout-milliseconds
+      (get-in config [:http-client :connect-timeout-milliseconds]
+        default-http-connect-timeout))
+    (assoc :http-client-idle-timeout-milliseconds
+      (get-in config [:http-client :idle-timeout-milliseconds]
+        default-http-socket-timeout))
+    (update-in [:borrow-timeout] #(or % default-borrow-timeout))
+    (update-in [:master-conf-dir] #(or % nil))
+    (update-in [:master-var-dir] #(or % nil))
+    (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
+    (update-in [:max-requests-per-instance] #(or % 0))))
 
 (schema/defn ^:always-validate
   create-pool-context :- jruby-schemas/PoolContext

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -98,6 +98,9 @@
     (update-in [:borrow-timeout] #(or % default-borrow-timeout))
     (update-in [:master-conf-dir] #(or % nil))
     (update-in [:master-var-dir] #(or % nil))
+    (update-in [:master-code-dir] #(or % nil))
+    (update-in [:master-run-dir] #(or % nil))
+    (update-in [:master-log-dir] #(or % nil))
     (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
     (update-in [:max-requests-per-instance] #(or % 0))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -5,6 +5,14 @@
 
 (use-fixtures :once schema-test/validate-schemas)
 
+(def min-config
+  {:product
+   {:name "puppet-server", :update-server-url "http://localhost:11111"},
+   :jruby-puppet
+   {:gem-home "./target/jruby-gem-home",
+    :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"]},
+   :certificate-authority {:certificate-status {:client-whitelist []}}})
+
 (deftest default-num-cpus-test
   (testing "1 jruby instance for a 1 or 2-core box"
     (is (= 1 (jruby-core/default-pool-size 1)))
@@ -19,3 +27,13 @@
     (is (= 4 (jruby-core/default-pool-size 16)))
     (is (= 4 (jruby-core/default-pool-size 32)))
     (is (= 4 (jruby-core/default-pool-size 64)))))
+
+(deftest initialize-config-test
+  (let [subject (fn [] (jruby-core/initialize-config min-config))]
+    (testing "master-{conf,var}-dir settings are optional"
+      (is (nil? (:master-conf-dir (subject))))
+      (is (nil? (:master-var-dir (subject)))))
+    (testing "(SERVER-647) master-{code,run,log}-dir settings are optional"
+      (is (nil? (:master-code-dir (subject))))
+      (is (nil? (:master-run-dir (subject))))
+      (is (nil? (:master-log-dir (subject)))))))


### PR DESCRIPTION
Without this patch puppetserver fails to start with with an uncaught exception
when these three settings are not defined.  This is a problem because these
settings are strictly necessary because they are defined in the underlying
puppet implementation.  This patch addresses the problem by settings the values
to nil which will cause puppetserver to consult puppet for the values.

The exception this fixes looks like:

    clojure.lang.ExceptionInfo: Output of initialize-config does not match schema:
    {:master-code-dir missing-required-key,
     :master-log-dir missing-required-key,
     :ruby-load-path missing-required-key,
     :master-run-dir missing-required-key}
    at puppetlabs.services.jruby.jruby_puppet_core$eval14631$initialize_config__14632.invoke (jruby_puppet_core.clj:84)
    ...