### PR TITLE
(SERVER-719) Improve documentation around master-dir settings

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -59,7 +59,7 @@ By default, Puppet Server is configured to use the correct Puppet Master and CA 
 
 This file contains the settings for Puppet Server itself.
 
-> **Note:** Most users should never set the `master-conf-dir`, `master-code-dir`, or `master-var-dir` settings to a non-default value. If you do, you must also change the equivalent Puppet settings (`confdir`, `codedir`, or `vardir`) to ensure that commands like `puppet cert` and `puppet module` will use the same directories as Puppet Server. Note also that a non-default `confdir` or `vardir` must be specified on the command line when running commands, since those two settings must be set before Puppet tries to find its config file.
+> **Note:** Most users should never set the `master-conf-dir` or `master-code-dir` settings to a non-default value. If you do, you must also change the equivalent Puppet settings (`confdir` or `codedir`) to ensure that commands like `puppet cert` and `puppet module` will use the same directories as Puppet Server. Note also that a non-default `confdir` must be specified on the command line when running commands, since that setting must be set before Puppet tries to find its config file.
 
 * The `jruby-puppet` settings configure the interpreter:
     * `ruby-load-path`: Where the Puppet Server expects to find Puppet, Facter, etc.

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -211,3 +211,28 @@ Puppet Server does not currently consider this setting for any code running on t
 ### [`http_proxy_port`](https://docs.puppetlabs.com/references/latest/configuration.html#httpproxyport)
 
 Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
