### PR TITLE
(MAINT) Bump expected Puppet version to 4.2.0 in spec test

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.1.0')
+      expect(subject).to eq('4.2.0')
     end
   end
 


### PR DESCRIPTION
This commit bumps the expected Puppet version in the `master_spec.rb`
Ruby spec test up to 4.2.0, in order to line up with the new version of
the Puppet submodule which is being used as of PR #619 being merged.