### PR TITLE
(SERVER-781) Add hiera as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ruby/facter"]
 	path = ruby/facter
 	url = https://github.com/puppetlabs/facter.git
+[submodule "ruby/hiera"]
+	path = ruby/hiera
+	url = https://github.com/puppetlabs/hiera.git

--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -13,7 +13,7 @@ product: {
 }
 
 os-settings: {
-    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib]
+    ruby-load-path: [./ruby/puppet/lib, ./ruby/facter/lib, ./ruby/hiera/lib]
 }
 
 webserver: {

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -219,7 +219,7 @@
 (deftest autosign-csr?-ruby-exe-test
   (let [executable (autosign-exe-file "ruby-autosign-executable")
         csr-fn #(csr-stream "test-agent")
-        ruby-load-path ["ruby/puppet/lib" "ruby/facter/lib"]]
+        ruby-load-path ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib"]]
 
     (testing "stdout and stderr are copied to master's log at debug level"
       (logutils/with-test-logging

--- a/test/unit/puppetlabs/services/ca/ca_testutils.clj
+++ b/test/unit/puppetlabs/services/ca/ca_testutils.clj
@@ -44,7 +44,7 @@
    :keylength             512
    :signeddir             (str cadir "/signed")
    :serial                (str cadir "/serial")
-   :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib"]})
+   :ruby-load-path        ["ruby/puppet/lib" "ruby/facter/lib" "ruby/hiera/lib"]})
 
 (defn ca-sandbox!
   "Copy the `cadir` to a temporary directory and return

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_core_test.clj
@@ -12,7 +12,7 @@
    {:name "puppet-server", :update-server-url "http://localhost:11111"},
    ; os-settings has merged into jruby-puppet as of puppetserver 2.0
    :os-settings
-   {:ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"]},
+   {:ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"]},
    :jruby-puppet
    {:gem-home "./target/jruby-gem-home"},
    :certificate-authority {:certificate-status {:client-whitelist []}}})

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -13,7 +13,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
 
-(def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib"])
+(def ruby-load-path ["./ruby/puppet/lib" "./ruby/facter/lib" "./ruby/hiera/lib"])
 
 (def conf-dir "./target/master-conf")
 (def var-dir "./target/master-var")


### PR DESCRIPTION
I chose version 1.3.4 as that was the version in the latest PE 3.8.1.  We can bump this up to newer versions for master branch, etc., as we do the merge-up from here.