### PR TITLE
(MAINT) Updates to README_BRANCHING.md for 1.1/2.1 releases

### DIFF
--- a/README_BRANCHING.md
+++ b/README_BRANCHING.md
@@ -1,5 +1,5 @@
 This document attempts to capture the details of our branching strategy
-for Puppet Server.  This information is up-to-date as of 2015-04-29.
+for Puppet Server.  This information is up-to-date as of 2015-05-21.
 
 ## Puppet Server Branches
 
@@ -12,41 +12,27 @@ OSS Puppet Server releases.  These releases are compatible with Puppet 3.x.
 
 The `master` branch maps to the 2.x series of OSS Puppet Server releases.  The
 2.0 release is compatible with Puppet 4.x as part of Puppet Collection 1 (PC1).
-The 2.1 release and later are intended to be compatible with Puppet 3.x and
-Puppet 4.x.  Puppet 3.x is supported for remote agents only, only Puppet 4.x
-satisfies the package dependency between Puppet Server and Puppet.
+The forthcoming 2.1 release and later are intended to be compatible with Puppet
+3.x and Puppet 4.x.  Puppet 3.x is supported for remote agents only, only Puppet
+4.x satisfies the package dependency between Puppet Server and Puppet.
 
 ## Important Notes About Upcoming Releases
 
-At the time of this writing, we've just released OSS 2.0.0.  This release
-should be considered roughly equivalent to the Puppet Server 1.0.2 release in
-terms of functionality, and will largely only contain changes related to Puppet
-4.0 compatibility.
+At the time of this writing, we're preparing for the release of OSS 1.1.0 and
+2.1.0.  The two releases are intended to be roughly equivalent to each other
+in terms of functionality, with the primary differences being around support
+for Puppet 4.x compatibility in Puppet Server 2.1.  The 2.1.0 release will
+include a URL compatibility layer that will allow Puppet 3.x agents to talk to
+Puppet Server 2.x.  For more info, see https://tickets.puppetlabs.com/browse/SERVER-526.
 
-There will be a quick turnaround for a 2.1 release following the 2.0 release.
-This 2.1 release will be 2.0, plus the bugfixes in 1.0.8, plus a URL
-compatibility layer that will allow Puppet 3.x agents to talk to Puppet Server
-2.x (for more info see https://tickets.puppetlabs.com/browse/SERVER-526).
-There may be a few other changes included in the 2.1 release but only on a
-very limited basis.  A `2.1.x` branch has been created specifically for 2.1
-development.
-
-Some time following the release of 2.1, we'll do a 1.1 and 2.2 release,
-hopefully close to one another.  These will be the next major feature releases
-(as opposed to 2.0 and 2.1, which are mostly just compatibility releases), and 
-will contain several new features, tuning improvements, etc.
-
-As development toward the 1.1 and 2.1 releases proceeds, changes from the
-`stable` and `2.1.x` branches, respectively, should be merged up to the `master`
-branch.  Any changes that may be considered too risky or inappropriate to be
-included in either the 1.1 or 2.1 releases could be targeted at the `master`
-branch.
+The `stable` and `master` branches are essentially frozen with the exception of
+any critical fixes which would otherwise block delivery of the 1.1 and/or
+2.1 releases.
 
 In summary:
 
  * `stable` is for work to be done toward the 1.1 release.
- * `2.1.x` is for work to be done toward the 2.1 release.
- * `master` is for work to be done toward the 2.2 release.
+ * `master` is for work to be done toward the 2.1 release.
 
 ## "Normal" branching workflow
 


### PR DESCRIPTION
This commit contains some updates to the text in the
`README_BRANCHING.md` document related to the upcoming 1.1 and 2.2
releases.