### PR TITLE
(SERVER-324) Add support for flushing a single environment

### DIFF
--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -121,6 +121,14 @@
   (pprint/pprint
     (map puppet-environment-state (jruby-pool))))
 
+(defn mark-environment-expired!
+  "Mark the specified environment, on all JRuby instances, stale so that it will
+  be flushed from the environment cache."
+  [env-name]
+  (jruby-protocol/mark-environment-expired!
+    (tka/get-service system :JRubyPuppetService)
+    env-name))
+
 (defn mark-all-environments-expired!
   "Mark all environments, on all JRuby instances, stale so that they will
   be flushed from the environment cache."

--- a/documentation/admin-api/v1/environment-cache.markdown
+++ b/documentation/admin-api/v1/environment-cache.markdown
@@ -15,6 +15,14 @@ endpoint to the master's HTTP API:
 To trigger a complete invalidation of the data in this cache, make an HTTP
 request to this endpoint.
 
+### Query Parameters
+
+(Introduced in Puppet Server 1.1/2.2)
+
+This endpoint accepts an optional query parameter, `environment`, whose value
+may be set to the name of a specific Puppet environment.  If this parameter
+is provided, only the specified environment will be flushed from the cache,
+as opposed to all environments.
 
 ### Response
 
@@ -26,6 +34,9 @@ The response body will be empty.
 
 ~~~
 $ curl -i --cert <PATH TO CERT> --key <PATH TO KEY> --cacert <PATH TO PUPPET CA CERT> -X DELETE https://localhost:8140/puppet-admin-api/v1/environment-cache
+HTTP/1.1 204 No Content
+
+$ curl -i --cert <PATH TO CERT> --key <PATH TO KEY> --cacert <PATH TO PUPPET CA CERT> -X DELETE https://localhost:8140/puppet-admin-api/v1/environment-cache?environment=production
 HTTP/1.1 204 No Content
 ~~~
 

--- a/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
+++ b/src/clj/puppetlabs/puppetserver/ring/middleware/params.clj
@@ -91,3 +91,19 @@
     (if (:query-params request)
       request
       (assoc-query-params request encoding))))
+
+(defn wrap-params
+  "Middleware to parse urlencoded parameters from the query string and form
+  body (if the request is a url-encoded form). Adds the following keys to
+  the request map:
+  :query-params - a map of parameters from the query string
+  :form-params  - a map of parameters from the body
+  :params       - a merged map of all types of parameter
+  Accepts the following options:
+  :encoding - encoding to use for url-decoding. If not specified, uses
+              the request character encoding, or \"UTF-8\" if no request
+              character encoding is set."
+  {:arglists '([handler] [handler options])}
+  [handler & [options]]
+  (fn [request]
+    (handler (params-request request options))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -129,6 +129,15 @@
   @(:state jruby-puppet))
 
 (schema/defn ^:always-validate
+  mark-environment-expired!
+  [context :- jruby-schemas/PoolContext
+   env-name :- schema/Str]
+  (doseq [jruby-instance (pool->vec context)]
+    (-> jruby-instance
+      :environment-registry
+      (puppet-env/mark-environment-expired! env-name))))
+
+(schema/defn ^:always-validate
   mark-all-environments-expired!
   [context :- jruby-schemas/PoolContext]
   (doseq [jruby-instance (pool->vec context)]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -50,6 +50,11 @@
           pool         (core/get-pool pool-context)]
       (core/free-instance-count pool)))
 
+  (mark-environment-expired!
+    [this env-name]
+    (let [pool-context (:pool-context (tk-services/service-context this))]
+      (core/mark-environment-expired! pool-context env-name)))
+
   (mark-all-environments-expired!
     [this]
     (let [pool-context (:pool-context (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/jruby/puppet_environments.clj
+++ b/src/clj/puppetlabs/services/jruby/puppet_environments.clj
@@ -4,7 +4,8 @@
 
 (defprotocol EnvironmentStateContainer
   (environment-state [this])
-  (mark-all-environments-expired! [this]))
+  (mark-all-environments-expired! [this])
+  (mark-environment-expired! [this env-name]))
 
 (defn environment-registry
   []
@@ -36,4 +37,7 @@
       (environment-state [this] state)
       (mark-all-environments-expired! [this]
         (log/info "Marking all registered environments as expired.")
-        (swap! state mark-all-expired!)))))
+        (swap! state mark-all-expired!))
+      (mark-environment-expired! [this env-name]
+        (log/infof "Marking environment '%s' as expired." env-name)
+        (swap! state mark-expired! (keyword env-name))))))

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -20,6 +20,10 @@
     [this]
     "The number of free JRubyPuppet instances left in the pool.")
 
+  (mark-environment-expired!
+    [this env-name]
+    "Mark the specified environment expired, in all JRuby instances.")
+
   (mark-all-environments-expired!
     [this]
     "Mark all cached environments expired, in all JRuby instances.")

--- a/test/unit/puppetlabs/services/jruby/puppet_environments_test.clj
+++ b/test/unit/puppetlabs/services/jruby/puppet_environments_test.clj
@@ -32,6 +32,22 @@
       (is (true? (expired? reg :foo)))
       (is (true? (.isExpired reg "bar")))
       (is (true? (expired? reg :bar)))))
+  (testing "mark-environment-expired"
+    (let [reg (puppet-env/environment-registry)]
+      (.registerEnvironment reg "foo")
+      (.registerEnvironment reg "bar")
+      (is (false? (expired? reg :foo)))
+      (is (false? (expired? reg :bar)))
+      (puppet-env/mark-environment-expired! reg "foo")
+      (is (true? (.isExpired reg "foo")))
+      (is (true? (expired? reg :foo)))
+      (is (false? (.isExpired reg "bar")))
+      (is (false? (expired? reg :bar)))
+      (puppet-env/mark-environment-expired! reg "bar")
+      (is (true? (.isExpired reg "foo")))
+      (is (true? (expired? reg :foo)))
+      (is (true? (.isExpired reg "bar")))
+      (is (true? (expired? reg :bar)))))
   (testing "removing and re-registering an environment clears staleness"
     (let [reg (puppet-env/environment-registry)]
       (.registerEnvironment reg "foo")


### PR DESCRIPTION
This commit extends our existing functionality around flushing
the Puppet environment cache.  Prior to this commit, the only
granularity that we allowed the cache to be flushed at was effectively
global.  This commit introduces functions for flushing an
individual environment, wires those functions all the way up through
the JRubyService protocol, and extends the puppet-admin-api HTTP endpoint
to support passing in an environment name as a query parameter.