+
+## Overriding Puppet settings in Puppet Server
+
+Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](configuration.markdown#puppetserver.conf) contains five settings
+(`master-conf-dir`, `master-code-dir`, `master-var-dir`, `master-run-dir`, and `master-log-dir`) that allow you to override settings set in
+your `puppet.conf` file. On installation, these five settings will be set to the default value that would normally be read by your
+`puppet.conf` file.
+
+While you are free to change these settings at will, please note that any changes made to the `master-conf-dir` and `master-code-dir` settings
+absolutely MUST be made to the corresponding Puppet settings (`confdir` and `codedir`) as well to ensure that Puppet Server and the puppet
+cli tools (such as `puppet cert` and `puppet module`) use the same directories as Puppet Server. The `master-conf-dir` and `master-code-dir`
+settings apply to Puppet Server only, and will be ignored by the ruby code that runs when the puppet CLI tools are run.
+
+For example, say you have the `codedir` setting left unset in your `puppet.conf` file, and you change the `master-code-dir` setting to
+`/etc/my-puppet-code-dir`. In this case, Puppet Server will read code from `/etc/my-puppet-code-dir`, but the `puppet module` tool will
+think that your code is stored in `/etc/puppetlabs/code`.
+
+While it is not as critical to keep `master-var-dir`, `master-run-dir`, and `master-log-dir` in sync with the `vardir`, `rundir`, and `logdir`
+Puppet settings, please note that this applies to these settings as well.
+
+Also, please note that these configuration differences also apply to the interpolation of the `confdir`, `codedir`, `vardir`, `rundir`, and `logdir`
+settings in your `puppet.conf` file. So, take the above example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Since the
+`basemodulepath` setting is by default `$codedir/modules:/opt/puppetlabs/puppet/modules`, then Puppet Server would use
+`/etc/my-puppet-code-dir:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting, whereas the `puppet module` tool would use
+`/etc/puppetlabs/code:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting.

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -216,13 +216,12 @@ Puppet Server does not currently consider this setting for any code running on t
 
 Currently, the [`jruby-puppet` section of your `puppetserver.conf` file](configuration.markdown#puppetserver.conf) contains five settings
 (`master-conf-dir`, `master-code-dir`, `master-var-dir`, `master-run-dir`, and `master-log-dir`) that allow you to override settings set in
-your `puppet.conf` file. On installation, these five settings will be set to the default value that would normally be read by your
-`puppet.conf` file.
+your `puppet.conf` file. On installation, these five settings will be set to the proper default values.
 
 While you are free to change these settings at will, please note that any changes made to the `master-conf-dir` and `master-code-dir` settings
-absolutely MUST be made to the corresponding Puppet settings (`confdir` and `codedir`) as well to ensure that Puppet Server and the puppet
-cli tools (such as `puppet cert` and `puppet module`) use the same directories as Puppet Server. The `master-conf-dir` and `master-code-dir`
-settings apply to Puppet Server only, and will be ignored by the ruby code that runs when the puppet CLI tools are run.
+absolutely MUST be made to the corresponding Puppet settings (`confdir` and `codedir`) as well to ensure that Puppet Server and the Puppet
+cli tools (such as `puppet cert` and `puppet module`) use the same directories. The `master-conf-dir` and `master-code-dir`
+settings apply to Puppet Server only, and will be ignored by the ruby code that runs when the Puppet CLI tools are run.
 
 For example, say you have the `codedir` setting left unset in your `puppet.conf` file, and you change the `master-code-dir` setting to
 `/etc/my-puppet-code-dir`. In this case, Puppet Server will read code from `/etc/my-puppet-code-dir`, but the `puppet module` tool will
@@ -234,5 +233,5 @@ Puppet settings, please note that this applies to these settings as well.
 Also, please note that these configuration differences also apply to the interpolation of the `confdir`, `codedir`, `vardir`, `rundir`, and `logdir`
 settings in your `puppet.conf` file. So, take the above example, wherein you set `master-code-dir` to `/etc/my-puppet-code-dir`. Since the
 `basemodulepath` setting is by default `$codedir/modules:/opt/puppetlabs/puppet/modules`, then Puppet Server would use
-`/etc/my-puppet-code-dir:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting, whereas the `puppet module` tool would use
-`/etc/puppetlabs/code:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting.
+`/etc/my-puppet-code-dir/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting, whereas the `puppet module` tool would use
+`/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules` for the value of the `basemodulepath` setting.

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -11,19 +11,21 @@ jruby-puppet: {
 
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings
-    # for Puppet Server, but not for the puppet CLI tools. This likely will not
+    # for Puppet Server, but not for the Puppet CLI tools. This likely will not
     # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
     # some critical setting in puppet.conf is interpolating the value of one
     # of the corresponding settings, but it is important that any changes made to
-    # master-conf-dir and master-code-dir are also made to the corresponding puppet
-    # settings when running the puppet CLI tools. See
+    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # settings when running the Puppet CLI tools. See
     # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
     # for more information.
 
-    # (optional) path to puppet conf dir; if not specified, will use the puppet default
+    # (optional) path to puppet conf dir; if not specified, will use
+    # /etc/puppetlabs/puppet
     master-conf-dir: /etc/puppetlabs/puppet
 
-    # (optional) path to puppet code dir; if not specified, will use the puppet default
+    # (optional) path to puppet code dir; if not specified, will use
+    # /etc/puppetlabs/code
     master-code-dir: /etc/puppetlabs/code
 
     # (optional) path to puppet var dir; if not specified, will use

--- a/resources/ext/config/conf.d/puppetserver.conf
+++ b/resources/ext/config/conf.d/puppetserver.conf
@@ -8,19 +8,34 @@ jruby-puppet: {
     # used by the `puppetserver gem` command line tool.
     gem-home: /opt/puppetlabs/server/data/puppetserver/jruby-gems
 
+
+    # PLEASE NOTE: Use caution when modifying the below settings. Modifying
+    # these settings will change the value of the corresponding Puppet settings
+    # for Puppet Server, but not for the puppet CLI tools. This likely will not
+    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # some critical setting in puppet.conf is interpolating the value of one
+    # of the corresponding settings, but it is important that any changes made to
+    # master-conf-dir and master-code-dir are also made to the corresponding puppet
+    # settings when running the puppet CLI tools. See
+    # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
+    # for more information.
+
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
     master-conf-dir: /etc/puppetlabs/puppet
 
     # (optional) path to puppet code dir; if not specified, will use the puppet default
     master-code-dir: /etc/puppetlabs/code
 
-    # (optional) path to puppet var dir; if not specified, will use the puppet default
+    # (optional) path to puppet var dir; if not specified, will use
+    # /opt/puppetlabs/server/data/puppetserver
     master-var-dir: /opt/puppetlabs/server/data/puppetserver
 
-    # (optional) path to puppet run dir; if not specified, will use the puppet default
+    # (optional) path to puppet run dir; if not specified, will use
+    # /var/run/puppetlabs/puppetserver
     master-run-dir: /var/run/puppetlabs/puppetserver
 
-    # (optional) path to puppet log dir; if not specified, will use the puppet default
+    # (optional) path to puppet log dir; if not specified, will use
+    # /var/log/puppetlabs/puppetserver
     master-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow


### PR DESCRIPTION
Improve the documentation around the consequences of changing the master-dir settings in `puppetserver.conf`.