### PR TITLE
(packaging) Update ezbake to 0.3.13

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -94,7 +94,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.11"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.13"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
Fixes for correctly handling service restarts for package
upgrades on Debian and Ubuntu.
Fixes for upgrading the service account on package upgrade