### PR TITLE
Add $codedir to the list of settings read from Puppet

### DIFF
--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -27,6 +27,7 @@
     :certdir
     :certname
     :cert-inventory
+    :codedir ; This is not actually needed in Puppet Server, but it's needed in PE (file sync)
     :csrdir
     :csr-attributes
     :dns-alt-names

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -25,20 +25,20 @@
     :capub
     :ca-ttl
     :certdir
-    :cert-inventory
     :certname
+    :cert-inventory
     :csrdir
-    :keylength
+    :csr-attributes
+    :dns-alt-names
     :hostcert
     :hostcrl
     :hostprivkey
     :hostpubkey
+    :keylength
     :localcacert
+    :requestdir
     :serial
     :signeddir
-    :requestdir
-    :dns-alt-names
-    :csr-attributes
     :ssl-client-header
     :ssl-client-verify-header})
 


### PR DESCRIPTION
Not actually needed in Puppet Server, but will be needed for file sync.