### PR TITLE
(SERVER-749) Update release notes for 1.1.1

### DIFF
--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -4,6 +4,49 @@ title: "Puppet Server: Release Notes"
 canonical: "/puppetserver/latest/release_notes.html"
 ---
 
+## Puppet Server 1.1.1
+
+Released June 18, 2015
+
+This is a security and bug fix release of Puppet Server 1.1 series.  No new
+features have been added since 1.1.0 in accordance with [Semantic
+Version](http://semver.org) guidelines.  All users are recommended to upgrade.
+
+### Bug fixes
+
+#### Upgrade JRuby from 1.7.20 to 1.7.20.1 to resolve CVE-2015-4020
+
+Bump JRuby dependency to version 1.7.20.1 to resolve
+[CVE-2015-1855](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1855)
+where JRuby has updated Rubygems to version 2.4.8. Rubygems 2.4.8 addresses
+CVE-2015-1855 to resolve some problems with wildcard matching of hostnames. See
+ruby-lang.org’s description for more info.
+
+ * [SERVER-761](https://tickets.puppetlabs.com/browse/SERVER-761)
+
+#### Consolidate environment handling behavior
+
+Consolidate JRuby environment handling, which was previously inconsistent across
+the use cases of `puppetserver gem`, `puppetserver irb`, `puppetserver ruby` and
+the puppetserver service.
+
+ * [SERVER-297](https://tickets.puppetlabs.com/browse/SERVER-297)
+
+#### Return good Content-Type for CA errors
+
+Two bugs in the way the CA service responds which caused issues for services
+consuming the CA API have been fixed.
+
+ * [SERVER-723](https://tickets.puppetlabs.com/browse/SERVER-723) Fix
+   Content-Type header in CA responses
+ * [SERVER-646](https://tickets.puppetlabs.com/browse/SERVER-646) Allow
+   charset for certificate_status content-type (b17a242)
+
+### Miscellaneous improvements
+
+Minor changes to documentation following the 1.1.0 release, primarily the
+re-introduction of the /status endpoint documentation.
+
 ## Puppet Server 1.1.0
 
 Released June 2, 2015
@@ -225,50 +268,3 @@ For a list of all changes in this release, see the following Jira pages:
 
 * [All Puppet Server issues targeted at this release](https://tickets.puppetlabs.com/browse/SERVER/fixforversion/12023/)
 * [All Trapperkeeper issues targeted at this release](https://tickets.puppetlabs.com/browse/TK/fixforversion/12131/)
-
-## Puppet Server 0.4.0
-
-This release contains improvements based on feedback from the community and
-Puppet Labs QA testing. It has usability and correctness improvements, mainly
-around SSL and our interaction with systemd. Notable changes:
-
-* (SERVER-89) The Puppet Server CA now creates a 'puppet' Subject Alternate
-  Name for master certificates for closer compatibility with the Ruby CA.
-* (SERVER-86) The CA no longer uses the 'ca_pub.pem' (which isn't guaranteed
-  to exist) when signing or revoking; instead it extracts the key from the
-  certificate directly (which IS guaranteed to be there).
-* (SERVER-70, SERVER-8, SERVER-84) Improvements around packaging will make
-  the Puppet Server behave better under OSes which use systemd and will now
-  preserve local changes to the /etc/sysconfig/puppetserver config on
-  upgrade.
-
-For a full list of bugs fixed in this release, check out the JIRA release page:
-https://tickets.puppetlabs.com/browse/SERVER/fixforversion/12014
-
-## Puppet Server 0.3.0
-This is the first feature update since the initial Puppet Server release.
-Notable user-facing improvements are:
-
-* (SERVER-18, SERVER-39) Puppet Server now supports externally-terminated SSL
-  in the same way as external termination on Apache+Passenger does.
-* (SERVER-4) Improve error messages and user feedback when starting on systems
-  with low memory. (We recommend at least 2GB RAM)
-* (SERVER-43) Add support for HTTP "basic" authentication; this was preventing
-  the 'http' report processor used by Dashboard from working.
-
-For a full list of bugs fixed in the release, check out this JIRA page:
-https://tickets.puppetlabs.com/browse/SERVER/fixforversion/11955
-
-## Puppet Server 0.2.2
-* (SERVER-13) Fix for file descriptor leak during report processing
-* (SERVER-7) Add licensing and copyright info
-* HTTP client connections from the master use the `localcacert` puppet.conf
-  setting to find the CA certs to use for validating a server.  Previously, the
-  `cacert` puppet.conf setting was used to find the CA certs used to validate
-  the server.
-
-## Puppet Server 0.2.1
-* (SERVER-9) Privileged data is accessible to non-privileged local users [CVE-2014-7170]
-
-## Puppet Server 0.2.0
- Initial Open Source Release


### PR DESCRIPTION
[ci skip] because this is a documentation only patch.