### PR TITLE
Update ezbake to 0.3.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.6"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.11"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
Updates since 0.3.6:

 * Fixes for service account handling on package
   and source based installations
 * Update default startup timeout to 180 seconds
 * Remove EL-5 as a build target
 * Add support for systemd tmpfiles.d configs

 * On package upgrade, update service account information (home dir,
   group membership, etc) if necessary

 * Packaging: Fix varlibdir to use real_name for PE (so its
   app_data/lib/puppetdb, not app_data/lib/pe-puppetdb)
 * Packaging: In Debian, ignore service stops for services that are already
   stopped during upgrade.
 * Packaging: In Debian, add a prerm section to stop services gracefully on a
   failed upgrade.
 * Packaging: Fixed lots of inconsistencies between PE and FOSS, now we are
   closer then ever.
 * Packaging: Users were being created using the old FOSS based homedirs.
 * Packaging: Removal of log files for FOSS during package uninstall removed old
   non-AIO log file dirs.
 * Packaging: sharedstatedir and localstatedir were no longer used, app_data is
   preferred so these have been removed.
 * Packaging: call install.sh in PE using exec
 * Packaging: Debian with PE was not using the group to set permissions, default
   file and init set correctly.
 * Packaging: Tighten up permissions on application data directories, no longer
   world-readable.

 * Packaging: Correct termini install.sh rubylibdir fallback detection for
   source based builds to work.
 * Packaging: Make rubylibdir setting in packaging consistent between PE/FOSS
   and Debian/Redhat.
 * Packaging: Fix: rundir should be created by the rpm package on install/upgrade
 * Packaging: Make install.sh use "localstatedir" variable instad of hardcoding '/var'

 * Packaging: Add Ubuntu Precise and SLES for PE builds