### PR TITLE
(SERVER-657) Bump lein-ezbake dependency to 0.2.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -91,7 +91,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.2.9"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.2.10"]]
                       :name "puppetserver"}
 
              :uberjar {:aot [puppetlabs.trapperkeeper.main]}


### PR DESCRIPTION
This commit bumps the lein-ezbake dependency to version 0.2.10.  This is
needed in order to allow Puppet Server packaging to include an updated
version of the foreground command which allows the HOME environment
variable to be set for the puppet user when the foreground subcommand is
executed.  Without this change, attempts to execute the foreground
subcommand on Ubuntu could result in an inappropriate value for the
HOME environment variable being used.