### PR TITLE
(maint) Fix failing FOO_DEBUG irb and ruby CLI tests

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -17,11 +17,11 @@ on(master, cmd) do
   assert_no_match(/UHOH/, stdout)
 end
 
-step "Check that FOO_DEBUG is preserved"
-cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{BAD}' | FOO_DEBUG=OK #{cli} irb -f"
+step "Check that FOO_DEBUG is filtered"
+cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{OK}' | FOO_DEBUG=BAD #{cli} irb -f"
 on(master, cmd) do
-  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/^BAD$/, stdout, "FOO_DEBUG is being unset, it should not be")
+  assert_match(/^OK$/, stdout)
+  assert_no_match(/^BAD$/, stdout, "FOO_DEBUG is not being filtered out")
 end
 
 step "Check that puppet is loadable"

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -17,10 +17,10 @@ on(master, cmd) do
   assert_no_match(/UHOH/, stdout)
 end
 
-step "Check that FOO_DEBUG is preserved"
-on(master, "FOO_DEBUG=OK #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{BAD}'") do
-  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/BAD/, stdout, "FOO_DEBUG is being unset, it should not be")
+step "Check that FOO_DEBUG is filtered out"
+on(master, "FOO_DEBUG=BAD #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{OK}'") do
+  assert_match(/^OK$/, stdout)
+  assert_no_match(/BAD/, stdout, "FOO_DEBUG is not being filtered out")
 end
 
 step "Check that puppet is loadable"


### PR DESCRIPTION
The smoke tests are failing checking that FOO_DEBUG is being preserved for the
irb and ruby subcommands.  This is a problem because the behavior has been
consolidated around the behavior of the production scripting container which is
to filter out variables like FOO_DEBUG.  This patch addresses the problem by
changing the test to assert the desired behavior.