### PR TITLE
(SERVER-297) Fix failing smoke tests on irb -e and output undefined var

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -15,9 +15,9 @@ end
 
 step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
 on(master, "puppetserver irb -f -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
-  assert_match(/\bPATH\b/, output, "PATH missing")
-  assert_match(/\bHOME\b/, output, "HOME missing")
-  assert_match(/\bGEM_HOME\b/, output, "GEM_HOME missing")
-  assert_match(/\bJARS_REQUIRE\b/, output, "JARS_REQUIRE missing")
-  assert_match(/\bJARS_NO_REQUIRE\b/, output, "JARS_NO_REQUIRE missing")
+  assert_match(/\bPATH\b/, stdout, "PATH missing")
+  assert_match(/\bHOME\b/, stdout, "HOME missing")
+  assert_match(/\bGEM_HOME\b/, stdout, "GEM_HOME missing")
+  assert_match(/\bJARS_REQUIRE\b/, stdout, "JARS_REQUIRE missing")
+  assert_match(/\bJARS_NO_REQUIRE\b/, stdout, "JARS_NO_REQUIRE missing")
 end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -14,7 +14,7 @@ on(master, "puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'
 end
 
 step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
-on(master, "puppetserver irb -f -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
+on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | puppetserver irb -f -rjson") do
   assert_match(/\bPATH\b/, stdout, "PATH missing")
   assert_match(/\bHOME\b/, stdout, "HOME missing")
   assert_match(/\bGEM_HOME\b/, stdout, "GEM_HOME missing")


### PR DESCRIPTION
(maint) Fix failing smoke test on irb -e

Fixes this error:

    IRB::UnrecognizedSwitch: Unrecognized switch: -e

irb reads from STDIN, it doesn't have a -e flag like the ruby command does.

(maint) Fix failing smoke test on undefined var output

Fixes:

    #<NameError: undefined local variable or method `output'