### PR TITLE
(SERVER-721) Consolidate JRuby environment handling

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/SERVER-297_common_behavior.rb
@@ -1,0 +1,23 @@
+require 'test/unit/assertions'
+require 'json'
+
+test_name "Puppetserver subcommand consolidated ENV handling tests."
+
+step "ruby: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
+on(master, "puppetserver ruby -rjson -e 'puts JSON.pretty_generate(ENV.to_hash)'") do
+  env = JSON.parse(stdout)
+  assert(env['PATH'], "PATH missing")
+  assert(env['HOME'], "HOME missing")
+  assert(env['GEM_HOME'], "GEM_HOME missing")
+  assert(env['JARS_REQUIRE'], "JARS_REQUIRE missing")
+  assert(env['JARS_NO_REQUIRE'], "JARS_NO_REQUIRE missing")
+end
+
+step "irb: Check that PATH, HOME, GEM_HOME JARS_REQUIRE and JARS_NO_REQUIRE are present"
+on(master, "echo 'puts JSON.pretty_generate(ENV.to_hash)' | puppetserver irb -f -rjson") do
+  assert_match(/\bPATH\b/, stdout, "PATH missing")
+  assert_match(/\bHOME\b/, stdout, "HOME missing")
+  assert_match(/\bGEM_HOME\b/, stdout, "GEM_HOME missing")
+  assert_match(/\bJARS_REQUIRE\b/, stdout, "JARS_REQUIRE missing")
+  assert_match(/\bJARS_NO_REQUIRE\b/, stdout, "JARS_NO_REQUIRE missing")
+end

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -67,3 +67,5 @@ initial_installed_gems.each do |gem_info|
   assert_send([final_installed_gems, :include?, gem_info])
 end
 
+step "Verify that gem env operates"
+on(master, "#{cli} gem env", :acceptable_exit_codes => [0])

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/irb.rb
@@ -17,11 +17,11 @@ on(master, cmd) do
   assert_no_match(/UHOH/, stdout)
 end
 
-step "Check that FOO_DEBUG is preserved"
-cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{BAD}' | FOO_DEBUG=OK #{cli} irb -f"
+step "Check that FOO_DEBUG is filtered"
+cmd = "echo 'puts ENV[%{FOO_DEBUG}] || %{OK}' | FOO_DEBUG=BAD #{cli} irb -f"
 on(master, cmd) do
-  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/^BAD$/, stdout, "FOO_DEBUG is being unset, it should not be")
+  assert_match(/^OK$/, stdout)
+  assert_no_match(/^BAD$/, stdout, "FOO_DEBUG is not being filtered out")
 end
 
 step "Check that puppet is loadable"

--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/ruby.rb
@@ -17,10 +17,10 @@ on(master, cmd) do
   assert_no_match(/UHOH/, stdout)
 end
 
-step "Check that FOO_DEBUG is preserved"
-on(master, "FOO_DEBUG=OK #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{BAD}'") do
-  assert_match(/^OK$/, stdout, "FOO_DEBUG is not being preserved")
-  assert_no_match(/BAD/, stdout, "FOO_DEBUG is being unset, it should not be")
+step "Check that FOO_DEBUG is filtered out"
+on(master, "FOO_DEBUG=BAD #{cli} ruby -e 'puts ENV[%{FOO_DEBUG}] || %{OK}'") do
+  assert_match(/^OK$/, stdout)
+  assert_no_match(/BAD/, stdout, "FOO_DEBUG is not being filtered out")
 end
 
 step "Check that puppet is loadable"

--- a/project.clj
+++ b/project.clj
@@ -106,7 +106,7 @@
             "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb"]}
 
   ; tests use a lot of PermGen (jruby instances)
