### PR TITLE
(SERVER-723) Return good Content-Type for CA errors

### DIFF
--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -385,6 +385,9 @@
                          :body (body-stream "{\"desired_state\":\"signed\"}")}
                 response (test-app request)]
             (is (= 404 (:status response)))
+            (is (= "text/plain; charset=UTF-8"
+                  (get-in response [:headers "Content-Type"]))
+              "Unexpected content type for response")
             (is (= "Invalid certificate subject." (:body response)))))
 
         (testing "Additional error handling on PUT requests"
@@ -397,9 +400,11 @@
                              :request-method :put
                              :body           (body-stream "{\"desired_state\":\"revoked\"}")}
                     response (test-app request)]
-
                 (is (= 409 (:status response))
                     (ks/pprint-to-string response))
+                (is (= "text/plain; charset=UTF-8"
+                      (get-in response [:headers "Content-Type"]))
+                  "Unexpected content type for response")
                 (is (= (:body response)
                        "Cannot revoke certificate for host test-agent without a signed certificate")
                     (ks/pprint-to-string response))))
@@ -410,6 +415,9 @@
                              :body           (body-stream "{\"desired_state\":\"signed\"}")}
                     response (test-app request)]
                 (is (= 409 (:status response)))
+                (is (= "text/plain; charset=UTF-8"
+                      (get-in response [:headers "Content-Type"]))
+                  "Unexpected content type for response")
                 (is (= (:body response)
                        "Cannot sign certificate for host localhost without a certificate request"))))
 
@@ -510,6 +518,9 @@
               response (test-app request)]
           (is (= 409 (:status response))
               (ks/pprint-to-string response))
+          (is (= "text/plain; charset=UTF-8"
+                (get-in response [:headers "Content-Type"]))
+            "Unexpected content type for response")
           (is (= (:body response)
                  (str "CSR 'hostwithaltnames' contains subject alternative names "
                       "(DNS:altname1, DNS:altname2, DNS:altname3), which are disallowed. "
@@ -523,6 +534,9 @@
               response (test-app request)]
           (is (= 409 (:status response))
               (ks/pprint-to-string response))
+          (is (= "text/plain; charset=UTF-8"
+                (get-in response [:headers "Content-Type"]))
+            "Unexpected content type for response")
           (is (= (:body response)
                  "Found extensions that are not permitted: 1.9.9.9.9.9.9")))))))
 


### PR DESCRIPTION
This commit wraps plain text error responses to CA requests with a
Content-Type of "text/plain" for 'error' cases in which liberator does
not automatically set the Content-Type.  Previously, these error cases
would have resulted in a Content-Type of ";charset=UTF-8" being
delivered in the response.  Some clients would subsequently fail to be
able to parse the error response correctly.