### PR TITLE
(SERVER-718) Load facter jar into system classloader classpath

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-puppet-service
   (:require [clojure.tools.logging :as log]
+            [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-puppet-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
@@ -28,6 +29,7 @@
           profiler          (get-profiler)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
+      (core/add-facter-jar-to-system-classloader (:ruby-load-path config))
       (let [pool-context (core/create-pool-context config profiler agent-shutdown-fn)]
         (jruby-agents/send-prime-pool! pool-context)
         (-> context

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core-test
   (:require [clojure.test :refer :all]
+            [me.raynes.fs :as fs]
             [schema.test :as schema-test]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -37,3 +39,45 @@
       (is (= "/etc/puppetlabs/code" (:master-code-dir (subject))))
       (is (= "/var/run/puppetlabs/puppetserver" (:master-run-dir (subject))))
       (is (= "/var/log/puppetlabs/puppetserver" (:master-log-dir (subject)))))))
+
+(deftest add-facter-to-classpath-test
+  (let [class-loader-files (fn [] (map #(.getFile %)
+                                    (.getURLs
+                                      (ClassLoader/getSystemClassLoader))))
+        create-temp-facter-jar (fn [] (-> (ks/temp-dir)
+                                        (fs/file jruby-core/facter-jar)
+                                        (fs/touch)
+                                        (fs/absolute-path)))
+        temp-dir-as-string (fn [] (-> (ks/temp-dir) (fs/absolute-path)))
+        fs-parent-as-string (fn [path]
+                              (-> path
+                                (fs/parent)
+                                (fs/absolute-path)))
+        jar-in-class-loader-file-list? (fn [jar]
+                                         (some #(= jar %)
+                                           (class-loader-files)))]
+    (testing "facter jar loaded from first position"
+      (let [temp-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(fs-parent-as-string temp-jar)])
+        (is (true? (jar-in-class-loader-file-list? temp-jar)))))
+    (testing "facter jar loaded from last position"
+      (let [temp-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+                                             (fs-parent-as-string temp-jar)])
+        (is (true? (jar-in-class-loader-file-list? temp-jar)))))
+    (testing "only first jar loaded when two present"
+      (let [first-jar (create-temp-facter-jar)
+            last-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(fs-parent-as-string first-jar)
+                                             (temp-dir-as-string)
+                                             (fs-parent-as-string last-jar)])
+        (is (true? (jar-in-class-loader-file-list? first-jar))
+          "first jar in the list was unexpectedly not found")
+        (is (nil? (jar-in-class-loader-file-list? last-jar))
+          "last jar in the list was unexpectedly not found")))
+    (testing "class loader files unchanged when no jar found"
+      (let [class-loader-files-before-load (class-loader-files)
+            _ (jruby-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+                                                   (temp-dir-as-string)])
+            class-loader-files-after-load (class-loader-files)]
+        (is (= class-loader-files-before-load class-loader-files-after-load))))))


### PR DESCRIPTION
This commit adds some logic which searches for a file named 'facter.jar'
in the ruby load path and, if found, adds the file to the system
classloader's classpath.  This is needed for compatibility with Facter
3+.  The jar needs to be in the system classloader's classpath in order
for Facter's backing native shared library to only be loaded once by a
classloader, avoiding an error which would otherwise occur if attempts
were made to load the library into more than 1 JRuby container instance
classloader.