### PR TITLE
(SERVER-297) Consolidate JRuby environment handling

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -1,0 +1,23 @@
+require 'test/unit/assertions'
+require 'json'
+
+test_name "Puppetserver subcommand consolidated ENV handling tests."
+
+step "ruby: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
+on(master, "puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
+  env = JSON.parse(stdout)
+  assert(env['PATH'], "PATH missing")
+  assert(env['HOME'], "HOME missing")
+  assert(env['GEM_HOME'], "GEM_HOME missing")
+  assert(env['JARS_REQUIRE'], "JARS_REQUIRE missing")
+  assert(env['JARS_NO_REQUIRE'], "JARS_NO_REQUIRE missing")
+end
+
+step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
+on(master, "puppetserver irb -f -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
+  assert_match(/\bPATH\b/, output, "PATH missing")
+  assert_match(/\bHOME\b/, output, "HOME missing")
+  assert_match(/\bGEM_HOME\b/, output, "GEM_HOME missing")
+  assert_match(/\bJARS_REQUIRE\b/, output, "JARS_REQUIRE missing")
+  assert_match(/\bJARS_NO_REQUIRE\b/, output, "JARS_NO_REQUIRE missing")
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -66,3 +66,6 @@ final_installed_gems = get_gem_list(master, "#{gem_list}")
 initial_installed_gems.each do |gem_info|
   assert_send([final_installed_gems, :include?, gem_info])
 end
+
+step "Verify that gem env operates"
+on(master, "#{cli} gem env", :acceptable_exit_codes => [0])

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -1,18 +1,10 @@
 (ns puppetlabs.puppetserver.cli.gem
-  (:import (org.jruby.embed ScriptingContainer))
-  (:require [puppetlabs.puppetserver.cli.subcommand :as cli]))
+  (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
   [config args]
-  (doto (ScriptingContainer.)
-    (.setArgv (into-array String args))
-    (.setEnvironment
-      (hash-map
-        "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
-        "JARS_NO_REQUIRE" "true"
-        "JARS_REQUIRE" "false"))
-    (.runScriptlet "require 'jar-dependencies'")
-    (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))
+  (jruby-core/cli-run! config "gem" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -1,39 +1,10 @@
 (ns puppetlabs.puppetserver.cli.irb
-  (:import (org.jruby Main RubyInstanceConfig CompatVersion)
-           (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
-
-(defn new-jruby-main
-  [config]
-  (let [jruby-config (RubyInstanceConfig.)
-        gem-home     (get-in config [:jruby-puppet :gem-home])
-        env          (doto (HashMap. (.getEnvironment jruby-config))
-                       (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true")
-                       (.put "JARS_REQUIRE" "false"))
-        jruby-home   (.getJRubyHome jruby-config)
-        load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
-                       (cons jruby-internal/ruby-code-dir)
-                       (cons (str jruby-home "/lib/ruby/1.9"))
-                       (cons (str jruby-home "/lib/ruby/shared"))
-                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
-    (doto jruby-config
-      (.setEnvironment env)
-      (.setLoadPaths load-path)
-      (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (Main. jruby-config)))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
-  [config ruby-args]
-  (doto (new-jruby-main config)
-    (.run (into-array String
-            (concat
-              ["-rjar-dependencies"
-               "-e"
-               "load 'META-INF/jruby.home/bin/irb'"
-               "--"]
-              ruby-args)))))
+  [config args]
+  (jruby-core/cli-run! config "irb" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -1,35 +1,7 @@
 (ns puppetlabs.puppetserver.cli.ruby
-  (:import (org.jruby Main RubyInstanceConfig CompatVersion)
-           (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
-
-(defn new-jruby-main
-  [config]
-  (let [jruby-config (RubyInstanceConfig.)
-        gem-home     (get-in config [:jruby-puppet :gem-home])
-        env          (doto (HashMap. (.getEnvironment jruby-config))
-                       (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true")
-                       (.put "JARS_REQUIRE" "false"))
-        jruby-home   (.getJRubyHome jruby-config)
-        load-path    (->> (get-in config [:jruby-puppet :ruby-load-path])
-                       (cons jruby-internal/ruby-code-dir)
-                       (cons (str jruby-home "/lib/ruby/1.9"))
-                       (cons (str jruby-home "/lib/ruby/shared"))
-                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
-    (doto jruby-config
-      (.setEnvironment env)
-      (.setLoadPaths load-path)
-      (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (Main. jruby-config)))
-
-(defn run!
-  [config ruby-args]
-  (doto (new-jruby-main config)
-    (.run (into-array String
-            (cons "-rjar-dependencies" ruby-args)))))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run jruby-core/cli-ruby! args))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -176,14 +176,15 @@
   [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
   (jruby-internal/return-to-pool instance))
 
-(schema/defn ^:always-validate cli-ruby!
+(schema/defn ^:always-validate cli-ruby! :- jruby-schemas/JRubyMainStatus
   "Run JRuby as though native `ruby` were invoked with args on the CLI"
   [config :- {schema/Keyword schema/Any}
    args :- [schema/Str]]
-  (doto (jruby-internal/new-main (initialize-config config))
-    (.run (into-array String (concat ["-rjar-dependencies"] args)))))
+  (let [main (jruby-internal/new-main (initialize-config config))
+        argv (into-array String (concat ["-rjar-dependencies"] args))]
+    (.run main argv)))
 
-(schema/defn ^:always-validate cli-run!
+(schema/defn ^:always-validate cli-run! :- jruby-schemas/JRubyMainStatus
   "Run a JRuby CLI command, e.g. gem, irb, etc..."
   [config :- {schema/Keyword schema/Any}
    command :- schema/Str

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -185,7 +185,7 @@
         argv (into-array String (concat ["-rjar-dependencies"] args))]
     (.run main argv)))
 
-(schema/defn ^:always-validate cli-run! :- jruby-schemas/JRubyMainStatusOrNil
+(schema/defn ^:always-validate cli-run! :- (schema/maybe jruby-schemas/JRubyMainStatus)
   "Run a JRuby CLI command, e.g. gem, irb, etc..."
   [config :- {schema/Keyword schema/Any}
    command :- schema/Str

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -190,3 +190,19 @@
   "Return a borrowed pool instance to its free pool."
   [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
   (jruby-internal/return-to-pool instance))
+
+(schema/defn ^:always-validate cli-ruby!
+  "Run JRuby as though native `ruby` were invoked with args on the CLI"
+  [config :- {schema/Keyword schema/Any}
+   args :- [schema/Str]]
+  (doto (jruby-internal/new-main (initialize-config config))
+    (.run (into-array String (concat ["-rjar-dependencies"] args)))))
+
+(schema/defn ^:always-validate cli-run!
+  "Run a JRuby CLI command, e.g. gem, irb, etc..."
+  [config :- {schema/Keyword schema/Any}
+   command :- schema/Str
+   args :- [schema/Str]]
+  (let [load-arg (format "load 'META-INF/jruby.home/bin/%s'" command)
+        load-args (concat ["-e" load-arg "--"] args)]
+    (cli-ruby! config load-args)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -42,21 +42,6 @@
   "/opt/puppetlabs/server/data/puppetserver")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Definitions
-
-(def jruby-puppet-env
-  "The environment variables that should be passed to the Puppet JRuby interpreters.
-  We don't want them to read any ruby environment variables, like $GEM_HOME or
-  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
-  Puppet needs HOME and PATH for facter resolution, so leave those."
-  (select-keys (System/getenv) ["HOME" "PATH"]))
-
-(def ruby-code-dir
-  "The name of the directory containing the ruby code in this project.
-  This directory lives under src/ruby/"
-  "puppet-server-lib")
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (defn default-pool-size

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -51,7 +51,8 @@
    :size size})
 
 (schema/defn ^:always-validate managed-environment :- {schema/Str schema/Str}
-  "The environment variables that should be passed to the Puppet JRuby interpreters.
+  "The environment variables that should be passed to the Puppet JRuby
+  interpreters.
 
   We don't want them to read any ruby environment variables, like $RUBY_LIB or
   anything like that, so pass it an empty environment map - except - Puppet

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -16,8 +16,17 @@
 ;;; Definitions
 
 (def ruby-code-dir
-  "The name of the directory containing the ruby code in this project."
-  "src/ruby/puppet-server-lib")
+  "The name of the directory containing the ruby code in this project.
+
+  This directory is relative to `src/ruby` and works from source because the
+  `src/ruby` directory is defined as a resource in `project.clj` which places
+  the directory on the classpath which in turn makes the directory available on
+  the JRuby load path.  Similarly, this works from the uberjar because this
+  directory is placed into the root of the jar structure which is on the
+  classpath.
+
+  See also:  http://jruby.org/apidocs/org/jruby/runtime/load/LoadService.html"
+  "puppet-server-lib")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -62,7 +71,7 @@
   (let [whitelist ["HOME" "PATH"]
         clean-env (select-keys env whitelist)]
     (assoc clean-env
-      "GEM_HOME" (fs/absolute-path gem-home)
+      "GEM_HOME" gem-home
       "JARS_NO_REQUIRE" "true"
       "JARS_REQUIRE" "false")))
 
@@ -73,15 +82,11 @@
   extensions extensions.  See SERVER-297 and SERVER-538 for more info."
   [ruby-load-path :- [schema/Str]
    jruby-home :- schema/Str]
-  (let [load-path (->> ruby-load-path
-                    (cons ruby-code-dir)
-                    (cons (str jruby-home "/lib/ruby/1.9"))
-                    (cons (str jruby-home "/lib/ruby/shared"))
-                    (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
-    (->> load-path
-      (map fs/absolute-path)
-      (map fs/normalized-path)
-      (map str))))
+  (->> ruby-load-path
+    (cons ruby-code-dir)
+    (cons (str jruby-home "/lib/ruby/1.9"))
+    (cons (str jruby-home "/lib/ruby/shared"))
+    (cons (str jruby-home "/lib/ruby/1.9/site_ruby"))))
 
 (defn prep-scripting-container
   [scripting-container ruby-load-path gem-home]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -80,7 +80,8 @@
                     (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
     (->> load-path
       (map fs/absolute-path)
-      (map fs/normalized-path))))
+      (map fs/normalized-path)
+      (map str))))
 
 (defn prep-scripting-container
   [scripting-container ruby-load-path gem-home]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -28,6 +28,16 @@
   See also:  http://jruby.org/apidocs/org/jruby/runtime/load/LoadService.html"
   "puppet-server-lib")
 
+(def compile-mode
+  "The JRuby compile mode to use for all ruby components, e.g. the master
+  service and CLI tools."
+  RubyInstanceConfig$CompileMode/OFF)
+
+(def compat-version
+  "The JRuby compatibility version to use for all ruby components, e.g. the
+  master service and CLI tools."
+  (CompatVersion/RUBY1_9))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
@@ -77,10 +87,11 @@
 
 (defn prep-scripting-container
   [scripting-container ruby-load-path gem-home]
+  ; Note, this behavior should remain consistent with new-main
   (doto scripting-container
     (.setLoadPaths (managed-load-path ruby-load-path))
-    (.setCompatVersion (CompatVersion/RUBY1_9))
-    (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
+    (.setCompatVersion compat-version)
+    (.setCompileMode compile-mode)
     (.setEnvironment (managed-environment (get-system-env) gem-home))))
 
 (defn empty-scripting-container
@@ -288,8 +299,10 @@
   [config :- jruby-schemas/JRubyPuppetConfig]
   (let [jruby-config (RubyInstanceConfig.)
         {:keys [ruby-load-path gem-home]} config]
+    ; Note, this behavior should remain consistent with prep-scripting-container
     (doto jruby-config
-      (.setEnvironment (managed-environment (get-system-env) gem-home))
       (.setLoadPaths (managed-load-path ruby-load-path))
-      (.setCompatVersion (CompatVersion/RUBY1_9)))
+      (.setCompatVersion compat-version)
+      (.setCompileMode compile-mode)
+      (.setEnvironment (managed-environment (get-system-env) gem-home)))
     (Main. jruby-config)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -290,6 +290,6 @@
         {:keys [ruby-load-path gem-home]} config]
     (doto jruby-config
       (.setEnvironment (managed-environment (get-system-env) gem-home))
-      (.setLoadPaths (managed-load-path ruby-load-path jruby-home))
+      (.setLoadPaths (managed-load-path ruby-load-path))
       (.setCompatVersion (CompatVersion/RUBY1_9)))
     (Main. jruby-config)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -41,7 +41,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
-(schema/defn get-system-env :- {schema/Str schema/Str}
+(schema/defn get-system-env :- jruby-schemas/EnvPersistentMap
   "Same as System/getenv, but returns a clojure persistent map instead of a
   Java unmodifiable map."
   []
@@ -53,7 +53,7 @@
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
   (LinkedBlockingDeque. size))
 
-(schema/defn ^:always-validate managed-environment :- {schema/Str schema/Str}
+(schema/defn ^:always-validate managed-environment :- jruby-schemas/EnvMap
   "The environment variables that should be passed to the Puppet JRuby
   interpreters.
 
@@ -70,7 +70,7 @@
   being phased out in favor of JARS_REQUIRE.  As of JRuby 1.7.20, only
   JARS_NO_REQUIRE is honored.  Setting both of those here for forward
   compatibility."
-  [env :- {schema/Str schema/Str}
+  [env :- jruby-schemas/EnvMap
    gem-home :- schema/Str]
   (let [whitelist ["HOME" "PATH"]
         clean-env (select-keys env whitelist)]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -4,6 +4,7 @@
   (:import (java.util.concurrent BlockingDeque)
            (clojure.lang Atom Agent IFn)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
+           (org.jruby Main)
            (org.jruby.embed ScriptingContainer)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -153,6 +154,10 @@
   [x]
   (instance? JRubyPuppetInstance x))
 
+(defn jruby-main-instance?
+  [x]
+  (instance? Main x))
+
 (defn poison-pill?
   [x]
   (instance? PoisonPill x))
@@ -172,3 +177,5 @@
                         retry-poison-pill?
                         jruby-puppet-instance?)))
 
+(def JRubyMain
+  (schema/pred jruby-main-instance?))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -186,7 +186,3 @@
 
 (def JRubyMainStatus
   (schema/pred jruby-main-status-instance?))
-
-(def JRubyMainStatusOrNil
-  (schema/either JRubyMainStatus
-    (schema/pred nil? 'nil?)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -4,7 +4,7 @@
   (:import (java.util.concurrent BlockingDeque)
            (clojure.lang Atom Agent IFn)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
-           (org.jruby Main)
+           (org.jruby Main Main$Status)
            (org.jruby.embed ScriptingContainer)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -158,6 +158,10 @@
   [x]
   (instance? Main x))
 
+(defn jruby-main-status-instance?
+  [x]
+  (instance? Main$Status x))
+
 (defn poison-pill?
   [x]
   (instance? PoisonPill x))
@@ -179,3 +183,6 @@
 
 (def JRubyMain
   (schema/pred jruby-main-instance?))
+
+(def JRubyMainStatus
+  (schema/pred jruby-main-status-instance?))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env])
   (:import (java.util.concurrent BlockingDeque)
-           (clojure.lang Atom Agent IFn)
+           (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
            (org.jruby Main Main$Status)
            (org.jruby.embed ScriptingContainer)))
@@ -186,3 +186,12 @@
 
 (def JRubyMainStatus
   (schema/pred jruby-main-status-instance?))
+
+(def EnvMap
+  "System Environment variables have strings for the keys and values of a map"
+  {schema/Str schema/Str})
+
+(def EnvPersistentMap
+  "Schema for a clojure persistent map for the system environment"
+  (schema/both EnvMap
+    (schema/either PersistentArrayMap PersistentHashMap)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -186,3 +186,7 @@
 
 (def JRubyMainStatus
   (schema/pred jruby-main-status-instance?))
+
+(def JRubyMainStatusOrNil
+  (schema/either JRubyMainStatus
+    (schema/pred nil? 'nil?)))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core-test
   (:require [clojure.test :refer :all]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core])
+  (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -12,6 +13,40 @@
    {:gem-home "./target/jruby-gem-home",
     :ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"]},
    :certificate-authority {:certificate-status {:client-whitelist []}}})
+
+(defmacro with-stdin-str
+  "Evaluates body in a context in which System/in is bound to a fresh
+  input stream initialized with the string s.  The return value of evaluating
+  body is returned."
+  [s & body]
+  `(let [system-input# (System/in)
+         string-input# (new ByteArrayInputStream (.getBytes ~s))]
+     (try
+       (System/setIn string-input#)
+       ~@body
+       (finally (System/setIn system-input#)))))
+
+(defmacro capture-out
+  "capture System.out and return it as the value of :out in the return map.
+  The return value of body is available as :return in the return map.
+
+  This macro is intended to be used for JRuby interop.  Please see with-out-str
+  for an idiomatic clojure equivalent.
+
+  This macro is not thread safe."
+  [& body]
+  `(let [return-map# (atom {})
+         system-output# (System/out)
+         captured-output# (new ByteArrayOutputStream)
+         capturing-print-stream# (new PrintStream captured-output#)]
+     (try
+       (System/setOut capturing-print-stream#)
+       (swap! return-map# assoc :return (do ~@body))
+       (finally
+         (.flush capturing-print-stream#)
+         (swap! return-map# assoc :out (.toString captured-output#))
+         (System/setOut system-output#)))
+     @return-map#))
 
 (deftest default-num-cpus-test
   (testing "1 jruby instance for a 1 or 2-core box"
@@ -37,3 +72,53 @@
       (is (= "/etc/puppetlabs/code" (:master-code-dir (subject))))
       (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir (subject))))
       (is (= "/var/log/puppetlabs/puppetserver" (:master-log-dir (subject)))))))
+
+(deftest ^:integration cli-run!-test
+  (testing "jruby cli command output"
+    (testing "gem env (SERVER-262)"
+      (let [m (capture-out (jruby-core/cli-run! min-config "gem" ["env"]))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        ; The choice of SHELL PATH is arbitrary, just need something to scan for
+        (is (re-find #"SHELL PATH:" out))))
+    (testing "gem list"
+      (let [m (capture-out (jruby-core/cli-run! min-config "gem" ["list"]))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        ; The choice of json is arbitrary, just need something to scan for
+        (is (re-find #"\bjson\b" out))))
+    (testing "irb"
+      (let [m (capture-out
+                (with-stdin-str "puts %{HELLO}"
+                  (jruby-core/cli-run! min-config "irb" ["-f"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"\nHELLO\n" out)))
+      (let [m (capture-out
+                (with-stdin-str "Kernel.exit(42)"
+                  (jruby-core/cli-run! min-config "irb" ["-f"])))
+            {:keys [return _]} m
+            exit-code (.getStatus return)]
+        (is (= 42 exit-code))))
+    (testing "irb with -r puppet"
+      (let [m (capture-out
+                (with-stdin-str "puts %{VERSION: #{Puppet.version}}"
+                  (jruby-core/cli-run! min-config "irb" ["-r" "puppet" "-f"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))))
+
+(deftest ^:integration cli-ruby!-test
+  (testing "jruby cli command output"
+    (testing "ruby -r puppet"
+      (let [m (capture-out
+                (with-stdin-str "puts %{VERSION: #{Puppet.version}}"
+                  (jruby-core/cli-ruby! min-config ["-r" "puppet"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -110,7 +110,9 @@
             {:keys [return out]} m
             exit-code (.getStatus return)]
         (is (= 0 exit-code))
-        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))))
+        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))
+    (testing "non existing subcommand returns nil"
+      (is (nil? (jruby-core/cli-run! min-config "doesnotexist" []))))))
 
 (deftest ^:integration cli-ruby!-test
   (testing "jruby cli command output"


### PR DESCRIPTION
Without this patch the manner in which environment variables are handled in the
JRuby portions of puppet-server vary across the use cases of the `puppetserver
{gem,irb,ruby}` command line utilities in addition to the service itself.  This
is a problem because the behaviors have not kept in sync with one another over
time so there has been divergence at times, e.g. `puppetserver gem env`
currently fails because PATH is unset in that scenario but set in others, e.g.
the production service.

This patch addresses the problem by consolidating all of the environment
handling behavior into a single authoritative method.  The behavior itself
remains unchanged, GEM_HOME is set based on the config file value, PATH and
HOME are the only variables allowed to flow through to JRuby unmodified, all
other variables are filtered out, and JARS_REQUIRE and JARS_NO_REQUIRE are set
appropriately.

In addition to the environment handling, this patch also consolidates the JRuby
load path handling in a similar fashion across the scenarios of command line
utilities and the production service.