### PR TITLE
(maint) Remove legacy-service dependency on Master and CA for PE

### DIFF
--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -13,9 +13,7 @@
 (tk/defservice legacy-routes-service
   [[:WebroutingService add-ring-handler get-route]
    [:RequestHandlerService handle-request]
-   [:PuppetServerConfigService get-config]
-   [:MasterService]
-   [:CaService]]
+   [:PuppetServerConfigService get-config]]
   (init
     [this context]
     (let [path (get-route this)


### PR DESCRIPTION
Without this patch the legacy-routes-service specifies a dependency on the
master-service and the ca-service.  This is a problem because the
master-service is not implemented in Puppet Enterprise, instead the
pe-master-service is implemented.  This patch addresses the problem by removing
the dependency on the master service which will allow the legacy-service to
operate in PE.

The dependency is no longer necessary because the catch-all 404 handler has
been removed from the master-service which allows either service to handle
request before handing them to the other service.