### PR TITLE
(MAINT) Add install options to 'install_dev_repos'

### DIFF
--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -1,6 +1,4 @@
-install_opts = {
-  :dev_builds_repos => ["PC1"],
-  :dev_builds_url => 'http://builds.delivery.puppetlabs.net'}
+install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
 repo_config_dir = 'tmp/repo_configs'
 
 case test_config[:puppetserver_install_type]

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -1,9 +1,15 @@
+install_opts = {
+  :dev_builds_repos => ["PC1"],
+  :dev_builds_url => 'http://builds.delivery.puppetlabs.net'}
+repo_config_dir = 'tmp/repo_configs'
+
 case test_config[:puppetserver_install_type]
 when :package
   step "Setup Puppet Server repositories." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version
+      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version,
+                                  repo_config_dir, install_opts
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end
@@ -15,7 +21,8 @@ if puppet_build_version
   confine_block :except, :platform => ['windows'] do
     step "Setup Puppet Labs Dev Repositories." do
       hosts.each do |host|
-        install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version
+        install_puppetlabs_dev_repo host, 'puppet-agent', puppet_build_version,
+                                    repo_config_dir, install_opts
       end
     end
   end

--- a/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/30_install_dev_repos.rb
@@ -1,9 +1,13 @@
+install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
+repo_config_dir = 'tmp/repo_configs'
+
 case test_config[:puppetserver_install_type]
 when :package
   step "Setup Puppet Server dev repository on the master." do
     package_build_version = ENV['PACKAGE_BUILD_VERSION']
     if package_build_version
-      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version
+      install_puppetlabs_dev_repo master, 'puppetserver', package_build_version,
+                                  repo_config_dir, install_opts
     else
       abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
     end
@@ -13,7 +17,8 @@ when :package
   if puppet_build_version
     confine_block :except, :platform => ['windows'] do
       step "Setup Puppet dev repository on the master." do
-        install_puppetlabs_dev_repo master, 'puppet-agent', puppet_build_version
+        install_puppetlabs_dev_repo master, 'puppet-agent', puppet_build_version,
+                                    repo_config_dir, install_opts
       end
     end
   end


### PR DESCRIPTION
This commit configures options explicitly for the
'30_install_dev_repos.rb' for package installs.  This was done
specifically to configure the use of the 'PC1' repo since this is
required for use with AIO testing.  The need for this change was
introduced by the beaker refactoring done for BKR-184 which removed PC1
from the default list of repos that beaker checks during installation.