### PR TITLE
(PE-8226) log jruby events

### DIFF
--- a/dev/bootstrap.cfg
+++ b/dev/bootstrap.cfg
@@ -1,5 +1,6 @@
 puppetlabs.services.request-handler.request-handler-service/request-handler-service
 puppetlabs.services.jruby.jruby-puppet-service/jruby-puppet-pooled-service
+puppetlabs.services.jruby.jruby-event-logger-service/jruby-event-logger-service
 puppetlabs.services.puppet-profiler.puppet-profiler-service/puppet-profiler-service
 puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
 puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -4,6 +4,7 @@
             [puppetlabs.services.master.master-service :refer [master-service]]
             [puppetlabs.services.request-handler.request-handler-service :refer [request-handler-service]]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
+            [puppetlabs.services.jruby.jruby-event-logger-service :refer [jruby-event-logger-service]]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :refer [puppet-profiler-service]]
@@ -53,6 +54,7 @@
                webrouting-service
                master-service
                jruby-puppet-pooled-service
+               jruby-event-logger-service
                puppet-profiler-service
                request-handler-service
                puppet-server-config-service

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -100,7 +100,7 @@
   [jruby-service]
   {:post [(map? %)]}
   (jruby/with-jruby-puppet
-    jruby-puppet jruby-service
+    jruby-puppet jruby-service :get-puppet-config
     (let [config (get-puppet-config* jruby-puppet)]
       (assoc config :puppet-version (.puppetVersion jruby-puppet)))))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_event_logger_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_event_logger_service.clj
@@ -1,0 +1,14 @@
+(ns puppetlabs.services.jruby.jruby-event-logger-service
+  (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
+            [puppetlabs.services.protocols.jruby-event-handler :as jruby-event-protocol]
+            [clojure.tools.logging :as log]))
+
+(trapperkeeper/defservice jruby-event-logger-service
+  jruby-event-protocol/JRubyEventHandlerService
+  []
+  (instance-requested [this action]
+    (log/trace "JRuby instance requested for action:" action))
+  (instance-borrowed [this action instance]
+    (log/trace "JRuby instance" (:id instance) "borrowed for action:" action))
+  (instance-returned [this instance]
+    (log/trace "JRuby instance" (:id instance) "returned.")))

