### PR TITLE
(MAINT) cherry-pick PUP-4659 test fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = https://github.com/puppetlabs/puppet.git
+	url = https://github.com/camlow325/puppet.git
 [submodule "ruby/facter"]
 	path = ruby/facter
 	url = https://github.com/puppetlabs/facter.git


### PR DESCRIPTION
This commit is a follow-on to the commit from PR #609, e1abff.  In that
commit, the Puppet submodule had been pointed from the camlow325/puppet
fork back to puppetlabs/puppet under the assumption that the underlying
test fixes would be good for Puppet Server acceptance testing to use.
Unfortunately, this is not yet the case because of the following issues:

1) Puppet Server acceptance for the master branch currently uses
puppet-agent 1.1.0 (puppet core 4.1.0).  Tests created/modified for the
following tickets were done post-puppet core 4.1.0 - PUP-2638 and
PUP-4538.

2) The new 'calling_all_functions' test is not currently working for the
agent configuration that Puppet Server uses - see PUP-4749.

This commit reverts back to the camlow325/puppet fork temporarily but
with the fixes for the environment_scenario acceptance tests done for
PUP-4659 cherry-picked into that fork.  This will allow Puppet Server to
run basically with the acceptance tests as they were for puppet core
4.1.0 but with just the minimal additional changes applied to compensate
for test issues.