### PR TITLE
(SERVER-683) Dynamically get master service for legacy route service

### DIFF
--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -21,7 +21,14 @@
           puppet-version (get-in config [:puppet-server :puppet-version])
           ca-settings (ca/config->ca-settings (get-config))
           ca-mount (get-route (tk-services/get-service this :CaService))
-          master-mount (master-service/get-master-path config)
+          master-ns (keyword (tk-services/service-symbol
+                               (tk-services/get-service this :MasterService)))
+          master-route-config (master-core/get-master-route-config
+                                master-ns
+                                config)
+          master-mount (master-core/get-master-mount
+                         master-ns
+                         master-route-config)
           master-handler (-> (master-core/root-routes handle-request)
                              (#(comidi/context path %))
                              comidi/routes->handler

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -1,12 +1,7 @@
 (ns puppetlabs.services.legacy-routes.legacy-routes-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-            [puppetlabs.trapperkeeper.core :as tk]
-            [puppetlabs.trapperkeeper.app :as tka]
-            [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.http.client.sync :as http-client]
-            [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.legacy-routes.legacy-routes-service :as legacy-routes-service]
             [puppetlabs.services.master.master-service :as master-service]
             [schema.test :as schema-test]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
@@ -44,7 +39,7 @@
     (logutils/with-test-logging
       (is (thrown-with-msg?
             IllegalArgumentException
-            #"Could not find a properly configured route for the master service"
+            #"Route not found for service .*master-service"
             (bootstrap/with-puppetserver-running app
                                                  {:web-router-service {::master-service/master-service {:foo "/bar"}}}
                                                  (is (= 200 (:status (http-get "/puppet/v3/node/localhost?environment=production"))))))))))


### PR DESCRIPTION
This commit changes the logic in the legacy-routes-service to get the
route of the master-service via the service protocol name rather than by
a hard-coded service name.  This allows for the legacy-routes-service to
pull the route from whatever service implementing the MasterService
protocol happens to be in the service stack, i.e., master-service for
OSS or pe-master-service for PE.