### PR TITLE
(SERVER-659) Restore broken http client timeout settings

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -105,7 +105,9 @@
    flush-instance-fn :- IFn
    profiler :- (schema/maybe PuppetProfiler)]
   (let [{:keys [ruby-load-path gem-home master-conf-dir master-var-dir
-                http-client-ssl-protocols http-client-cipher-suites]} config]
+                http-client-ssl-protocols http-client-cipher-suites
+                http-client-connect-timeout-milliseconds
+                http-client-idle-timeout-milliseconds]} config]
     (when-not ruby-load-path
       (throw (Exception.
                "JRuby service missing config value 'ruby-load-path'")))
@@ -125,7 +127,10 @@
         (.put puppet-server-config "cipher_suites" (into-array String http-client-cipher-suites)))
       (.put puppet-server-config "profiler" profiler)
       (.put puppet-server-config "environment_registry" env-registry)
-
+      (.put puppet-server-config "http_connect_timeout_milliseconds"
+        http-client-connect-timeout-milliseconds)
+      (.put puppet-server-config "http_idle_timeout_milliseconds"
+        http-client-idle-timeout-milliseconds)
       (let [instance (jruby-schemas/map->JRubyPuppetInstance
                        {:pool                 pool
                         :id                   id

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -49,7 +49,19 @@
         when https client requests are made.
 
     * :http-client-cipher-suites - A list of legal SSL cipher suites that may
-        be used when https client requests are made."
+        be used when https client requests are made.
+
+    * :http-client-connect-timeout-milliseconds - The amount of time, in
+        milliseconds, that an outbound HTTP connection will wait to connect
+        before giving up.  If 0, the timeout is infinite and if negative, the
+        value is undefined in the application and governed by the system default
+        behavior.
+
+    * :http-client-idle-timeout-milliseconds - The amount of time, in
+        milliseconds, that an outbound HTTP connection will wait for data to be
+        available after a request is sent before closing the socket.  If 0, the
+        timeout is infinite and if negative, the value is undefined by the
+        application and is governed by the default system behavior."
   ;; NOTE: there is a bug in the version of schema we're using, which causes
   ;; the order of things that you put into a `both` to be very important.
   ;; The `vector?` pred here MUST come before the `[schema/Str]`.  For more info

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
@@ -1,0 +1,34 @@
+(ns puppetlabs.services.jruby.jruby-puppet-internal-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils])
+  (:import (java.util.concurrent LinkedBlockingDeque)))
+
+  (deftest ^:integration settings-plumbed-into-jruby-container
+    (testing "setting plumbed into jruby container for"
+      (let [pool (LinkedBlockingDeque. 1)
+            config (jruby-testutils/jruby-puppet-config
+                     {:http-client-connect-timeout-milliseconds 2
+                      :http-client-idle-timeout-milliseconds 5
+                      :http-client-cipher-suites ["TLS_RSA_WITH_AES_256_CBC_SHA256"
+                                                  "TLS_RSA_WITH_AES_256_CBC_SHA"]
+                      :http-client-ssl-protocols ["TLSv1" "TLSv1.2"]})
+            instance (jruby-internal/create-pool-instance! pool 0 config #() nil)
+            container (:scripting-container instance)]
+        (try
+          (let [settings (into {} (.runScriptlet container
+                                    "java.util.HashMap.new
+                                       (Puppet::Server::HttpClient.settings)"))]
+            (testing "http_connect_timeout_milliseconds"
+              (is (= 2 (settings "http_connect_timeout_milliseconds"))))
+            (testing "http_idle_timeout_milliseconds"
+              (is (= 5 (settings "http_idle_timeout_milliseconds"))))
+            (testing "cipher_suites"
+              (is (= ["TLS_RSA_WITH_AES_256_CBC_SHA256"
+                      "TLS_RSA_WITH_AES_256_CBC_SHA"]
+                    (into [] (settings "cipher_suites")))))
+            (testing "ssl_protocols"
+              (is (= ["TLSv1" "TLSv1.2"]
+                    (into [] (settings "ssl_protocols"))))))
+          (finally
+            (.terminate container))))))


### PR DESCRIPTION
This commit restores the ability for connect and idle timeout settings
configured for Puppet Server to be honored for HTTP client requests.
The code to support these settings had previously been inadvertently
removed as part of some refactor work for SERVER-325.