### PR TITLE
(SERVER-701) Cherry-pick jar exclusion acceptance test

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -223,6 +223,30 @@ EOF
         raise "Package #{name} cannot be upgraded on #{host}"
     end
   end
+
+  def get_defaults_var(host, varname)
+    if master.is_pe?
+      package_name = "pe-puppetserver"
+    else
+      package_name = "puppetserver"
+    end
+
+    variant, version, _, _ = master['platform'].to_array
+
+    case variant
+    when /^(fedora|el|centos)$/
+      defaults_dir = "/etc/sysconfig/"
+    when /^(debian|ubuntu)$/
+      defaults_dir = "/etc/defaults/"
+    else
+      logger.warn("#{platform}: Unsupported platform for puppetserver.")
+    end
+
+    defaults_file = File.join(defaults_dir, package_name)
+
+    on(host, "source #{defaults_file}; echo -n $#{varname}")
+    stdout
+  end
 end
 
 Beaker::TestCase.send(:include, PuppetServerExtensions)

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -237,7 +237,7 @@ EOF
     when /^(fedora|el|centos)$/
       defaults_dir = "/etc/sysconfig/"
     when /^(debian|ubuntu)$/
-      defaults_dir = "/etc/defaults/"
+      defaults_dir = "/etc/default/"
     else
       logger.warn("#{platform}: Unsupported platform for puppetserver.")
     end

--- a/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
+++ b/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
@@ -11,6 +11,7 @@ install_dir = get_defaults_var(master, "INSTALL_DIR")
 
 jarfile = File.join(install_dir, "puppet-server-release.jar")
 
+on(master, "test -e \"#{jarfile}\"")
 install_package(master, "unzip")
 
 unzip_grep = "unzip -lf #{jarfile} "

--- a/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
+++ b/acceptance/suites/tests/00_smoke/validate-excluded-bc-jars.rb
@@ -1,0 +1,22 @@
+
+test_name "Validate excluded BC jars are not in packaged uberjar."
+
+if master.is_pe?
+  package_name = "pe-puppetserver"
+else
+  package_name = "puppetserver"
+end
+
+install_dir = get_defaults_var(master, "INSTALL_DIR")
+
+jarfile = File.join(install_dir, "puppet-server-release.jar")
+
+install_package(master, "unzip")
+
+unzip_grep = "unzip -lf #{jarfile} "
+unzip_grep += "| grep META-INF/jruby.home/lib/ruby/shared"
+
+on(master, unzip_grep, :acceptable_exit_codes => [0,1]) do
+  assert_no_match(/bcpkix.*bcpkix.*\.jar/, stdout, "Found Bouncy Castle jars in #{jarfile}")
+  assert_no_match(/bcprov.*bcprov.*\.jar/, stdout, "Found Bouncy Castle jars in #{jarfile}")
+end


### PR DESCRIPTION
JARS_NO_REQUIRE is an environment variable which, if set to `true`, will prevent
the loading of embedded jars using the `require_jar' method of the
`jar-dependencies` gem.

This is required to ensure that jruby-openssel, which is loaded by the JRuby
Kernel whenever ruby code requires 'openssl', does not attempt to load embedded
bouncy castle jars onto the classpath. The effect is to ensure that
jruby-openssl uses the bouncycastle included as a requirement of
jvm-certificate-authority rather than the version included with JRuby, as well
as preventing jvm-ceritificate-authority from using JRuby's bouncycastle.

This commit also adds an integration smoke test to ensure that the jar is
actually excluded by listing the contents of the jar then using the
`assert_no_match` minitest method to validate the listed output does not contain
BC jars.

Conflicts:
	src/clj/puppetlabs/puppetserver/cli/gem.clj
	src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj