### PR TITLE
(MAINT) Bump puppet-agent dep and puppet module - 2015-06-18

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ruby/puppet"]
 	path = ruby/puppet
-	url = https://github.com/camlow325/puppet.git
+	url = https://github.com/puppetlabs/puppet.git
 [submodule "ruby/facter"]
 	path = ruby/facter
 	url = https://github.com/puppetlabs/facter.git

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -25,11 +25,11 @@ module PuppetServerExtensions
                          nil, "Puppet Version", "PUPPET_VERSION", nil) ||
                          get_puppet_version
 
-    # SERVER-339, SERVER-386 - puppet-agent version corresponds to packaged
-    # development version located at http://builds.puppetlabs.lan/puppet-agent/
+    # puppet-agent version corresponds to packaged development version located at:
+    # http://builds.puppetlabs.lan/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "1.1.0")
+                         "PUPPET_BUILD_VERSION", "42427827d2d923e040f0a6083fccdd2bda876858")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
This commit bumps the puppet-agent version dependency and puppet
submodule forward to a version which is closer to what is
planned for release in puppet-agent 1.2.0.  This is being done to get
some early feedback on potential conflicts between the forthcoming
puppet-agent release and latest puppetserver master branch code.