-  :jvm-opts ["-XX:MaxPermSize=256m"]
+  :jvm-opts ["-XX:MaxPermSize=256m" "-Xmx1024M"]
 
   :repl-options {:init-ns user}
 

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -1,18 +1,10 @@
 (ns puppetlabs.puppetserver.cli.gem
-  (:import (org.jruby.embed ScriptingContainer))
-  (:require [puppetlabs.puppetserver.cli.subcommand :as cli]))
+  (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
   [config args]
-  (doto (ScriptingContainer.)
-    (.setArgv (into-array String args))
-    (.setEnvironment
-      (hash-map
-        "GEM_HOME" (get-in config [:jruby-puppet :gem-home])
-        "JARS_NO_REQUIRE" "true"
-        "JARS_REQUIRE" "false"))
-    (.runScriptlet "require 'jar-dependencies'")
-    (.runScriptlet "load 'META-INF/jruby.home/bin/gem'")))
+  (jruby-core/cli-run! config "gem" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -1,39 +1,10 @@
 (ns puppetlabs.puppetserver.cli.irb
-  (:import (org.jruby Main RubyInstanceConfig CompatVersion)
-           (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
-
-(defn new-jruby-main
-  [config]
-  (let [jruby-config (RubyInstanceConfig.)
-        gem-home     (get-in config [:jruby-puppet :gem-home])
-        env          (doto (HashMap. (.getEnvironment jruby-config))
-                       (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true")
-                       (.put "JARS_REQUIRE" "false"))
-        jruby-home   (.getJRubyHome jruby-config)
-        load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                       (cons jruby-internal/ruby-code-dir)
-                       (cons (str jruby-home "/lib/ruby/1.9"))
-                       (cons (str jruby-home "/lib/ruby/shared"))
-                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
-    (doto jruby-config
-      (.setEnvironment env)
-      (.setLoadPaths load-path)
-      (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (Main. jruby-config)))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
-  [config ruby-args]
-  (doto (new-jruby-main config)
-    (.run (into-array String
-            (concat
-              ["-rjar-dependencies"
-               "-e"
-               "load 'META-INF/jruby.home/bin/irb'"
-               "--"]
-              ruby-args)))))
+  [config args]
+  (jruby-core/cli-run! config "irb" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -1,35 +1,7 @@
 (ns puppetlabs.puppetserver.cli.ruby
-  (:import (org.jruby Main RubyInstanceConfig CompatVersion)
-           (java.util HashMap))
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
-
-(defn new-jruby-main
-  [config]
-  (let [jruby-config (RubyInstanceConfig.)
-        gem-home     (get-in config [:jruby-puppet :gem-home])
-        env          (doto (HashMap. (.getEnvironment jruby-config))
-                       (.put "GEM_HOME" gem-home)
-                       (.put "JARS_NO_REQUIRE" "true")
-                       (.put "JARS_REQUIRE" "false"))
-        jruby-home   (.getJRubyHome jruby-config)
-        load-path    (->> (get-in config [:os-settings :ruby-load-path])
-                       (cons jruby-internal/ruby-code-dir)
-                       (cons (str jruby-home "/lib/ruby/1.9"))
-                       (cons (str jruby-home "/lib/ruby/shared"))
-                       (cons (str jruby-home "/lib/ruby/1.9/site_ruby")))]
-    (doto jruby-config
-      (.setEnvironment env)
-      (.setLoadPaths load-path)
-      (.setCompatVersion (CompatVersion/RUBY1_9)))
-    (Main. jruby-config)))
-
-(defn run!
-  [config ruby-args]
-  (doto (new-jruby-main config)
-    (.run (into-array String
-            (cons "-rjar-dependencies" ruby-args)))))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run jruby-core/cli-ruby! args))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -4,7 +4,8 @@
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
-            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents])
+            [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
+            [clojure.java.io :as io])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance)
            (com.puppetlabs.puppetserver PuppetProfiler)))
 
@@ -25,21 +26,6 @@
   "The default number of milliseconds that the client will allow for no data to
   be available on the socket. Currently set to 20 minutes."
   (* 20 60 1000))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Definitions
-
-(def jruby-puppet-env
-  "The environment variables that should be passed to the Puppet JRuby interpreters.
-  We don't want them to read any ruby environment variables, like $GEM_HOME or
-  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
-  Puppet needs HOME and PATH for facter resolution, so leave those."
-  (select-keys (System/getenv) ["HOME" "PATH"]))
-
-(def ruby-code-dir
-  "The name of the directory containing the ruby code in this project.
-  This directory lives under src/ruby/"
-  "puppet-server-lib")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -173,3 +159,20 @@
   "Return a borrowed pool instance to its free pool."
   [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry]
   (jruby-internal/return-to-pool instance))
+
+(schema/defn ^:always-validate cli-ruby! :- jruby-schemas/JRubyMainStatus
+  "Run JRuby as though native `ruby` were invoked with args on the CLI"
+  [config :- {schema/Keyword schema/Any}
+   args :- [schema/Str]]
+  (let [main (jruby-internal/new-main (initialize-config config))
+        argv (into-array String (concat ["-rjar-dependencies"] args))]
+    (.run main argv)))
+
+(schema/defn ^:always-validate cli-run! :- (schema/maybe jruby-schemas/JRubyMainStatus)
+  "Run a JRuby CLI command, e.g. gem, irb, etc..."
+  [config :- {schema/Keyword schema/Any}
+   command :- schema/Str
+   args :- [schema/Str]]
+  (let [load-path (format "META-INF/jruby.home/bin/%s" command)]
+    (if-let [url (io/resource load-path (.getClassLoader org.jruby.Main))]
+      (cli-ruby! config (concat ["-e" (format "load '%s'" url) "--"] args)))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -7,7 +7,7 @@
   (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
            (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
            (java.util HashMap)
-           (org.jruby CompatVersion RubyInstanceConfig$CompileMode)
+           (org.jruby CompatVersion Main RubyInstanceConfig RubyInstanceConfig$CompileMode)
            (org.jruby.embed ScriptingContainer LocalContextScope)
            (java.util.concurrent LinkedBlockingDeque TimeUnit)
            (clojure.lang IFn)))
@@ -15,20 +15,37 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
 
-(def jruby-puppet-env
-  "The environment variables that should be passed to the Puppet JRuby interpreters.
-  We don't want them to read any ruby environment variables, like $GEM_HOME or
-  $RUBY_LIB or anything like that, so pass it an empty environment map - except -
-  Puppet needs HOME and PATH for facter resolution, so leave those."
-  (select-keys (System/getenv) ["HOME" "PATH"]))
-
 (def ruby-code-dir
   "The name of the directory containing the ruby code in this project.
-  This directory lives under src/ruby/"
+
+  This directory is relative to `src/ruby` and works from source because the
+  `src/ruby` directory is defined as a resource in `project.clj` which places
+  the directory on the classpath which in turn makes the directory available on
+  the JRuby load path.  Similarly, this works from the uberjar because this
+  directory is placed into the root of the jar structure which is on the
+  classpath.
+
+  See also:  http://jruby.org/apidocs/org/jruby/runtime/load/LoadService.html"
   "puppet-server-lib")
+
+(def compile-mode
+  "The JRuby compile mode to use for all ruby components, e.g. the master
+  service and CLI tools."
+  RubyInstanceConfig$CompileMode/OFF)
+
+(def compat-version
+  "The JRuby compatibility version to use for all ruby components, e.g. the
+  master service and CLI tools."
+  (CompatVersion/RUBY1_9))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
+
+(schema/defn get-system-env :- jruby-schemas/EnvPersistentMap
+  "Same as System/getenv, but returns a clojure persistent map instead of a
+  Java unmodifiable map."
+  []
+  (into {} (System/getenv)))
 
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
@@ -36,32 +53,53 @@
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
   (LinkedBlockingDeque. size))
 
-(schema/defn ^:always-validate
-  create-pool-from-config :- jruby-schemas/PoolState
-  "Create a new PoolData based on the config input."
-  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
-  {:pool (instantiate-free-pool size)
-   :size size})
+(schema/defn ^:always-validate managed-environment :- {schema/Str schema/Str}
+  "The environment variables that should be passed to the Puppet JRuby
+  interpreters.
+
+  We don't want them to read any ruby environment variables, like $RUBY_LIB or
+  anything like that, so pass it an empty environment map - except - Puppet
+  needs HOME and PATH for facter resolution, so leave those, along with GEM_HOME
+  which is necessary for third party extensions that depend on gems.
+
+  We need to set the JARS..REQUIRE variables in order to instruct JRuby's
+  'jar-dependencies' to not try to load any dependent jars.  This is being
+  done specifically to avoid JRuby trying to load its own version of Bouncy
+  Castle, which may not the same as the one that 'puppetlabs/ssl-utils'
+  uses. JARS_NO_REQUIRE was the legacy way to turn off jar loading but is
+  being phased out in favor of JARS_REQUIRE.  As of JRuby 1.7.20, only
+  JARS_NO_REQUIRE is honored.  Setting both of those here for forward
+  compatibility."
+  [env :- jruby-schemas/EnvMap
+   gem-home :- schema/Str]
+  (let [whitelist ["HOME" "PATH"]
+        clean-env (select-keys env whitelist)]
+    (assoc clean-env
+      "GEM_HOME" gem-home
+      "JARS_NO_REQUIRE" "true"
+      "JARS_REQUIRE" "false")))
+
+(schema/defn ^:always-validate managed-load-path :- [schema/Str]
+  "Return a list of ruby LOAD_PATH directories built from the
+  user-configurable ruby-load-path setting of the jruby-puppet configuration
+  section and prepending specific JRuby directories necessary for third party
+  extensions.  See SERVER-297 and SERVER-538 for more info."
+  [ruby-load-path :- [schema/Str]
+   jruby-home :- schema/Str]
+  (->> ruby-load-path
+    (cons ruby-code-dir)
+    (cons (str jruby-home "/lib/ruby/1.9"))
+    (cons (str jruby-home "/lib/ruby/shared"))
+    (cons (str jruby-home "/lib/ruby/1.9/site_ruby"))))
 
 (defn prep-scripting-container
   [scripting-container ruby-load-path gem-home]
-  (doto scripting-container
-    (.setLoadPaths (cons ruby-code-dir
-                         (map fs/absolute-path ruby-load-path)))
-    (.setCompatVersion (CompatVersion/RUBY1_9))
-    (.setCompileMode RubyInstanceConfig$CompileMode/OFF)
-    ;; We need to set the JARS..REQUIRE variables in order to instruct
-    ;; JRuby's 'jar-dependencies' to not try to load any dependent jars.  This
-    ;; is being done specifically to avoid JRuby trying to load its own version
-    ;; of Bouncy Castle, which may not the same as the one that
-    ;; 'puppetlabs/ssl-utils' uses. JARS_NO_REQUIRE was the legacy way to turn
-    ;; off jar loading but is being phased out in favor of JARS_REQUIRE.  As of
-    ;; JRuby 1.7.20, only JARS_NO_REQUIRE is honored.  Setting both of those
-    ;; here for forward compatibility.
-    (.setEnvironment (merge {"GEM_HOME" gem-home
-                             "JARS_NO_REQUIRE" "true"
-                             "JARS_REQUIRE" "false"}
-                            jruby-puppet-env))))
+  (let [jruby-home (.getHomeDirectory scripting-container)]
+    (doto scripting-container
+      (.setLoadPaths (managed-load-path ruby-load-path jruby-home))
+      (.setCompatVersion compat-version)
+      (.setCompileMode compile-mode)
+      (.setEnvironment (managed-environment (get-system-env) gem-home)))))
 
 (defn empty-scripting-container
   "Creates a clean instance of `org.jruby.embed.ScriptingContainer` with no code loaded."
@@ -71,7 +109,7 @@
          (string? gem-home)]
    :post [(instance? ScriptingContainer %)]}
   (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
-      (prep-scripting-container ruby-load-path gem-home)))
+    (prep-scripting-container ruby-load-path gem-home)))
 
 (defn create-scripting-container
   "Creates an instance of `org.jruby.embed.ScriptingContainer` and loads up the
@@ -95,6 +133,35 @@
     ;; information.
     (.runScriptlet "require 'jar-dependencies'")
     (.runScriptlet "require 'puppet/server/master'")))
+
+(schema/defn ^:always-validate config->puppet-config :- HashMap
+  "Given the raw jruby-puppet configuration section, return a
+  HashMap with the configuration necessary for ruby Puppet."
+  [config :- jruby-schemas/JRubyPuppetConfig]
+  (let [puppet-config (new HashMap)]
+    (doseq [[setting dir] [[:master-conf-dir "confdir"]
+                           [:master-code-dir "codedir"]
+                           [:master-var-dir "vardir"]
+                           [:master-run-dir "rundir"]
+                           [:master-log-dir "logdir"]]]
+      (if-let [value (get config setting)]
+        (.put puppet-config dir (fs/absolute-path value))))
+    puppet-config))
+
+(schema/defn borrow-with-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
+  [timeout :- schema/Int
+   pool :- jruby-schemas/pool-queue-type]
+  (.pollFirst pool timeout TimeUnit/MILLISECONDS))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(schema/defn ^:always-validate
+  create-pool-from-config :- jruby-schemas/PoolState
+  "Create a new PoolState based on the config input."
+  [{size :max-active-instances} :- jruby-schemas/JRubyPuppetConfig]
+  {:pool (instantiate-free-pool size)
+   :size size})
 
 (schema/defn ^:always-validate
   create-pool-instance! :- JRubyPuppetInstance
@@ -170,11 +237,6 @@
   [pool :- jruby-schemas/pool-queue-type]
   (.takeFirst pool))
 
-(schema/defn borrow-with-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
-  [timeout :- schema/Int
-   pool :- jruby-schemas/pool-queue-type]
-  (.pollFirst pool timeout TimeUnit/MILLISECONDS))
-
 (schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
   If successful, updates the state information and returns the JRuby instance.
@@ -241,3 +303,19 @@
         (.putFirst pool instance)))
     ;; if we get here, we got a Retry, so we just put it back into the pool.
     (.putFirst (:pool instance) instance)))
+
+(schema/defn ^:always-validate new-main :- jruby-schemas/JRubyMain
+  "Return a new JRuby Main instance which should only be used for CLI purposes,
+  e.g. for the ruby, gem, and irb subcommands.  Internal core services should
+  use `create-scripting-container` instead of `new-main`."
+  [config :- jruby-schemas/JRubyPuppetConfig]
+  (let [jruby-config (RubyInstanceConfig.)
+        jruby-home   (.getJRubyHome jruby-config)
+        {:keys [ruby-load-path gem-home]} config]
+    ; Note, this behavior should remain consistent with prep-scripting-container
+    (doto jruby-config
+      (.setLoadPaths (managed-load-path ruby-load-path jruby-home))
+      (.setCompatVersion compat-version)
+      (.setCompileMode compile-mode)
+      (.setEnvironment (managed-environment (get-system-env) gem-home)))
+    (Main. jruby-config)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -134,20 +134,6 @@
     (.runScriptlet "require 'jar-dependencies'")
     (.runScriptlet "require 'puppet/server/master'")))
 
