### PR TITLE
(MAINT) Switch puppet submodule to core Puppet and remove bundler pin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = https://github.com/camlow325/puppet.git
+	url = https://github.com/puppetlabs/puppet.git
 [submodule "ruby/facter"]
 	path = ruby/facter
 	url = https://github.com/puppetlabs/facter.git

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,3 @@
-## Starting with version 1.10.0 of bundler, the .gemspec file from core
-## Ruby Puppet is automatically validated at 'bundle install' startup.
-## The rubygems version in JRuby, 2.4.6, is not the same as the rubygems
-## version in the core Puppet repo's .gemspec file, 1.8.24.  This causes
-## validation to fail and, therefore, for the "bundle install" to fail.
-## Pinning to bundler version 1.9.9 for now because it doesn't
-## enforce validation.  Need to figure out a better long-term solution.
-## See SERVER-697 for follow-up.
-
-BUNDLER_VER = '1.9.9'
-
 PROJECT_ROOT = File.dirname(__FILE__)
 ACCEPTANCE_ROOT = ENV['ACCEPTANCE_ROOT'] ||
   File.join(PROJECT_ROOT, 'acceptance')
@@ -49,7 +38,7 @@ namespace :spec do
       ## Line 2 programmatically runs 'gem install bundler' via the gem command that comes with JRuby
       gem_install_bundler = <<-CMD
       lein run -m org.jruby.Main \
-      -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler -v '#{BUNDLER_VER}'
+      -e 'load "META-INF/jruby.home/bin/gem"' install -i '#{TEST_GEMS_DIR}' --no-rdoc --no-ri bundler
       CMD
       sh gem_install_bundler
 


### PR DESCRIPTION
This commit contains a couple of changes:

1) Switch the ruby/puppet submodule back from a commit on
   camlow325/puppet to one on puppetlabs/puppet.  The prior submodule
   was used temporarily because of broken tests being skipped per
   PUP-4659.  The PUP ticket has been fixed now, though, so these
   tests should be runnable again.

2) Unpin bundler version 1.9.9.  This was done previously because
   1.10.0 would fail because of a rubygems version mismatch between the
   Puppet .gemspec requirement and JRuby rubygems version.  The Puppet
   .gemspec rubygems requirement is no longer present with this new
   Puppet submodule and, therefore, the bundler pin should no longer be
   needed.