### PR TITLE
(MAINT) Update Puppet submodule tests for 4.1.0 acceptance test fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = https://github.com/puppetlabs/puppet.git
+	url = https://github.com/camlow325/puppet.git
 [submodule "ruby/facter"]
 	path = ruby/facter
 	url = https://github.com/puppetlabs/facter.git


### PR DESCRIPTION
This commit temporarily changes Puppet Server to point at a branch of
the core Puppet repo which is based on the Puppet 4.1.0 tag but with a
couple of changes to the acceptance tests which would otherwise cause
failures when the tests are run.  This should only be latest on the
master branch for a very short period of time, hopefully until the fixes
for the acceptance tests land in the core Puppet repo.

Changes on the acceptance test branch are:

* Cherry-picked fix for PUP-4652 for the
 `4420_pluginfacts_should_be_resolvable_on_agent.rb` test.

* Skipped broken `environment_scenario` tests documented in PUP-4659.