### PR TITLE
(maint) Fix dev sample config file

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -51,19 +51,19 @@ jruby-puppet: {
     gem-home: ./target/jruby-gems
 
     # (optional) path to puppet conf dir; if not specified, will use the puppet default
-    #master-conf-dir: /etc/puppetlabs/puppet
+    master-conf-dir: ./target/master-conf-dir
 
     # (optional) path to puppet code dir; if not specified, will use the puppet default
-    #master-code-dir: /etc/puppetlabs/code
+    master-code-dir: ./target/master-code-dir
 
     # (optional) path to puppet var dir; if not specified, will use the puppet default
-    #master-var-dir: /opt/puppetlabs/server/data/puppetserver
+    master-var-dir: ./target/master-var-dir
 
     # (optional) path to puppet run dir; if not specified, will use the puppet default
-    #master-run-dir: /var/run/puppetlabs/puppetserver
+    master-run-dir: ./target/master-run-dir
 
     # (optional) path to puppet log dir; if not specified, will use the puppet default
-    #master-log-dir: /var/log/puppetlabs/puppetserver
+    master-log-dir: ./target/master-log-dir
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: 1


### PR DESCRIPTION
Without this change, the dev sample config file cannot be used without
modification - if they are, the server will crash during startup with an
error: "Permission denied - /var/log/puppetlabs"

This error was introduced by f7627a78aa25e647501c22dac4f6d318c6874137