-(schema/defn ^:always-validate config->puppet-config :- HashMap
-  "Given the raw jruby-puppet configuration section, return a
-  HashMap with the configuration necessary for ruby Puppet."
-  [config :- jruby-schemas/JRubyPuppetConfig]
-  (let [puppet-config (new HashMap)]
-    (doseq [[setting dir] [[:master-conf-dir "confdir"]
-                           [:master-code-dir "codedir"]
-                           [:master-var-dir "vardir"]
-                           [:master-run-dir "rundir"]
-                           [:master-log-dir "logdir"]]]
-      (if-let [value (get config setting)]
-        (.put puppet-config dir (fs/absolute-path value))))
-    puppet-config))
-
 (schema/defn borrow-with-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
   [timeout :- schema/Int
    pool :- jruby-schemas/pool-queue-type]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -2,8 +2,9 @@
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env])
   (:import (java.util.concurrent BlockingDeque)
-           (clojure.lang Atom Agent IFn)
+           (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
+           (org.jruby Main Main$Status)
            (org.jruby.embed ScriptingContainer)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -141,6 +142,14 @@
   [x]
   (instance? JRubyPuppetInstance x))
 
+(defn jruby-main-instance?
+  [x]
+  (instance? Main x))
+
+(defn jruby-main-status-instance?
+  [x]
+  (instance? Main$Status x))
+
 (defn poison-pill?
   [x]
   (instance? PoisonPill x))
@@ -160,3 +169,17 @@
                         retry-poison-pill?
                         jruby-puppet-instance?)))
 
+(def JRubyMain
+  (schema/pred jruby-main-instance?))
+
+(def JRubyMainStatus
+  (schema/pred jruby-main-status-instance?))
+
+(def EnvMap
+  "System Environment variables have strings for the keys and values of a map"
+  {schema/Str schema/Str})
+
+(def EnvPersistentMap
+  "Schema for a clojure persistent map for the system environment"
+  (schema/both EnvMap
+    (schema/either PersistentArrayMap PersistentHashMap)))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,9 +1,54 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core-test
   (:require [clojure.test :refer :all]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core])
