### PR TITLE
(SERVER-724) Fix Fedora 21 3.x failures

### DIFF
--- a/acceptance/lib/puppetserver/acceptance/compat_utils.rb
+++ b/acceptance/lib/puppetserver/acceptance/compat_utils.rb
@@ -1,5 +1,11 @@
 def nonmaster_agents()
-  agents.reject { |agent| agent == master }
+  agents.reject { |agent| agent.host_hash[:platform].start_with?('fedora-21') || agent == master }
+end
+
+# This is all agents minus those legacy agents running Fedora 21, as it is not supported
+# by Puppet 3.x
+def valid_agents
+  agents.reject{ |agent| agent.host_hash[:platform].start_with?('fedora-21') && agent != master }
 end
 
 def apply_simmons_class(agent, studio, classname)
@@ -19,7 +25,7 @@ end
 def rm_vardirs()
   # In order to prevent file caching and ensure agent-master HTTP communication
   # during agent runs we blow away the vardirs, which contains the cached files
-  hosts.each do |host|
+  valid_agents.each do |host|
     vardir = on(host, puppet("config print vardir")).stdout.chomp
     on(host, "rm -rf #{vardir}")
   end

--- a/acceptance/scripts/test-full-puppet3compat.sh
+++ b/acceptance/scripts/test-full-puppet3compat.sh
@@ -6,4 +6,4 @@ export GENCONFIG_LAYOUT="${GENCONFIG_LAYOUT:-redhat6-64ma-debian6-64a-windows200
 export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-acceptance/suites/puppet3_tests}"
 export BEAKER_PRESUITE="acceptance/suites/pre_suite/puppet3_compat"
 
-bash ./acceptance/scripts/generic/testrun-full.sh
+bash ./acceptance/scripts/generic/testrun.sh

--- a/acceptance/suites/pre_suite/puppet3_compat/80_configure_agents.rb
+++ b/acceptance/suites/pre_suite/puppet3_compat/80_configure_agents.rb
@@ -2,7 +2,7 @@ require 'puppetserver/acceptance/compat_utils'
 
 step "Perform agent upgrade steps" do
   step "Enable structured facts" do
-    on(agents, puppet("config set stringify_facts false --section agent"))
+    on(valid_agents, puppet("config set stringify_facts false --section agent"))
   end
 end
 

--- a/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
+++ b/acceptance/suites/puppet3_tests/010_hello_world/testtest.rb
@@ -1,10 +1,7 @@
 test_name "Testing Master/Agent backwards compatibility"
 
-# Agent running on the master is current, not legacy.
-legacy_agents = agents.reject { |agent| agent == master }
-
 step "Check that legacy agents have Puppet 3.x installed"
-on(legacy_agents, puppet("--version")) do
+on(nonmaster_agents, puppet("--version")) do
   assert(stdout.start_with? "3.", "puppet --version does not start with major version 3.")
 end
 

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/binary_file_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('binary_file_test')
 
   step "Apply simmons::binary_file to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/content_file_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('content_file_test')
 
   step "Apply simmons::content_file to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/custom_fact_output_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('custom_fact_output_test')
 
   step "Apply simmons::custom_fact_output to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/external_fact_output_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('external_fact_output_test')
 
   step "Apply simmons::external_fact_output to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_binary_file_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('mount_point_binary_file_test')
 
   step "Apply simmons::mount_point_binary_file to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/mount_point_source_file_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('mount_point_source_file_test')
 
   step "Apply simmons::mount_point_source_file to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/recursive_directory_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('recursive_directory_test')
 
   step "Apply simmons::recursive_directory to agent #{agent.platform}" do

--- a/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
+++ b/acceptance/suites/puppet3_tests/020_backwards_compat/source_file_test.rb
@@ -6,7 +6,7 @@ teardown do
   rm_vardirs()
 end
 
-agents.each do |agent|
+valid_agents.each do |agent|
   studio = agent.tmpdir('source_file_test')
 
   step "Apply simmons::source_file to agent #{agent.platform}" do


### PR DESCRIPTION
Do not run the 3.x compatibility tests on Fedora 21 agents, as
Puppet 3.x does not support Fedora 21.