### PR TITLE
(SERVER-682) Restore 'scan=true' to logback xml files

### DIFF
--- a/dev/request-logging-dev.xml
+++ b/dev/request-logging-dev.xml
@@ -1,4 +1,4 @@
-<configuration scan="true" debug="false">
+<configuration debug="false" scan="true">
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>./target/logs/puppetserver-access.log</file>
     <encoder>

--- a/ezbake/config/logback.xml
+++ b/ezbake/config/logback.xml
@@ -1,4 +1,4 @@
-<configuration>
+<configuration scan="true">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -1,4 +1,4 @@
-<configuration debug="false">
+<configuration debug="false" scan="true">
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>/var/log/puppetserver/puppetserver-access.log</file>
     <encoder>


### PR DESCRIPTION
This commit restores the 'scan=true' attribute to the configuration
element in the logback and request-logging-dev xml files.  This had been
added previously as part of SERVER-275 but errantly lost in the
transition from ezbake to the lein-ezbake plugin between the Puppet
Server 1.0.2 and 1.0.8 releases.