### PR TITLE
(SERVER-625) Add Puppet 3 URL compatibility notes

### DIFF
--- a/documentation/compatibility_with_puppet_agent.markdown
+++ b/documentation/compatibility_with_puppet_agent.markdown
@@ -35,13 +35,13 @@ particular should be configured:
 # auth.conf
 
 The REST API URL structure has changed starting in Puppet 4.  The major change
-is the introduction of a versioned API rooted at `/puppet`.  In the general
-case a Puppet 3 URL can be translated to Puppet 4 by stripping off the
-environment name prefix, pre-pending `/puppet/v3`, and then adding back the
-environment name as a query parameter.  If `auth.conf` has been customized and
-Puppet Server 2.1 is going to be used with Puppet 3 agents then the Puppet 3
-requests need to be translated in this way and expressed in auth.conf in their
-Puppet 4 form.
+is the introduction of a versioned API rooted at `/puppet`, with the CA API
+separated out at `/puppet-ca`.  In the general case a Puppet 3 URL can be
+translated to Puppet 4 by stripping off the environment name prefix, pre-pending
+`/puppet/v3`, and then adding back the environment name as a query parameter.
+If `auth.conf` has been customized and Puppet Server 2.1 is going to be used
+with Puppet 3 agents then the Puppet 3 requests need to be translated in this
+way and expressed in auth.conf in their Puppet 4 form.
 
 For example, consider a customized deployment that uses UUID's to uniquely
 identify certificates, but omits the UUID from the node-name to facilitate