--- a/src/clj/puppetlabs/services/protocols/jruby_event_handler.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_event_handler.clj
@@ -1,0 +1,20 @@
+(ns puppetlabs.services.protocols.jruby-event-handler)
+
+(defprotocol JRubyEventHandlerService
+  "Describes a service which handles events related to the JRubyPuppet pool."
+
+  (instance-requested
+    [this action]
+    "Called when a consumer asks to borrow a JRuby instance.  `action` is an
+    identifier (usually a map) describing the reason for borrowing the
+    JRuby instance.  It may be used for metrics and logging purposes.")
+
+  (instance-borrowed
+    [this action jruby-instance]
+    "Called when a JRuby instance is successfully borrowed from the pool.  `action`
+    is an identifier (usually a map) describing the reason for borrowing the
+    JRuby instance.  `jruby-instance` is a reference to the borrowed instance.")
+
+  (instance-returned
+    [this jruby-instance]
+    "Called when a jruby-instance is returned to the pool."))

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -4,13 +4,16 @@
   "Describes the JRubyPuppet provider service which pools JRubyPuppet instances."
 
   (borrow-instance
-    [this]
+    [this action]
     "Borrows an instance from the JRubyPuppet interpreter pool. If there are no
     interpreters left in the pool then the operation blocks until there is one
     available. A timeout (integer measured in milliseconds) can be configured
     which will either return an interpreter if one is available within the
     timeout length, or will return nil after the timeout expires if no
-    interpreters are available. This timeout defaults to 1200000 milliseconds.")
+    interpreters are available. This timeout defaults to 1200000 milliseconds.
+
+    `action` is an identifier (usually a map) describing the reason for borrowing the
+    JRuby instance.  It may be used for metrics and logging purposes.")
 
   (return-instance
     [this jrubypuppet-instance]

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -281,7 +281,7 @@
     (jruby/with-jruby-puppet
       jruby-instance
       jruby-service
-      {:request request}
+      {:request (dissoc request :ssl-client-cert)}
       (handle-request-via-jruby jruby-instance request config))
     (catch bad-request? e
       (output-error request e 400))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -278,7 +278,10 @@
 (defn handle-request
   [request jruby-service config]
   (sling/try+
-    (jruby/with-jruby-puppet jruby-instance jruby-service
+    (jruby/with-jruby-puppet
+      jruby-instance
+      jruby-service
+      {:request request}
       (handle-request-via-jruby jruby-instance request config))
     (catch bad-request? e
       (output-error request e 400))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -8,6 +8,7 @@
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+            [puppetlabs.services.jruby.jruby-event-logger-service :as jruby-event-logger-service]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
             [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as webrouting]
@@ -247,6 +248,7 @@
           app
           [profiler/puppet-profiler-service
            jruby/jruby-puppet-pooled-service
+           jruby-event-logger-service/jruby-event-logger-service
            jetty9/jetty9-service
            webrouting/webrouting-service
            puppet-admin/puppet-admin-service]

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -107,19 +107,19 @@
   [jruby-service]
   ;; borrow until we get an instance that doesn't have a constant,
   ;; so we'll know that the new pool is online
-  (loop [instance (jruby-protocol/borrow-instance jruby-service)]
+  (loop [instance (jruby-protocol/borrow-instance jruby-service :wait-for-new-pool)]
     (let [has-constant? (constant-defined? instance)]
       (jruby-protocol/return-instance jruby-service instance)
       (when has-constant?
-        (recur (jruby-protocol/borrow-instance jruby-service))))))
+        (recur (jruby-protocol/borrow-instance jruby-service :wait-for-new-pool))))))
 
 (defn borrow-until-desired-borrow-count
   [jruby-service desired-borrow-count]
-  (loop [instance (jruby-protocol/borrow-instance jruby-service)]
+  (loop [instance (jruby-protocol/borrow-instance jruby-service :borrow-until-desired-borrow-count)]
     (let [borrow-count (:borrow-count @(:state instance))]
       (jruby-protocol/return-instance jruby-service instance)
       (if (< (inc borrow-count) desired-borrow-count)
-        (recur (jruby-protocol/borrow-instance jruby-service))))))
+        (recur (jruby-protocol/borrow-instance jruby-service :borrow-until-desired-borrow-count))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
@@ -186,7 +186,8 @@
         (is (true? (set-constants-and-verify pool-context 4)))
         (let [flush-complete (add-watch-for-flush-complete pool-context)
               ;; borrow an instance and hold the reference to it.
-              instance (jruby-protocol/borrow-instance jruby-service)]
+              instance (jruby-protocol/borrow-instance jruby-service
+                         :hold-instance-while-pool-flush-in-progress-test)]
           ;; trigger a flush
           (is (true? (trigger-flush ssl-request-options)))
           ;; wait for the new pool to become available
@@ -211,7 +212,8 @@
         (is (true? (set-constants-and-verify pool-context 4)))
         (let [flush-complete (add-watch-for-flush-complete pool-context)
               ;; borrow an instance and hold the reference to it.
-              instance (jruby-protocol/borrow-instance jruby-service)
+              instance (jruby-protocol/borrow-instance jruby-service
+                         :hold-instance-while-pool-flush-in-progress-test)
               sc (:scripting-container instance)]
           (.runScriptlet sc
                          (str "$unique_file = "
@@ -268,13 +270,15 @@
             (let [flush-complete (add-watch-for-flush-complete pool-context)
                   ;; borrow one instance and hold the reference to it, to prevent
                   ;; the flush operation from completing
-                  instance1 (jruby-protocol/borrow-instance jruby-service)]
+                  instance1 (jruby-protocol/borrow-instance jruby-service
+                              :max-requests-flush-while-pool-flush-in-progress-test)]
               ;; we are going to borrow and return a second instance until we get its
               ;; request count up to max-requests - 1, so that we can use it to test
               ;; flushing behavior the next time we return it.
               (borrow-until-desired-borrow-count jruby-service 9)
               ;; now we grab a reference to that instance and hold onto it for later.
-              (let [instance2 (jruby-protocol/borrow-instance jruby-service)]
+              (let [instance2 (jruby-protocol/borrow-instance jruby-service
+                                :max-requests-flush-while-pool-flush-in-progress-test)]
                 (is (= 9 (:borrow-count @(:state instance2))))
 
                 ;; trigger a flush

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -155,7 +155,8 @@
     (bootstrap/with-puppetserver-running app {:jruby-puppet
                                               {:max-active-instances num-jrubies}}
       (let [jruby-service   (tk-app/get-service app :JRubyPuppetService)
-            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service)
+            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service
+                              :environment-flush-integration-test)
             return-jruby-fn (partial jruby-protocol/return-instance jruby-service)]
         ;; wait for all of the jrubies to be ready so that we can
         ;; validate cache state differences between them.

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -37,7 +37,7 @@
 
         (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
           (jruby/with-jruby-puppet
-            jruby-puppet jruby-service
+            jruby-puppet jruby-service :ca-disabled-files-test
             (is (not (nil? (fs/list-dir ssl-dir))))
             (is (empty? (fs/list-dir (str ssl-dir "/ca"))))))))))
 

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -4,6 +4,7 @@
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+            [puppetlabs.services.jruby.jruby-event-logger-service :as jruby-event-logger]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
@@ -28,6 +29,7 @@
 
         [profiler/puppet-profiler-service
          jruby/jruby-puppet-pooled-service
+         jruby-event-logger/jruby-event-logger-service
          disabled/certificate-authority-disabled-service]
 
         (-> (jruby-testutils/jruby-puppet-tk-config

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -4,6 +4,7 @@
             [puppetlabs.services.config.puppet-server-config-service :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :as core]
             [puppetlabs.services.jruby.jruby-puppet-service :refer [jruby-puppet-pooled-service]]
+            [puppetlabs.services.jruby.jruby-event-logger-service :refer [jruby-event-logger-service]]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]
@@ -15,7 +16,7 @@
 
 (def service-and-deps
   [puppet-server-config-service jruby-puppet-pooled-service jetty9-service
-   profiler/puppet-profiler-service])
+   profiler/puppet-profiler-service jruby-event-logger-service])
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/config/puppet_server_config_service_test")

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -62,7 +62,7 @@
                                     (remove-watch pool-state key)
                                     (deliver pool-state-swapped true)))]
         ; borrow an instance so we know that the pool is ready
-        (jruby/with-jruby-puppet jruby-puppet jruby-service)
+        (jruby/with-jruby-puppet jruby-puppet jruby-service :retry-poison-pill-test)
         (add-watch (:pool-state pool-context) :pool-state-watch pool-state-watch-fn)
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until we know the new pool has been swapped in
@@ -97,6 +97,7 @@
           (jruby/with-jruby-puppet
             jruby-puppet
             jruby-service
+            :with-jruby-retry-test
             (is (instance? JRubyPuppet jruby-puppet))))
         (is (= 4 @num-borrows))))))
 

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -49,6 +49,7 @@
               (jruby/with-jruby-puppet
                 jruby-puppet
                 jruby-service
+                :ca-files-test
 
                 (letfn [(test-path!
                           [setting expected-path]

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -4,6 +4,7 @@
     [puppetlabs.services.master.master-service :refer :all]
     [puppetlabs.services.config.puppet-server-config-service :refer [puppet-server-config-service]]
     [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+    [puppetlabs.services.jruby.jruby-event-logger-service :as jruby-event-logger]
     [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
     [puppetlabs.trapperkeeper.services.webserver.jetty9-service :refer [jetty9-service]]
     [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :refer [webrouting-service]]
@@ -29,6 +30,7 @@
             [master-service
              puppet-server-config-service
              jruby/jruby-puppet-pooled-service
+             jruby-event-logger/jruby-event-logger-service
              jetty9-service
              webrouting-service
              request-handler-service

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -236,7 +236,7 @@
 (deftest handle-request-test
   (def dummy-service
     (reify jruby/JRubyPuppetService
-      (borrow_instance [_] {})
+      (borrow_instance [_ _] {})
       (return_instance [_ _])
       (free_instance_count [_])
       (mark_all_environments_expired_BANG_ [_])
@@ -244,7 +244,7 @@
 
   (def dummy-service-with-timeout
     (reify jruby/JRubyPuppetService
-      (borrow_instance [_] nil)
+      (borrow_instance [_ _] nil)
       (return_instance [_ _])
       (free_instance_count [_])
       (mark_all_environments_expired_BANG_ [_])


### PR DESCRIPTION
This PR does the following:

* Refactors a few functions to make them more re-usable
* Adds an `action` argument to all of the functions related to borrowing a JRuby instance to the pool.  This `action` value is a description of what the JRuby instance will be used for, and can be used in log messages and other places to help provide insight into the state of the running system.
* Adds a `jruby-event-logging-service`, which logs debugging information when interesting events related to the JRuby pool occur.  This implementation is swappable, see PE-8226 for more details.