### PR TITLE
(SERVER-692) Add defaults to master dir settings

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -26,6 +26,21 @@
   be available on the socket. Currently set to 20 minutes."
   (* 20 60 1000))
 
+(def default-master-conf-dir
+  "/etc/puppetlabs/puppet")
+
+(def default-master-code-dir
+  "/etc/puppetlabs/code")
+
+(def default-master-log-dir
+  "/var/log/puppetlabs/puppetserver")
+
+(def default-master-run-dir
+  "/var/run/puppetlabs/puppetserver")
+
+(def default-master-var-dir
+  "/opt/puppetlabs/server/data/puppetserver")
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
 
@@ -96,11 +111,11 @@
       (get-in config [:http-client :idle-timeout-milliseconds]
         default-http-socket-timeout))
     (update-in [:borrow-timeout] #(or % default-borrow-timeout))
-    (update-in [:master-conf-dir] #(or % nil))
-    (update-in [:master-var-dir] #(or % nil))
-    (update-in [:master-code-dir] #(or % nil))
-    (update-in [:master-run-dir] #(or % nil))
-    (update-in [:master-log-dir] #(or % nil))
+    (update-in [:master-conf-dir] #(or % default-master-conf-dir))
+    (update-in [:master-var-dir] #(or % default-master-var-dir))
+    (update-in [:master-code-dir] #(or % default-master-code-dir))
+    (update-in [:master-run-dir] #(or % default-master-run-dir))
+    (update-in [:master-log-dir] #(or % default-master-log-dir))
     (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
     (update-in [:max-requests-per-instance] #(or % 0))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -31,9 +31,9 @@
 (deftest initialize-config-test
   (let [subject (fn [] (jruby-core/initialize-config min-config))]
     (testing "master-{conf,var}-dir settings are optional"
-      (is (nil? (:master-conf-dir (subject))))
-      (is (nil? (:master-var-dir (subject)))))
+      (is (= "/etc/puppetlabs/puppet" (:master-conf-dir (subject))))
+      (is (= "/opt/puppetlabs/server/data/puppetserver" (:master-var-dir (subject)))))
     (testing "(SERVER-647) master-{code,run,log}-dir settings are optional"
-      (is (nil? (:master-code-dir (subject))))
-      (is (nil? (:master-run-dir (subject))))
-      (is (nil? (:master-log-dir (subject)))))))
+      (is (= "/etc/puppetlabs/code" (:master-code-dir (subject))))
+      (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir (subject))))
+      (is (= "/var/log/puppetlabs/puppetserver" (:master-log-dir (subject)))))))


### PR DESCRIPTION
Add hardcoded defaults for the :master-_-dir settings so that
the behavior of puppetserver will be in line with our
docs when these settings are absent.