### PR TITLE
(SERVER-811) port request handler service to middleware-style

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -1,14 +1,17 @@
 (ns puppetlabs.services.request-handler.request-handler-service
   (:require [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.protocols.request-handler :as handler]
-            [puppetlabs.services.request-handler.request-handler-core :as core]
+            [puppetlabs.services.request-handler.request-handler-core :as request-handler-core]
             [puppetlabs.trapperkeeper.services :as tk-services]))
 
 (tk/defservice request-handler-service
   handler/RequestHandlerService
   [[:PuppetServerConfigService get-config]]
+  (init [this context]
+    (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
+          config (request-handler-core/config->request-handler-settings (get-config))]
+      (assoc context :request-handler (request-handler-core/build-request-handler jruby-service config))))
   (handle-request
     [this request]
-    (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
-          config (core/config->request-handler-settings (get-config))]
-      (core/handle-request request jruby-service config))))
+    (let [handler (:request-handler (tk-services/service-context this))]
+      (handler request))))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -5,10 +5,10 @@
             [puppetlabs.trapperkeeper.services :as tk-services]))
 
 (tk/defservice request-handler-service
-               handler/RequestHandlerService
-               [[:PuppetServerConfigService get-config]]
-               (handle-request
-                 [this request]
-                 (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
-                       config (core/config->request-handler-settings (get-config))]
-                   (core/handle-request request jruby-service config))))
+  handler/RequestHandlerService
+  [[:PuppetServerConfigService get-config]]
+  (handle-request
+    [this request]
+    (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
+          config (core/config->request-handler-settings (get-config))]
+      (core/handle-request request jruby-service config))))


### PR DESCRIPTION
This commit modifies the `request-handler` service to use more
of a ring-middleware style of composing functions for building
up the final request handler function.  This should make it easier
to share code / extend the service in subsequent development.