### PR TITLE
(SERVER-808) Enable containerized test running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
 - oraclejdk7
 - openjdk7
 script: "./ext/travisci/test.sh"
+sudo: false
 notifications:
   email: false
   hipchat:


### PR DESCRIPTION
The `sudo: false` flag indicated to Travis-CI that the tests should be
run in a container instead of VM. This should hopefully allow for faster
test results.