### PR TITLE
(MAINT) Bump beaker dependency to 2.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.9.0')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.12.0')
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '~> 0.11'
   end


### PR DESCRIPTION
This commit bumps the beaker dependency to 2.12.0.