### PR TITLE
(maint) Update submodule and tests to Puppet 3.8.1

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -28,7 +28,7 @@ module PuppetServerExtensions
 
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "3.7.3")
+                         "PUPPET_BUILD_VERSION", "3.8.1")
 
     @config = {
       :base_dir => base_dir,

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -14,7 +14,7 @@ describe Puppet::Server::Master do
   context "puppet version" do
     it "returns the correct puppet version number" do
       master = Puppet::Server::Master.new({}, {})
-      master.puppetVersion.should == '3.7.5'
+      master.puppetVersion.should == '3.8.1'
     end
   end
 


### PR DESCRIPTION
Without this patch the tests are mixing and matching the version of Puppet
being installed.  For example, the legacy puppet agent tests are installing
3.8.1 while the unit and integration tests run with a Puppet 3.7 version from
the submodule.

This patch addresses the problem by updating the behavior of the tests to use
the same version, 3.8.1.