### PR TITLE
(SERVER-761) Bump JRuby dependency to version 1.7.20.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.0"]
                  [puppetlabs/http-client "0.4.4"]
-                 [org.jruby/jruby-core "1.7.20"
+                 [org.jruby/jruby-core "1.7.20.1"
                   :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  ;; jffi and jnr-x86asm are explicit dependencies because,
                  ;; in JRuby's poms, they are defined using version ranges,
@@ -29,7 +29,7 @@
                  ;; NOTE: jruby-stdlib packages some unexpected things inside
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
-                 [org.jruby/jruby-stdlib "1.7.20"]
+                 [org.jruby/jruby-stdlib "1.7.20.1"]
                  [org.clojure/data.json "0.2.3"]
                  [org.clojure/tools.macro "0.1.5"]
                  [joda-time "2.5"]


### PR DESCRIPTION
This commit bumps Puppet Server's JRuby dependency to 1.7.20.1 in order
to mitigate RubyGems CVE-2015-4020.