### PR TITLE
(SERVER-655) Fix Bouncy Castle cli command failure

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -4,14 +4,9 @@
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
 
-(defn run!
-  [config args]
-  (let [args         (into-array String
-                       (concat ["-e"
-                                "load 'META-INF/jruby.home/bin/irb'"
-                                "--"]
-                               args))
-        jruby-config (RubyInstanceConfig.)
+(defn new-jruby-main
+  [config]
+  (let [jruby-config (RubyInstanceConfig.)
         gem-home     (get-in config [:jruby-puppet :gem-home])
         env          (doto (HashMap. (.getEnvironment jruby-config))
                        (.put "GEM_HOME" gem-home)
@@ -19,17 +14,26 @@
                        (.put "JARS_REQUIRE" "false"))
         jruby-home   (.getJRubyHome jruby-config)
         load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-internal/ruby-code-dir)
-                          (cons (str jruby-home "/lib/ruby/1.9"))
-                          (cons (str jruby-home "/lib/ruby/shared"))
-                          (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
+                       (cons jruby-internal/ruby-code-dir)
+                       (cons (str jruby-home "/lib/ruby/1.9"))
+                       (cons (str jruby-home "/lib/ruby/shared"))
+                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
     (doto jruby-config
       (.setEnvironment env)
       (.setLoadPaths load-path)
       (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (doto (Main. jruby-config)
-      (.run (into-array String ["-e" "require 'jar-dependencies'"]))
-      (.run args))))
+    (Main. jruby-config)))
+
+(defn run!
+  [config ruby-args]
+  (doto (new-jruby-main config)
+    (.run (into-array String
+            (concat
+              ["-rjar-dependencies"
+               "-e"
+               "load 'META-INF/jruby.home/bin/irb'"
+               "--"]
+              ruby-args)))))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -6,14 +6,18 @@
 
 (defn new-jruby-main
   [config]
-  (let [load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                          (cons jruby-internal/ruby-code-dir))
+  (let [jruby-config (RubyInstanceConfig.)
         gem-home     (get-in config [:jruby-puppet :gem-home])
-        jruby-config (new RubyInstanceConfig)
         env          (doto (HashMap. (.getEnvironment jruby-config))
                        (.put "GEM_HOME" gem-home)
                        (.put "JARS_NO_REQUIRE" "true")
-                       (.put "JARS_REQUIRE" "false"))]
+                       (.put "JARS_REQUIRE" "false"))
+        jruby-home   (.getJRubyHome jruby-config)
+        load-path    (->> (get-in config [:os-settings :ruby-load-path])
+                       (cons jruby-internal/ruby-code-dir)
+                       (cons (str jruby-home "/lib/ruby/1.9"))
+                       (cons (str jruby-home "/lib/ruby/shared"))
+                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
     (doto jruby-config
       (.setEnvironment env)
       (.setLoadPaths load-path)
@@ -23,8 +27,8 @@
 (defn run!
   [config ruby-args]
   (doto (new-jruby-main config)
-    (.run (into-array String ["-e" "require 'jar-dependencies'"]))
-    (.run (into-array String ruby-args))))
+    (.run (into-array String
+            (cons "-rjar-dependencies" ruby-args)))))
 
 (defn -main
   [& args]


### PR DESCRIPTION
This commit adds onto the changes made in the first PR for SERVER-655.
In the first PR, the ruby subcommand was still errantly trying to load
the JRuby Bouncy Castle jar when a require was passed via a "-r" flag on
the command line.  The same behavior was not occurring for the irb
subcommand, though.  The difference was that the irb subcommand already
had logic to front load the Ruby load path with the list of libraries
that JRuby uses for loading its intenal libs.  One of those paths is the
path to jar-dependencies.  This commit addresses that and syncs up the
irb and ruby subcommands to basically have the same logic.