### PR TITLE
Merge stable into master

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -279,7 +279,9 @@
   it available in the request as `:jruby-instance`"
   [f jruby-service]
   (fn [request]
+    (log/debug "Borrowing a JRuby instance ...")
     (jruby/with-jruby-puppet jruby-instance jruby-service
+      (log/debug "JRuby instance borrowed")
       (f (assoc request :jruby-instance jruby-instance)))))
 
 (defn jruby-request-handler

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -1,14 +1,17 @@
 (ns puppetlabs.services.request-handler.request-handler-service
   (:require [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.protocols.request-handler :as handler]
-            [puppetlabs.services.request-handler.request-handler-core :as core]
+            [puppetlabs.services.request-handler.request-handler-core :as request-handler-core]
             [puppetlabs.trapperkeeper.services :as tk-services]))
 
 (tk/defservice request-handler-service
-               handler/RequestHandlerService
-               [[:PuppetServerConfigService get-config]]
-               (handle-request
-                 [this request]
-                 (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
-                       config (core/config->request-handler-settings (get-config))]
-                   (core/handle-request request jruby-service config))))
+  handler/RequestHandlerService
+  [[:PuppetServerConfigService get-config]]
+  (init [this context]
+    (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
+          config (request-handler-core/config->request-handler-settings (get-config))]
+      (assoc context :request-handler (request-handler-core/build-request-handler jruby-service config))))
+  (handle-request
+    [this request]
+    (let [handler (:request-handler (tk-services/service-context this))]
+      (handler request))))

--- a/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
@@ -6,11 +6,7 @@
     [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.certificate-authority :as ca]
-    [puppetlabs.services.request-handler.request-handler-core :as request-handler]
-    [puppetlabs.dujour.version-check :as version-check]
-    [puppetlabs.trapperkeeper.app :as tk-app]
-    [puppetlabs.services.config.puppet-server-config-core :as config]
-    [puppetlabs.services.master.master-core :as master]))
+    [puppetlabs.services.request-handler.request-handler-core :as request-handler]))
 
 (use-fixtures :once
               (jruby-testutils/with-puppet-conf
@@ -37,11 +33,11 @@
           ;; this test is specifically written for the case an Exception is
           ;; thrown somewhere inside this codebase, and is not caught anywhere
           ;; until it gets all the way up the stack to jetty.  To trigger this
-          ;; sort of error, the next line of code re-defines the main
-          ;; 'request handling' function (which is part of the mapping layer
+          ;; sort of error, the next line of code re-defines one of the main
+          ;; 'request handling' functions (which is part of the mapping layer
           ;; between the ring handler and the JRuby layer, and called on every
           ;; request) to simply ignore any arguments and just throw an Exception.
-          (with-redefs [request-handler/handle-request just-throw-it]
+          (with-redefs [request-handler/as-jruby-request just-throw-it]
             (let [response (http-client/get
                              "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
                              bootstrap/request-options)]

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -233,37 +233,31 @@
                         slurp
                         ring-codec/url-encode))))))
 
-(deftest handle-request-test
-  (def dummy-service
-    (reify jruby/JRubyPuppetService
-      (borrow_instance [_] {})
-      (return_instance [_ _])
-      (free_instance_count [_])
-      (mark_all_environments_expired_BANG_ [_])
-      (flush_jruby_pool_BANG_ [_])))
-
-  (def dummy-service-with-timeout
-    (reify jruby/JRubyPuppetService
-      (borrow_instance [_] nil)
-      (return_instance [_ _])
-      (free_instance_count [_])
-      (mark_all_environments_expired_BANG_ [_])
-      (flush_jruby_pool_BANG_ [_])))
-
-  (logutils/with-test-logging
-    (testing "slingshot bad requests translated to ring response"
-      (let [bad-message "it's real bad"]
-        (with-redefs [core/as-jruby-request (fn [_ _]
-                                              (core/throw-bad-request!
-                                               bad-message))]
-          (let [response (core/handle-request {:body (StringReader. "blah")}
-                                              dummy-service
-                                              {})]
-            (is (= 400 (:status response)) "Unexpected response status")
-            (is (= bad-message (:body response)) "Unexpected response body"))
-          (let [response (core/handle-request {:body (StringReader. "")}
-                                              dummy-service-with-timeout
-                                              {})]
+(deftest request-handler-test
+  (let [dummy-service (reify jruby/JRubyPuppetService
+                        (borrow-instance [_] {})
+                        (return-instance [_ _])
+                        (free-instance-count [_])
+                        (mark-all-environments-expired! [_])
+                        (flush-jruby-pool! [_]))
+        dummy-service-with-timeout (reify jruby/JRubyPuppetService
+                                     (borrow-instance [_] nil)
+                                     (return-instance [_ _])
+                                     (free-instance-count [_])
+                                     (mark-all-environments-expired! [_])
+                                     (flush-jruby-pool! [_]))]
+    (logutils/with-test-logging
+      (testing "slingshot bad requests translated to ring response"
+        (let [bad-message "it's real bad"
+              request-handler (core/build-request-handler dummy-service {})]
+          (with-redefs [core/as-jruby-request (fn [_ _]
+                                                (core/throw-bad-request!
+                                                  bad-message))]
+            (let [response (request-handler {:body (StringReader. "blah")})]
+              (is (= 400 (:status response)) "Unexpected response status")
+              (is (= bad-message (:body response)) "Unexpected response body")))
+          (let [request-handler (core/build-request-handler dummy-service-with-timeout {})
+                response (request-handler {:body (StringReader. "")})]
             (is (= 503 (:status response)) "Unexpected response status")
             (is (.startsWith
                   (:body response)


### PR DESCRIPTION
Merge conflicts:
* a couple places where we're testing against the Puppet or puppet-agent version number (obviously, different across branches)
* `puppetlabs.puppetserver.error-handling-int-test/test-HTTP-500` had to be updated to no longer refer to the `handle-request` function which was deleted in #645.  This test does not exist on stable.