### PR TITLE
(SERVER-251) Add a couple of more jruby flush tests

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -141,6 +141,38 @@
         ;; now the pool is flushed, so the constants should be cleared
         (is (true? (verify-no-constants pool-context 4)))))))
 
+(deftest ^:integration admin-api-multiple-flush-jruby-pool-test
+  (testing "Flushing the jruby pool multiple times results in all new JRuby instances"
+    (bootstrap/with-puppetserver-running
+      app
+      {:puppet-admin {:client-whitelist ["localhost"]}
+       :jruby-puppet {:max-active-instances 4}}
+      (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+            context (tk-services/service-context jruby-service)
+            pool-context (:pool-context context)
+            times-to-flush 3]
+        ;; set a ruby constant in each instance so that we can recognize them
+        (is (true? (set-constants-and-verify pool-context 4)))
+        (let [times-flushed (atom 0)
+              _ (add-watch (:pool-agent pool-context)
+                           :flush-callback
+                           (fn [k _ _ _]
+                             (when (= k :flush-callback)
+                               (swap! times-flushed inc))))
+              wait-until (+ (System/currentTimeMillis) 300000)]
+          (dotimes [_ times-to-flush]
+            (is (true? (trigger-flush ssl-request-options))))
+          (while (and (< (System/currentTimeMillis) wait-until)
+                      (< @times-flushed times-to-flush))
+            (Thread/sleep 100))
+          (is (< (System/currentTimeMillis) wait-until)
+              (str "Pool not flushed expected number of times before timeout"))
+          (is (= @times-flushed times-to-flush)
+              "Pool flushed an unexpected number of times")
+          (remove-watch (:pool-agent pool-context) :flush-callback))
+        ;; now the pool is flushed, so the constants should be cleared
+        (is (true? (verify-no-constants pool-context 4)))))))
+
 (deftest ^:integration hold-instance-while-pool-flush-in-progress-test
   (testing "instance borrowed from old pool before pool flush begins and returned *after* new pool is available"
     (bootstrap/with-puppetserver-running
@@ -159,6 +191,42 @@
           (is (true? (trigger-flush ssl-request-options)))
           ;; wait for the new pool to become available
           (wait-for-new-pool jruby-service)
+          ;; return the instance
+          (jruby-protocol/return-instance jruby-service instance)
+          ;; wait until the flush is complete
+          @flush-complete)
+        ;; now the pool is flushed, and the constants should be cleared
+        (is (true? (verify-no-constants pool-context 4)))))))
+
+(deftest ^:integration hold-file-handle-on-instance-while-pool-flush-in-progress-test
+  (testing "file handle opened from old pool instance is held open across pool flush"
+    (bootstrap/with-puppetserver-running
+      app
+      {:puppet-admin {:client-whitelist ["localhost"]}
+       :jruby-puppet {:max-active-instances 4}}
+      (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+            context (tk-services/service-context jruby-service)
+            pool-context (:pool-context context)]
+        ;; set a ruby constant in each instance so that we can recognize them
+        (is (true? (set-constants-and-verify pool-context 4)))
+        (let [flush-complete (add-watch-for-flush-complete pool-context)
+              ;; borrow an instance and hold the reference to it.
+              instance (jruby-protocol/borrow-instance jruby-service)
+              sc (:scripting-container instance)]
+          (.runScriptlet sc
+                         (str "$unique_file = "
+                              "Puppet::FileSystem::Uniquefile.new"
+                              "('hold-instance-test-', './target')"))
+          (try
+            ;; trigger a flush
+            (is (true? (trigger-flush ssl-request-options)))
+            ;; wait for the new pool to become available
+            (wait-for-new-pool jruby-service)
+
+            (is (nil? (.runScriptlet sc "$unique_file.close"))
+                "Unexpected response on attempt to close unique file")
+            (finally
+              (.runScriptlet sc "$unique_file.unlink")))
           ;; return the instance
           (jruby-protocol/return-instance jruby-service instance)
           ;; wait until the flush is complete


### PR DESCRIPTION
This commit adds a couple of more JRuby pool flush tests:

1) Make multiple JRuby flush requests back-to-back and ensure that
   nothing obviously *bad* happens.

2) Ensure that a file handle open from Ruby code run in a
   `ScriptingContainer` is not automatically invalidated when a
   pool flush is requested.