### PR TITLE
(SERVER-646) Allow charset for certificate_status content-type

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -14,6 +14,7 @@
             [liberator.core :refer [defresource]]
             ;[liberator.dev :as liberator-dev]
             [liberator.representation :as representation]
+            [ring.util.request :as request]
             [ring.util.response :as rr]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -90,7 +91,7 @@
 
 (defn content-type-valid?
   [context]
-  (let [content-type (get-in context [:request :headers "content-type"])]
+  (let [content-type (request/content-type (:request context))]
     (or
       (nil? content-type)
       (media-types content-type))))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -455,6 +455,21 @@
         (is (true? (fs/exists? signed-cert-path)))
         (is (= 204 (:status response))))))
 
+  (testing "a signing request w/ a 'application/json' content-type and charset succeeds"
+    (let [settings (testutils/ca-sandbox! cadir)
+          test-app (-> (build-ring-handler settings "42.42.42")
+                     (wrap-with-ssl-client-cert))
+          signed-cert-path (ca/path-to-cert (:signeddir settings) "test-agent")]
+      (is (false? (fs/exists? signed-cert-path)))
+      (let [response (test-app
+                      {:uri "/production/certificate_status/test-agent"
+                       :request-method :put
+                       :headers {"content-type"
+                                 "application/json; charset=UTF-8"}
+                       :body (body-stream "{\"desired_state\":\"signed\"}")})]
+        (is (true? (fs/exists? signed-cert-path)))
+        (is (= 204 (:status response))))))
+
   (testing "a signing request w/ a 'text/pson' content-type succeeds"
     (let [settings         (testutils/ca-sandbox! cadir)
           test-app         (-> (build-ring-handler settings "42.42.42")
@@ -469,6 +484,20 @@
         (is (true? (fs/exists? signed-cert-path)))
         (is (= 204 (:status response))))))
 
+  (testing "a signing request w/ a 'text/pson' content-type and charset succeeds"
+    (let [settings (testutils/ca-sandbox! cadir)
+          test-app (-> (build-ring-handler settings "42.42.42")
+                     (wrap-with-ssl-client-cert))
+          signed-cert-path (ca/path-to-cert (:signeddir settings) "test-agent")]
+      (is (false? (fs/exists? signed-cert-path)))
+      (let [response (test-app
+                      {:uri "/production/certificate_status/test-agent"
+                       :request-method :put
+                       :headers {"content-type" "text/pson; charset=UTF-8"}
+                       :body (body-stream "{\"desired_state\":\"signed\"}")})]
+        (is (true? (fs/exists? signed-cert-path)))
+        (is (= 204 (:status response))))))
+
   (testing "a signing request w/ a 'pson' content-type succeeds"
     (let [settings         (testutils/ca-sandbox! cadir)
           test-app         (-> (build-ring-handler settings "42.42.42")
@@ -480,6 +509,20 @@
                        :request-method :put
                        :headers        {"content-type" "pson"}
                        :body           (body-stream "{\"desired_state\":\"signed\"}")})]
+        (is (true? (fs/exists? signed-cert-path)))
+        (is (= 204 (:status response))))))
+
+  (testing "a signing request w/ a 'pson' content-type and charset succeeds"
+    (let [settings (testutils/ca-sandbox! cadir)
+          test-app (-> (build-ring-handler settings "42.42.42")
+                     (wrap-with-ssl-client-cert))
+          signed-cert-path (ca/path-to-cert (:signeddir settings) "test-agent")]
+      (is (false? (fs/exists? signed-cert-path)))
+      (let [response (test-app
+                       {:uri "/production/certificate_status/test-agent"
+                        :request-method :put
+                        :headers {"content-type" "pson; charset=UTF-8"}
+                        :body (body-stream "{\"desired_state\":\"signed\"}")})]
         (is (true? (fs/exists? signed-cert-path)))
         (is (= 204 (:status response))))))
 


### PR DESCRIPTION
This commit changes the validation for the 'certificate_status' endpoint
to allow for the request's content-type to include a "charset"
parameter.  Previously, the presence of a "charset" parameter in the
content-type would cause the content-type to fail validation with an
HTTP 415 (unsupported media type) error.