--- a/documentation/compatibility_with_puppet_agent.markdown
+++ b/documentation/compatibility_with_puppet_agent.markdown
@@ -1,0 +1,106 @@
+# Puppet 3 Backwards Compatibility
+
+Puppet Server 2.1 introduces a new feature that allows Puppet 3 agents to
+operate with puppetserver.  Puppet Server 1.x requires Puppet 3 while Puppet
+Server 2.x requires Puppet 4.  These requirements created a situation where
+only Puppet 4 agents operate with Puppet Server 2.0 masters.  We've added
+Puppet 3 support in Puppet Server 2.1 to ease the upgrade process for users.
+
+Compatibility is provided by a so-called `legacy-routes-service`.  This service
+intercepts all Puppet 3 REST API requests and transforms the URL structure and
+request headers into a Puppet 4 compatible request which is handled normally by
+the Puppet Master service.  The biggest implication of this implementation is
+that Puppet's `auth.conf` rules need special attention if they've been
+customized from their default values because all Puppet 3 requests have already
+been transformed into Puppet 4 requests by the time `auth.conf` rules are
+enforced.
+
+Other implications of this implementation are discrepancies in the request and
+response REST API headers.   These differences are worth noting, but should
+have no effect on typical deployments.
+
+# Configuration settings
+
+When operating Puppet 3 agents against Puppet Server 2.1, some configuration
+changes on the agents may be required ahead of time.  Two settings in
+particular should be configured:
+
+ * `stringify_facts = false` which is required with a Puppet 4 master.
+ * The master will operate with the future parser turned on, so if the future
+   parser is not being used with Puppet 3, please turn it on and try it out
+   before upgrading to Puppet Server 2.1.  Any incompatibilities between
+   existing Puppet code and the future parser should be resolved prior to
+   upgrading to Puppet Server 2.1.
+
+# auth.conf
+
+The REST API URL structure has changed starting in Puppet 4.  The major change
+is the introduction of a versioned API rooted at `/puppet`.  In the general
+case a Puppet 3 URL can be translated to Puppet 4 by stripping off the
+environment name prefix, pre-pending `/puppet/v3`, and then adding back the
+environment name as a query parameter.  If `auth.conf` has been customized and
+Puppet Server 2.1 is going to be used with Puppet 3 agents then the Puppet 3
+requests need to be translated in this way and expressed in auth.conf in their
+Puppet 4 form.
+
+For example, consider a customized deployment that uses UUID's to uniquely
+identify certificates, but omits the UUID from the node-name to facilitate
+de-provisioning and re-provisioning the same node identity using unique
+certificates.
+
+    # puppet.conf on the agent
+    [main]
+    certname = emanon.uuid.ec7f5196-7f63-5f73-f18d-ca69afc5c24d
+    node_name_value = emanon.uuid
+
+To support this configuration in Puppet 3 auth.conf has been customized as
+follows:
+
+    # Puppet 3 auth.conf on the master
+    path ~ ^/catalog/([^/]+).uuid$
+    method find
+    allow /^$1\.uuid.*/
+    # Default rule, should follow the more specific rules
+    path ~ ^/catalog/([^/]+)$
+    method find
+    allow $1
+
+This configuration will not work in Puppet Server 2 with Puppet 3 because of
+the translation to Puppet 4 format URL's.  A working configuration looks like
+so:
+
+    # Puppet 3 & 4 compatible auth.conf with Puppet Server 2.1
+    path ~ ^/puppet/v3/catalog/([^/]+).uuid$
+    method find
+    allow /^$1\.uuid.*/
+    # Default rule, should follow the more specific rules
+    path ~ ^/puppet/v3/catalog/([^/]+)$
+    method find
+    allow $1
+
+Note the `/puppet/v3` prefix of the path regular expression.  For more
+information about Puppet 3 and Puppet 4 API request and their differences
+please see the [HTTP API](https://docs.puppetlabs.com/guides/rest_api.html)
+documentation.  The default Puppet 4.1.0 auth.conf is located
+[here](https://github.com/puppetlabs/puppet/blob/4.1.0/conf/auth.conf) and the
+default Puppet 3.8.0 auth.conf is located
+[here](https://github.com/puppetlabs/puppet/blob/3.8.0/conf/auth.conf) for
+comparison.
+
+# HTTP Headers
+
+When Puppet Server 2.1 handles requests from Puppet 3 agents, there are some
+differences with respect to headers and "normal" Puppet 4 REST API requests.
+Specifically, the X-Puppet-Version header will not be present for Puppet 3
+requests which should only affect users relying on this header for advanced
+configuration of third party reverse proxies, e.g. HAProxy or NGINX.  In
+addition, the Accept: request header is munged in a manner suitable for use
+with content the Puppet 4 master service is able to provide.  Accept: raw and
+Accept: s are translated to Accept: binary as an example.  The munging of the
+Accept header should not affect any Puppet deployment because this header is
+rarely, if ever, used in advanced reverse proxy configurations with Puppet.
+Finally, the API request to obtain file bucket content is modified such that
+the content-type is treated as application/octet-stream internally in Puppet
+Server, but the request and the response are treated as text/plain for
+compatibility with Puppet 3.  This too should have no impact on any Puppet
+deployment.

--- a/documentation/compatibility_with_puppet_agent.markdown
+++ b/documentation/compatibility_with_puppet_agent.markdown
@@ -66,7 +66,7 @@ follows:
     allow $1
 
 This configuration will not work in Puppet Server 2 with Puppet 3 because of
-the translation to Puppet 4 format URL's.  A working configuration looks like
+the translation to Puppet 4 format URLs.  A working configuration looks like
 so:
 
     # Puppet 3 & 4 compatible auth.conf with Puppet Server 2.1

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -12,6 +12,7 @@ Puppet Server is the next-generation application for managing Puppet agents.
 * [Notable Differences vs. the Apache/Passenger Stack](./puppetserver_vs_passenger.markdown)
 * [Installation](./install_from_packages.markdown)
 * [Configuring Puppet Server](./configuration.markdown)
+* [Compatibility with Puppet Agent](./compatibility_with_puppet_agent.markdown)
 * [Differing Behavior in puppet.conf](./puppet_conf_setting_diffs.markdown)
 * [Subcommands](./subcommands.markdown)
 * [Using Ruby Gems](./gems.markdown)

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -1,21 +1,17 @@
 ---
 layout: default
 title: "Puppet Server 2.0: Release Notes"
-canonical: "/puppetserver/latest/release_notes.html"
+canonical: "/puppetserver/latest/release\_notes.html"
 ---
 
-## Puppet Server 2.0
+## Puppet Server 2.1
 
-In keeping with [semantic versioning][semver] practices, this release
-of Puppet Server introduces changes that break compatibility with
-Puppet 3.x agents. Please carefully read these release notes before
-attempting to upgrade your Puppet installation, as the locations of
-key files have moved, and changes to the Puppet Server API may require
-configuration changes.
+In keeping with [semantic versioning][semver] practices, this release of Puppet
+Server introduces changes that contain new backwards compatible functionality.
 
 ### Supported Platforms
 
-Puppet Server 2.0 ships for the following supported platforms:
+Puppet Server 2.1 ships for the following supported platforms:
 
  * Enterprise Linux 7
  * Enterprise Linux 6
@@ -23,127 +19,49 @@ Puppet Server 2.0 ships for the following supported platforms:
  * Ubuntu 12.04
  * Debian 7
 
-### What's New in Puppet Server 2.0 
+### What's New in Puppet Server 2.1
 
-#### Repository Location and Pre-Installation
+#### Backwards Compatibility with Puppet 3
 
-As with Puppet 4.0, Puppet Server 2.0 is now distributed via the new
-Puppet Collection repositories. Puppet Server 2.0 is part of Puppet
-Collection 1.
+Puppet Server 2.1 now supports both Puppet 4 and Puppet 3 agents.  This is new
+functionality compared to Puppet Server 2.0 which only supported Puppet 4
+agents.
 
-In order to install Puppet Server 2.0, you'll need to install a
-release package appropriate to your operating system. See the
-[Puppet 4 installation guide][pup4install] for information on how to
-prepare your system for installation, and specific installation
-instructions.
+Please see [Compatibility with Puppet
+Agent](./compatibility_with_puppet_agent.markdown) for more information.
 
-* [SERVER-524](https://tickets.puppetlabs.com/browse/SERVER-524) - Set
-  repo-target to PC1 for 2.0 release
+#### Flush JRuby after max-requests reached
 
-#### Changes to Library and File Locations
+Puppet Server 2.1 introduces a new feature that allows the JRuby containers and
+associated threads to be flushed and re-initialized after a configurable number
+of HTTP requests.  This functionality is similar to the PassengerMaxRequests
+functionality that is often tuned in Puppet+Passenger configurations.
 
-> **Note:** These changes affect your ability to upgrade
-> agents. Please consult the [Puppet installation layout][layout]
-> document for guidance on where to move files before upgrading.
-
-As part of the move to a unified all-in-one configuration layout, the
-locations of configuration files and directories has changed.
-
-Due to changes in the location of Ruby gems in Puppet Server 2.0,
-you'll need to move your SSL certificates and any extensions you've
-installed, as well. 
-
-* [SERVER-370](https://tickets.puppetlabs.com/browse/SERVER-370) -
-  Change ruby-load-path to /opt/puppetlabs/puppet/lib/ruby/vendor_ruby
-* [SERVER-371](https://tickets.puppetlabs.com/browse/SERVER-371) -
-  Change gem_home to /opt/puppetlabs/puppet/cache/jruby-gems
-* [SERVER-387](https://tickets.puppetlabs.com/browse/SERVER-387)-
-  Update puppet-server config directory
-* [SERVER-409](https://tickets.puppetlabs.com/browse/SERVER-409) -
-  Plumb confdir, vardir, codedir, logdir, rundir values
+Please see [SERVER-325](https://tickets.puppetlabs.com/browse/SERVER-325) and
+the [Tuning Guide](./tuning_guide.markdown) for more information.
 
 #### REST auth.conf
 
-As a result of the REST API URL changes between Puppet Server 1.x
-and 2.0, Puppet Server 1.x users who have modified their `auth.conf` will
-need to make changes when upgrading to Puppet Server 2.0.  See
-[SERVER-526](https://tickets.puppetlabs.com/browse/SERVER-526) for
-some additional information.
+As a result of the REST API URL changes between Puppet Server 1.x and 2.0,
+Puppet Server 2.1 users who have modified their `auth.conf` will need to make
+changes when using Puppet 3 agents with Puppet Server 2.1.  Please see
+[Compatibility with Puppet Agent](./compatibility_with_puppet_agent.markdown)
+for more information.
 
 These auth.conf changes follow the same changes required for any users
-upgrading from Puppet 3.x to Puppet 4.x. 
-
-#### Backwards Compatibility
-
-Puppet Server 2.0 is not backwards compatible with Puppet 3.x agents.
-Version 2.0 of Puppet Server is only compatible with Puppet 4.x
-agents. If upgrading all your agents and masters in concert will be a
-problem for you, please consider waiting until we release Puppet
-Server 2.1.
+upgrading from Puppet 3.x to Puppet 4.x.
 
 ### Known Issues
 
-#### Installing gems when Puppet Server is behind a proxy requires manual download of gems
-
-When a Puppet master must access the Internet via a proxy server, it
-is not possible to use the `puppetserver gem` command to install
-gems. To work around this issue until we release a fix:
-
-1. Use [rubygems.org](http://rubygems.org) to search for and download
-   the gem you want to install.
-2. Run the command `puppetserver gem install --local <PATH to GEM>`.
-
-* [SERVER-377](https://tickets.puppetlabs.com/browse/SERVER-377) -
-  `puppetserver gem` command doesn't work from behind a proxy server
+#### TBA
 
 ### Bug Fixes
 
-#### Puppet Server now reports when new versions are available.
-
-Due to a mismatch in naming conventions, Puppet Server was unable to
-report the availability of new versions. We've addressed this bug by
-adopting the increasing preference to eliminate hyphens from assorted
-project and package names.
-
-* [SERVER-520](https://tickets.puppetlabs.com/browse/SERVER-520) -
-  Apply artifact-id updates to version checks in master
-* [SERVER-457](https://tickets.puppetlabs.com/browse/SERVER-457) - Get
-  dujour working with Puppet Server 2.0.0 RC
-
-#### Fix inconsistent behavior around `always_cache_features` setting
-
-We've fixed a bug in puppetserver where always\_cache\_features was not always
-overridden because it could be changed in puppet.conf. The behavior is
-now explicitly managed in code rather than configuration.
-
-* [SERVER-410](https://tickets.puppetlabs.com/browse/SERVER-410) -
-  Explicitly override `always\_cache\_features` in puppetserver
-
-#### Fix unreliable puppetserver start behavior
-
-We've Fixed a bug where puppetserver was not starting reliably from
-the service management framework due to the "rundir" not being
-writable.
-
-* [SERVER-414](https://tickets.puppetlabs.com/browse/SERVER-414) -
-  Handle rundir creation for puppet and puppetserver in Puppet
-  Server 2.x
-
-#### Fix misleading silence from `puppetserver foreground` command 
-
-We've fixed a bug where the puppetserver foreground command would not
-produce any output, making it appear as if the command had not started
-or was stalled. The foreground command produces debugging output
-in 2.0.0.
-
-* [SERVER-356](https://tickets.puppetlabs.com/browse/SERVER-356) -
-  puppetserver foreground produces no output
+#### TBA
 
 ### All Changes
 
 For a list of all changes in this release, see this JIRA page:
-
-* [All Puppet Server issues targeted at this release](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.0.0%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
 
 [layout]: https://github.com/puppetlabs/puppet-specifications/blob/2818c90163837ae6a45eb070cf9f6edfb39a1e3f/file_paths.md
 [current-install-docs]: /guides/install_puppet/install_el.html


### PR DESCRIPTION
Without this patch the documentation directory the Docs team frequently looks
at doesn't have an information about the Puppet 3 URL compatibility feature we
added to Puppet Server 2.1.

This patch adds those documents, focusing on these things:

 * The actual structure of the URL
 * How `auth.conf` works with Puppet 3 agents
 * An example of a customized auth.conf

This patch also adds information about changes in 2.1, specifically the
`max-requests` feature added as SERVER-325.