### PR TITLE
(SERVER-759) Do not forward disabled CA routes

### DIFF
--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -33,24 +33,37 @@
   [& args]
   (str (apply fs/file master-conf-dir "ssl" args)))
 
-(defmacro with-puppetserver-running
-  [app config-overrides & body]
+(defn load-dev-config-with-overrides
+  [overrides]
   (let [tmp-conf (ks/temp-file "puppet-server" ".conf")]
     (fs/copy dev-config-file tmp-conf)
-    (let [config (-> (tk-config/load-config (.getPath tmp-conf))
-                     (assoc-in [:global :logging-config] logging-test-conf-file)
-                     (assoc-in [:jruby-puppet :master-conf-dir] master-conf-dir)
-                     (assoc-in [:jruby-puppet :master-code-dir] master-code-dir)
-                     (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)
-                     (assoc-in [:jruby-puppet :master-run-dir] master-run-dir)
-                     (assoc-in [:jruby-puppet :master-log-dir] master-log-dir)
-                     (ks/deep-merge config-overrides))]
-      `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
-         (tk-testutils/with-app-with-config
-           ~app
-           services#
-           ~config
-           ~@body)))))
+    (-> (tk-config/load-config (.getPath tmp-conf))
+        (assoc-in [:global :logging-config] logging-test-conf-file)
+        (assoc-in [:jruby-puppet :master-conf-dir] master-conf-dir)
+        (assoc-in [:jruby-puppet :master-code-dir] master-code-dir)
+        (assoc-in [:jruby-puppet :master-var-dir] master-var-dir)
+        (assoc-in [:jruby-puppet :master-run-dir] master-run-dir)
+        (assoc-in [:jruby-puppet :master-log-dir] master-log-dir)
+        (ks/deep-merge overrides))))
+
+(defmacro with-puppetserver-running-with-services
+  [app services config-overrides & body]
+  (let [config (load-dev-config-with-overrides config-overrides)]
+    `(tk-testutils/with-app-with-config
+       ~app
+       ~services
+       ~config
+       ~@body)))
+
+(defmacro with-puppetserver-running
+  [app config-overrides & body]
+  (let [config (load-dev-config-with-overrides config-overrides)]
+    `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
+       (tk-testutils/with-app-with-config
+         ~app
+         services#
+         ~config
+         ~@body))))
 
 (defn pem-file
   [& args]

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -6,7 +6,16 @@
             [schema.test :as schema-test]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [me.raynes.fs :as fs]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [puppetlabs.services.request-handler.request-handler-service :as handler]
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as webserver]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting]
+            [puppetlabs.services.config.puppet-server-config-service :as ps-config]
+            [puppetlabs.services.legacy-routes.legacy-routes-service :as legacy-routes]
+            [puppetlabs.services.puppet-admin.puppet-admin-service :as admin]
+            [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled-ca]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test")
@@ -43,3 +52,28 @@
             (bootstrap/with-puppetserver-running app
                                                  {:web-router-service {::master-service/master-service {:foo "/bar"}}}
                                                  (is (= 200 (:status (http-get "/puppet/v3/node/localhost?environment=production"))))))))))
+
+(deftest ^:integration legacy-ca-routes-disabled
+  (testing "The legacy CA routes are on longer forwarded"
+    (logutils/with-test-logging
+      (bootstrap/with-puppetserver-running-with-services
+        app
+        [handler/request-handler-service
+         jruby/jruby-puppet-pooled-service
+         profiler/puppet-profiler-service
+         webserver/jetty9-service
+         webrouting/webrouting-service
+         ps-config/puppet-server-config-service
+         master-service/master-service
+         legacy-routes/legacy-routes-service
+         admin/puppet-admin-service
+         disabled-ca/certificate-authority-disabled-service]
+        {}
+
+        (is (= 404 (:status (http-get "/production/certificate_statuses/all")))
+            (str "A 404 was not returned, indicating that the legacy CA routes "
+                 "are still being forwarded to the core CA functions."))
+
+        (is (not (= 200 (:status (http-get "/production/certificate_statuses/all"))))
+            (str "A 200 was returned from a request made to a legacy CA endpoint "
+                 "indicating the disabled CA service was not detected."))))))


### PR DESCRIPTION
Previously all CA routes were forwarded directly the core CA functions,
even if the disabled CA service was enabled. This commit removes the
legacy CA forwarding when the disabled CA service is enabled.