### PR TITLE
(docs) Store navigation sidebar alongside Puppet Server docs content

### DIFF
--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -1,0 +1,39 @@
+{% capture server_version %}2.1{% endcapture %}
+
+
+<h3 id="puppetserver-{{server_version}}-docs">Puppet Server {{ server_version }} Docs</h3>
+
+    <ul>
+      <li><a href="/puppetserver/{{ server_version }}/index.html">Index</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/services_master_puppetserver.html">About Puppet Server</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/release_notes.html">Release Notes</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/puppetserver_vs_passenger.html">Notable Differences vs. the Apache/Passenger Stack</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/install_from_packages.html">Installation</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/configuration.html">Configuring Puppet Server</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/puppet_conf_setting_diffs.html">Differing Behavior in puppet.conf</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/gems.html">Using Ruby Gems</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/subcommands.html">Subcommands</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/compatibility_with_puppet_agent.html">Backwards Compatibility With Puppet 3 Agents</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/external_ca_configuration.html">Using an External CA</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/external_ssl_termination.html">External SSL Termination</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/tuning_guide.html">Tuning Guide</a></li>
+      <li><strong>Known Issues and Workarounds</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/known_issues.html">Known Issues</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/ssl_server_certificate_change_and_virtual_ips.html">SSL Problems With Load-Balanced PuppetDB Servers ("Server Certificate Change" error)</a></li>
+        </ul>
+      </li>
+      <li><strong>Administrative API</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/environment-cache.html">Environment Cache</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/admin-api/v1/jruby-pool.html">JRuby Pool</a></li>
+        </ul>
+      </li>
+      <li><strong>Developer Info</strong>
+        <ul>
+          <li><a href="/puppetserver/{{ server_version }}/dev_debugging.html">Debugging</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/dev_running_from_source.html">Running From Source</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/dev_trace_func.html">Tracing Code Events</a></li>
+        </ul>
+      </li>
+    </ul>


### PR DESCRIPTION
In the docs.puppetlabs.com website, we use a central config file to assign an
HTML fragment as the navigation sidebar for a group of pages.

It used to be that we had to store these fragments in one specific directory,
but we recently revised our tools so we could load an HTML fragment from any
content directory.

This makes it possible to maintain the navigation TOC right alongside the
content that it governs. The PuppetDB team have been doing this for a few months
now, and it makes it much easier to add or delete a page.

Once this PR is merged, there will be two new tasks for maintaining these docs:

* If you add a page, add it to the TOC. Its URL should be an absolute path from
  the root of the docs site, and should use a {{server_version}} placeholder
  to represent the version number.
* When it's time to start preparing for a new X.Y release, change the
  server_version value at the top of the nav fragment.