### PR TITLE
(SERVER-718) Load facter jar into system classloader classpath

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -1,5 +1,8 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core
-  (:require [schema.core :as schema]
+  (:require [clojure.tools.logging :as log]
+            [me.raynes.fs :as fs]
+            [schema.core :as schema]
+            [puppetlabs.kitchensink.classpath :as ks-classpath]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
@@ -104,6 +107,25 @@
     (update-in [:master-log-dir] #(or % default-master-log-dir))
     (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
     (update-in [:max-requests-per-instance] #(or % 0))))
+
+(def facter-jar
+  "Well-known name of the facter jar file"
+  "facter.jar")
+
+(schema/defn ^:always-validate
+  add-facter-jar-to-system-classloader
+  "Searches the ruby load path for a file whose name matches that of the
+  facter jar file.  The first one found is added to the system classloader's
+  classpath.  If no match is found, an info message is written to the log
+  but no failure is returned"
+  [ruby-load-path :- (schema/both (schema/pred vector?) [schema/Str]) ]
+  (if-let [facter-jar (first
+                        (filter fs/exists?
+                          (map #(fs/file % facter-jar) ruby-load-path)))]
+    (do
+      (log/debugf "Adding facter jar to classpath from: %s" facter-jar)
+      (ks-classpath/add-classpath facter-jar))
+    (log/info "Facter jar not found in ruby load path")))
 
 (schema/defn ^:always-validate
   create-pool-context :- jruby-schemas/PoolContext

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-puppet-service
   (:require [clojure.tools.logging :as log]
+            [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-puppet-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.core :as trapperkeeper]
@@ -28,6 +29,7 @@
           profiler          (get-profiler)]
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
+      (core/add-facter-jar-to-system-classloader (:ruby-load-path config))
       (let [pool-context (core/create-pool-context config profiler agent-shutdown-fn)]
         (jruby-agents/send-prime-pool! pool-context)
         (-> context

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core-test
   (:require [clojure.test :refer :all]
+            [me.raynes.fs :as fs]
             [schema.test :as schema-test]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core])
   (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
 
@@ -124,3 +126,41 @@
             exit-code (.getStatus return)]
         (is (= 0 exit-code))
         (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))))
+
+(deftest add-facter-to-classpath-test
+  (letfn [(class-loader-files [] (map #(.getFile %)
+                                   (.getURLs
+                                     (ClassLoader/getSystemClassLoader))))
+          (create-temp-facter-jar [] (-> (ks/temp-dir)
+                                       (fs/file jruby-core/facter-jar)
+                                       (fs/touch)
+                                       (fs/absolute-path)))
+          (temp-dir-as-string [] (-> (ks/temp-dir) (fs/absolute-path)))
+          (fs-parent-as-string [path] (-> path (fs/parent) (fs/absolute-path)))
+          (jar-in-class-loader-file-list? [jar]
+            (some #(= jar %) (class-loader-files)))]
+    (testing "facter jar loaded from first position"
+      (let [temp-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(fs-parent-as-string temp-jar)])
+        (is (true? (jar-in-class-loader-file-list? temp-jar)))))
+    (testing "facter jar loaded from last position"
+      (let [temp-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+                                             (fs-parent-as-string temp-jar)])
+        (is (true? (jar-in-class-loader-file-list? temp-jar)))))
+    (testing "only first jar loaded when two present"
+      (let [first-jar (create-temp-facter-jar)
+            last-jar (create-temp-facter-jar)]
+        (jruby-core/add-facter-jar-to-system-classloader [(fs-parent-as-string first-jar)
+                                             (temp-dir-as-string)
+                                             (fs-parent-as-string last-jar)])
+        (is (true? (jar-in-class-loader-file-list? first-jar))
+          "first jar in the list was unexpectedly not found")
+        (is (nil? (jar-in-class-loader-file-list? last-jar))
+          "last jar in the list was unexpectedly not found")))
+    (testing "class loader files unchanged when no jar found"
+      (let [class-loader-files-before-load (class-loader-files)
+            _ (jruby-core/add-facter-jar-to-system-classloader [(temp-dir-as-string)
+                                                   (temp-dir-as-string)])
+            class-loader-files-after-load (class-loader-files)]
+        (is (= class-loader-files-before-load class-loader-files-after-load))))))


### PR DESCRIPTION
This commit adds some logic which searches for a file named 'facter.jar'
in the ruby load path and, if found, adds the file to the system
classloader's classpath.  This is needed for compatibility with Facter
3+.  The jar needs to be in the system classloader's classpath in order
for Facter's backing native shared library to only be loaded once by a
classloader, avoiding an error which would otherwise occur if attempts
were made to load the library into more than 1 JRuby container instance
classloader.