### PR TITLE
(SERVER-649) Additionally test 4x->4x in compatibility tests

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -2,7 +2,7 @@ def nonmaster_agents()
   agents.reject { |agent| agent == master }
 end
 
-def apply_simmons_class(agent, master, studio, classname)
+def apply_simmons_class(agent, studio, classname)
   sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
   create_remote_file(master, sitepp, <<SITEPP)
 class { 'simmons':
@@ -16,10 +16,11 @@ SITEPP
   end
 end
 
-def cleanup(studio)
-  on(agents, "rm -rf #{studio}")
+def rm_vardirs()
+  # In order to prevent file caching and ensure agent-master HTTP communication
+  # during agent runs we blow away the vardirs, which contains the cached files
   hosts.each do |host|
-    var_dir = on(host, puppet("config print vardir")).stdout.chomp
-    on(host, "rm -fr #{var_dir}")
+    vardir = on(host, puppet("config print vardir")).stdout.chomp
+    on(host, "rm -rf #{vardir}")
   end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
@@ -2,25 +2,26 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'binary file resource'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('binary_file_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::binary_file to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::binary_file')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('binary_file_test')
 
-step "Validate binary-file" do
-  md5 = on(agent, "md5sum #{studio}/binary-file | awk '{print $1}'").stdout.chomp
-  assert_equal('7cfc2db80222ef224d99648716cea8e4', md5)
-end
+  step "Apply simmons::binary_file to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::binary_file')
+  end
 
-step "Validate binary-file filebucket backup" do
-  old_md5 = on(agent, "md5sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
-  on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5} --server #{master}"))
-  diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
-  assert_equal(0, diff, 'binary-file was not backed up to filebucket')
+  step "Validate binary-file" do
+    md5 = on(agent, "md5sum #{studio}/binary-file | awk '{print $1}'").stdout.chomp
+    assert_equal('7cfc2db80222ef224d99648716cea8e4', md5)
+  end
+
+  step "Validate binary-file filebucket backup" do
+    old_md5 = on(agent, "md5sum #{studio}/binary-file-old | awk '{print $1}'").stdout.chomp
+    on(agent, puppet("filebucket restore #{studio}/binary-file-backup #{old_md5} --server #{master}"))
+    diff = on(agent, "diff #{studio}/binary-file-old #{studio}/binary-file-backup").exit_code
+    assert_equal(0, diff, 'binary-file was not backed up to filebucket')
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
@@ -2,18 +2,19 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'content file resource'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('content_file_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::content_file to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::content_file')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('content_file_test')
 
-step "Validate content-file" do
-  contents = on(agent, "cat #{studio}/content-file").stdout.chomp
-  assert_equal('Static content defined in manifest', contents)
+  step "Apply simmons::content_file to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::content_file')
+  end
+
+  step "Validate content-file" do
+    contents = on(agent, "cat #{studio}/content-file").stdout.chomp
+    assert_equal('Static content defined in manifest', contents)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
@@ -2,19 +2,20 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'custom fact'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('custom_fact_output_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::custom_fact_output to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::custom_fact_output')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('custom_fact_output_test')
 
-step "Validate custom-fact-output" do
-  expected = on(agent, "hostname").stdout.chomp
-  content = on(agent, "cat #{studio}/custom-fact-output").stdout.chomp
-  assert_equal(expected, content)
+  step "Apply simmons::custom_fact_output to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::custom_fact_output')
+  end
+
+  step "Validate custom-fact-output" do
+    expected = on(agent, "hostname").stdout.chomp
+    content = on(agent, "cat #{studio}/custom-fact-output").stdout.chomp
+    assert_equal(expected, content)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
@@ -2,24 +2,24 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'executable external fact'
 
-agent = nonmaster_agents().first
-
-# This skip should be removed when executable external facts work for Puppet 4.x
-# on Linux-based platforms again (PUP-4420)
-skip_test unless agent['platform'] =~ /windows/
-
-studio = agent.tmpdir('external_fact_output_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::external_fact_output to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::external_fact_output')
-end
+agents.each do |agent|
+  # This skip should be removed when executable external facts work for Puppet 4.x
+  # on Linux-based platforms again (PUP-4420)
+  next unless agent.platform =~ /windows/
 
-step "Validate external-fact-output" do
-  expected = on(agent, "hostname").stdout.chomp
-  content = on(agent, "cat #{studio}/external-fact-output").stdout.chomp
-  assert_equal(expected, content)
+  studio = agent.tmpdir('external_fact_output_test')
+
+  step "Apply simmons::external_fact_output to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::external_fact_output')
+  end
+
+  step "Validate external-fact-output" do
+    expected = on(agent, "hostname").stdout.chomp
+    content = on(agent, "cat #{studio}/external-fact-output").stdout.chomp
+    assert_equal(expected, content)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
@@ -2,18 +2,19 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'binary file resource from custom mount point'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('mount_point_binary_file_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::mount_point_binary_file to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::mount_point_binary_file')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('mount_point_binary_file_test')
 
-step "Validate mount-point-binary-file" do
-  md5 = on(agent, "md5sum #{studio}/mount-point-binary-file | awk '{print $1}'").stdout.chomp
-  assert_equal('4b392568e0c19886bf274663a63b7d18', md5)
+  step "Apply simmons::mount_point_binary_file to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::mount_point_binary_file')
+  end
+
+  step "Validate mount-point-binary-file" do
+    md5 = on(agent, "md5sum #{studio}/mount-point-binary-file | awk '{print $1}'").stdout.chomp
+    assert_equal('4b392568e0c19886bf274663a63b7d18', md5)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
@@ -2,18 +2,19 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'source file resource from custom mount point'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('mount_point_source_file_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::mount_point_source_file to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::mount_point_source_file')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('mount_point_source_file_test')
 
-step "Validate mount-point-source-file" do
-  contents = on(agent, "cat #{studio}/mount-point-source-file").stdout.chomp
-  assert_equal('File served from custom mount point', contents)
+  step "Apply simmons::mount_point_source_file to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::mount_point_source_file')
+  end
+
+  step "Validate mount-point-source-file" do
+    contents = on(agent, "cat #{studio}/mount-point-source-file").stdout.chomp
+    assert_equal('File served from custom mount point', contents)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
@@ -2,30 +2,34 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'recursive directory file resource'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('recursive_directory_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::recursive_directory to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::recursive_directory')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('recursive_directory_test')
 
-step "Validate recursive-directory" do
-  directory_exists = on(agent, "test -d #{studio}/recursive-directory").exit_code
-  assert_equal(0, directory_exists)
+  step "Apply simmons::recursive_directory to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::recursive_directory')
+  end
 
-  file1_contents = on(agent, "cat #{studio}/recursive-directory/file1").stdout.chomp
-  assert_equal('recursive file 1', file1_contents)
+  step "Validate recursive-directory" do
+    directory_exists = on(agent, "test -d #{studio}/recursive-directory").exit_code
 
-  file2_contents = on(agent, "cat #{studio}/recursive-directory/file2").stdout.chomp
-  assert_equal('recursive file 2', file2_contents)
+    assert_equal(0, directory_exists)
 
-  subdir_exists = on(agent, "test -d #{studio}/recursive-directory/subdir").exit_code
-  assert_equal(0, subdir_exists)
+    file1_contents = on(agent, "cat #{studio}/recursive-directory/file1").stdout.chomp
 
-  subfile_contents = on(agent, "cat #{studio}/recursive-directory/subdir/subfile").stdout.chomp
-  assert_equal('recursive subfile contents', subfile_contents)
+    assert_equal('recursive file 1', file1_contents)
+
+    file2_contents = on(agent, "cat #{studio}/recursive-directory/file2").stdout.chomp
+    assert_equal('recursive file 2', file2_contents)
+
+
+    subdir_exists = on(agent, "test -d #{studio}/recursive-directory/subdir").exit_code
+    assert_equal(0, subdir_exists)
+
+    subfile_contents = on(agent, "cat #{studio}/recursive-directory/subdir/subfile").stdout.chomp
+    assert_equal('recursive subfile contents', subfile_contents)
+  end
 end

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
@@ -2,25 +2,26 @@ require 'puppetserver/acceptance/compat_utils'
 
 test_name 'source file resource'
 
-agent = nonmaster_agents().first
-studio = agent.tmpdir('source_file_test')
-
 teardown do
-  cleanup(studio)
+  rm_vardirs()
 end
 
-step "Apply simmons::source_file to agent(s)" do
-  apply_simmons_class(agent, master, studio, 'simmons::source_file')
-end
+agents.each do |agent|
+  studio = agent.tmpdir('source_file_test')
 
-step "Validate source-file" do
-  contents = on(agent, "cat #{studio}/source-file").stdout.chomp
-  assert_equal('Static source file contents', contents)
-end
+  step "Apply simmons::source_file to agent #{agent.platform}" do
+    apply_simmons_class(agent, studio, 'simmons::source_file')
+  end
 
-step "Validate source-file filebucket backup" do
-  old_md5 = on(agent, "md5sum #{studio}/source-file-old | awk '{print $1}'").stdout.chomp
-  on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5} --server #{master}"))
-  diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
-  assert_equal(0, diff, 'source-file was not backed up to filebucket')
+  step "Validate source-file" do
+    contents = on(agent, "cat #{studio}/source-file").stdout.chomp
+    assert_equal('Static source file contents', contents)
+  end
+
+  step "Validate source-file filebucket backup" do
+    old_md5 = on(agent, "md5sum #{studio}/source-file-old | awk '{print $1}'").stdout.chomp
+    on(agent, puppet("filebucket restore #{studio}/source-file-backup #{old_md5} --server #{master}"))
+    diff = on(agent, "diff #{studio}/source-file-old #{studio}/source-file-backup").exit_code
+    assert_equal(0, diff, 'source-file was not backed up to filebucket')
+  end
 end


### PR DESCRIPTION
This changes the tests to iterate over all agents instead of just the
legacy one, which means the 4.x agent on the master will now be tested
against the 4.x master the same way as the 3.x agents.