+  (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
 
 (use-fixtures :once schema-test/validate-schemas)
+
+(def min-config
+  {:product
+   {:name "puppet-server", :update-server-url "http://localhost:11111"},
+   ; os-settings has merged into jruby-puppet as of puppetserver 2.0
+   :os-settings
+   {:ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"]},
+   :jruby-puppet
+   {:gem-home "./target/jruby-gem-home"},
+   :certificate-authority {:certificate-status {:client-whitelist []}}})
+
+(defmacro with-stdin-str
+  "Evaluates body in a context in which System/in is bound to a fresh
+  input stream initialized with the string s.  The return value of evaluating
+  body is returned."
+  [s & body]
+  `(let [system-input# (System/in)
+         string-input# (new ByteArrayInputStream (.getBytes ~s))]
+     (try
+       (System/setIn string-input#)
+       ~@body
+       (finally (System/setIn system-input#)))))
+
+(defmacro capture-out
+  "capture System.out and return it as the value of :out in the return map.
+  The return value of body is available as :return in the return map.
+
+  This macro is intended to be used for JRuby interop.  Please see with-out-str
+  for an idiomatic clojure equivalent.
+
+  This macro is not thread safe."
+  [& body]
+  `(let [return-map# (atom {})
+         system-output# (System/out)
+         captured-output# (new ByteArrayOutputStream)
+         capturing-print-stream# (new PrintStream captured-output#)]
+     (try
+       (System/setOut capturing-print-stream#)
+       (swap! return-map# assoc :return (do ~@body))
+       (finally
+         (.flush capturing-print-stream#)
+         (swap! return-map# assoc :out (.toString captured-output#))
+         (System/setOut system-output#)))
+     @return-map#))
 
 (deftest default-num-cpus-test
   (testing "1 jruby instance for a 1 or 2-core box"
@@ -19,3 +64,55 @@
     (is (= 4 (jruby-core/default-pool-size 16)))
     (is (= 4 (jruby-core/default-pool-size 32)))
     (is (= 4 (jruby-core/default-pool-size 64)))))
+
+(deftest ^:integration cli-run!-test
+  (testing "jruby cli command output"
+    (testing "gem env (SERVER-262)"
+      (let [m (capture-out (jruby-core/cli-run! min-config "gem" ["env"]))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        ; The choice of SHELL PATH is arbitrary, just need something to scan for
+        (is (re-find #"SHELL PATH:" out))))
+    (testing "gem list"
+      (let [m (capture-out (jruby-core/cli-run! min-config "gem" ["list"]))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        ; The choice of json is arbitrary, just need something to scan for
+        (is (re-find #"\bjson\b" out))))
+    (testing "irb"
+      (let [m (capture-out
+                (with-stdin-str "puts %{HELLO}"
+                  (jruby-core/cli-run! min-config "irb" ["-f"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"\nHELLO\n" out)))
+      (let [m (capture-out
+                (with-stdin-str "Kernel.exit(42)"
+                  (jruby-core/cli-run! min-config "irb" ["-f"])))
+            {:keys [return _]} m
+            exit-code (.getStatus return)]
+        (is (= 42 exit-code))))
+    (testing "irb with -r puppet"
+      (let [m (capture-out
+                (with-stdin-str "puts %{VERSION: #{Puppet.version}}"
+                  (jruby-core/cli-run! min-config "irb" ["-r" "puppet" "-f"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))
+    (testing "non existing subcommand returns nil"
+      (is (nil? (jruby-core/cli-run! min-config "doesnotexist" []))))))
+
+(deftest ^:integration cli-ruby!-test
+  (testing "jruby cli command output"
+    (testing "ruby -r puppet"
+      (let [m (capture-out
+                (with-stdin-str "puts %{VERSION: #{Puppet.version}}"
+                  (jruby-core/cli-ruby! min-config ["-r" "puppet"])))
+            {:keys [return out]} m
+            exit-code (.getStatus return)]
+        (is (= 0 exit-code))
+        (is (re-find #"VERSION: \d+\.\d+\.\d+" out))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.services.jruby.jruby-puppet-core-test
   (:require [clojure.test :refer :all]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core])
+            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
   (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -64,6 +65,12 @@
     (is (= 4 (jruby-core/default-pool-size 16)))
     (is (= 4 (jruby-core/default-pool-size 32)))
     (is (= 4 (jruby-core/default-pool-size 64)))))
+
+(deftest cli-run!-error-handling-test
+  (testing "when command is not found as a resource"
+    (logutils/with-test-logging
+      (is (nil? (jruby-core/cli-run! min-config "DNE" [])))
+      (is (logged? #"DNE could not be found" :error)))))
 
 (deftest ^:integration cli-run!-test
   (testing "jruby cli command output"


### PR DESCRIPTION
Without this patch the manner in which environment variables are handled
in the JRuby portions of puppet-server vary across the use cases of the
`puppetserver {gem,irb,ruby}` command line utilities in addition to the
service itself.  This is a problem because the behaviors have not kept
in sync with one another over time so there has been divergence at
times, e.g. `puppetserver gem env` currently fails because PATH is unset
in that scenario but set in others, e.g. the production service.

This patch addresses the problem by consolidating all of the environment
handling behavior into a single authoritative method.  The behavior
itself remains unchanged, GEM_HOME is set based on the config file
value, PATH and HOME are the only variables allowed to flow through to
JRuby unmodified, all other variables are filtered out, and JARS_REQUIRE
and JARS_NO_REQUIRE are set appropriately.

In addition to the environment handling, this patch also consolidates
the JRuby load path handling in a similar fashion across the scenarios
of command line utilities and the production service.

(maint) Fix managed-load-path schema errors

Fix this error:

    Caused by: clojure.lang.ExceptionInfo: Output of managed-load-path does not match schema: [(not (instance? java.lang.String a-java.io.File)) (not (instance? java.lang.String a-java.io.File)) (not (instance? java.lang.String a-java.io.File)) (not (instance? java.lang.String a-java.io.File)) (not (instance? java.lang.String a-java.io.File)) (not (instance? java.lang.String a-java.io.File))]
     at puppetlabs.services.jruby.jruby_puppet_internal$eval9067$managed_load_path__9068.invoke (jruby_puppet_internal.clj:69)
        puppetlabs.services.jruby.jruby_puppet_internal$prep_scripting_container.invoke (jruby_puppet_internal.clj:89)
        puppetlabs.services.jruby.jruby_puppet_internal$empty_scripting_container.invoke (jruby_puppet_internal.clj:101)
        puppetlabs.services.jruby.jruby_puppet_internal$create_scripting_container.invoke (jruby_puppet_internal.clj:117)
        puppetlabs.services.jruby.jruby_puppet_internal$eval9122$create_pool_instance_BANG___9123$fn__9124.invoke (jruby_puppet_internal.clj:156)
        puppetlabs.services.jruby.jruby_puppet_internal$eval9122$create_pool_instance_BANG___9123.invoke (jruby_puppet_internal.clj:141)

(maint) Remove unused definitions from jruby-puppet-core

These defs moved over to jruby-puppet-internal in
23154f42f24351e55a329cf52663d291c4c5312f and are no longer used from
jruby-puppet-core.

(SERVER-297) Fix up LOAD_PATH behavior

Without this patch the load path behavior is incorrect because the use
of normalized and absolute paths is incompatible with the use of loading
resources from a sealed jar.  This patch addresses the problem by
restoring the previous behavior of implicitly relying in JRuby's
LoadService implementation.

For more information, particularly on the combination and interaction of
load path, class path, and ruby require, please see:

https://github.com/jruby/jruby/blob/1.7.20/core/src/main/java/org/jruby/runtime/load/LoadService.java

(SERVER-297) Add jruby subcommand integration tests

Without this patch there are not tests covering the behavior of the irb,
ruby, and gem JRuby subcommands.  This patch addresses the problem by
adding integration tests that assert against standard output and the
exit status.

NB this patch differs from the patch against master in that the
ruby-load-path setting is under the os-settings configuration section in
this patch while it is under the jruby-puppet section in the patch
against master for puppetserver 2.0

(SERVER-297) Check if subcommand exists before loading

Without this patch the subcommand string given to the cli-run! command
may not actually exist in the assumed directory of
META-INF/jruby.home/bin/  This patch checks before trying to execute the
given subcommand.

(maint) Mark j_p_internal functions public / private

Addressing PR comments, sorted by using "find usages" in cursive.

(maint) Add compile-mode, compat-version defs

Without this patch the initialization logic for the JRuby instances in
new-main and prep-scripting-container are almost identical.  This is a
problem because they should be identical and the compatibility version
and compile mode are not referenced in a way that changing one will also
change the other.

This patch addresses the problem by making the behavior identical
without going so far as to providing a single function that operates on
both classes of objects.

(maint) use schema/maybe instead of schema/pred nil?

(SERVER-297) Add acceptance tests for env behavior

Without this patch there aren't any acceptance tests that validate the
behavior of environment handling.  This patch addresses the problem by
adding a test for the irb and ruby commands.  The gem command is already
tested via the `gem env` command and is difficult to inspect the
environment from since it doesn't evaluate arbitrary code like irb and
ruby can.

(maint) Fix failing FOO_DEBUG irb and ruby CLI tests

The smoke tests are failing checking that FOO_DEBUG is being preserved
for the irb and ruby subcommands.  This is a problem because the
behavior has been consolidated around the behavior of the production
scripting container which is to filter out variables like FOO_DEBUG.
This patch addresses the problem by changing the test to assert the
desired behavior.

(maint) Fix failing smoke test on undefined var output

Fixes:

    #<NameError: undefined local variable or method `output'

(maint) Fix failing smoke test on irb -e

Fixes this error:

    IRB::UnrecognizedSwitch: Unrecognized switch: -e

irb reads from STDIN, it doesn't have a -e flag like the ruby command
does.

(maint) Add jruby-schemas/EnvMap