### PR TITLE
(SERVER-815) Add getClassInfo methods to JRubyPuppet interface

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -29,7 +29,7 @@ module PuppetServerExtensions
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "8d94d0975422089568e27581a5f6c9f05243e9cb")
+                         "PUPPET_BUILD_VERSION", "26e4ed2c7d8352e37d9831c45ac0d194d82f6c6c")
 
     @config = {
       :base_dir => base_dir,

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -29,7 +29,7 @@ module PuppetServerExtensions
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "1.2.2")
+                         "PUPPET_BUILD_VERSION", "8d94d0975422089568e27581a5f6c9f05243e9cb")
 
     @config = {
       :base_dir => base_dir,

--- a/project.clj
+++ b/project.clj
@@ -109,7 +109,7 @@
             "irb" ["trampoline" "run" "-m" "puppetlabs.puppetserver.cli.irb"]}
 
   ; tests use a lot of PermGen (jruby instances)
-  :jvm-opts ["-XX:MaxPermSize=256m" "-Xmx1024M"]
+  :jvm-opts ["-XX:MaxPermSize=256m" "-Xmx2g"]
 
   :repl-options {:init-ns user}
 

--- a/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
+++ b/src/java/com/puppetlabs/puppetserver/JRubyPuppet.java
@@ -15,6 +15,8 @@ import java.util.Map;
  *
  */
 public interface JRubyPuppet {
+    Map<String, Map> getClassInfoForAllEnvironments();
+    Map getClassInfoForEnvironment(String environment);
     JRubyPuppetResponse handleRequest(Map request);
     Object getSetting(String setting);
     String puppetVersion();

--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -87,8 +87,8 @@ class Puppet::Server::HttpClient
   end
 
   def self.terminate
-    unless self.client.nil?
-      self.client.close
+    unless @client.nil?
+      @client.close
     end
   end
 

--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -1,5 +1,7 @@
 require 'puppet/server'
 
+require 'puppet/info_service'
+
 require 'puppet/network/http'
 require 'puppet/network/http/api/master/v3'
 
@@ -32,6 +34,7 @@ class Puppet::Server::Master
                           any.
                           chain(Puppet::Network::HTTP::API::Master::V3.routes)
     register([master_routes])
+    @env_loader = Puppet.lookup(:environments)
   end
 
   def handleRequest(request)
@@ -57,6 +60,53 @@ class Puppet::Server::Master
         response["X-Puppet-Version"])
   end
 
+  def getClassInfoForAllEnvironments()
+    # The clear_environment_settings(env) ensures that the calls which happen
+    # later on to enumerate all of the manifests for each environment are
+    # using the latest environment.conf settings for each environment.  Without
+    # this call, cached (and, therefore, possibly stale) environment.conf
+    # settings would be used.  We want to return the latest data for any calls
+    # made to this method.
+    @env_loader.list.each do |env|
+      Puppet.settings.clear_environment_settings(env)
+    end
+
+    environments =
+      Hash[@env_loader.list.collect do |env|
+       [env.name, self.class.getManifests(env)]
+      end]
+
+    classes_per_env =
+        Puppet::InfoService::ClassInformationService.new.classes_per_environment(environments)
+    Hash[classes_per_env.collect {|key, value| [key.to_s, value]}]
+  end
+
+  def getClassInfoForEnvironment(env)
+    # The clear_environment_settings(env) ensures that the calls which happen
+    # later on to enumerate all of the manifests for each environment are
+    # using the latest environment.conf settings for each environment.  Without
+    # this call, cached (and, therefore, possibly stale) environment.conf
+    # settings would be used.  We want to return the latest data for any calls
+    # made to this method.
+    Puppet.settings.clear_environment_settings(env)
+
+    # It would be more direct and less expensive to call `@env_loader.get(env)`
+    # here.  The problem with doing that, though, is that a Cached `env_loader`
+    # could return an Environment object with cached settings.  The `list` call
+    # to the Cached loader results in new Environment objects being created
+    # and so would not be subject to any potentially stale settings data being
+    # used to enumerate manifests.
+    environment = @env_loader.list.find do |env_from_loader|
+      env_from_loader.name == env
+    end
+    unless environment.nil?
+      environments = Hash[env, self.class.getManifests(environment)]
+      classes_per_env =
+          Puppet::InfoService::ClassInformationService.new.classes_per_environment(environments)
+      classes_per_env[env]
+    end
+  end
+
   def getSetting(setting)
     Puppet[setting]
   end
@@ -73,4 +123,19 @@ class Puppet::Server::Master
     Puppet::Server::Config.terminate_puppet_server
   end
 
+  private
+
+  def self.getManifests(env)
+    manifests = []
+    if env.manifest != Puppet::Node::Environment::NO_MANIFEST
+      if File.directory?(env.manifest)
+        manifests = Dir.glob(File.join(env.manifest, '**/*.pp')).sort
+      else
+        manifests = [env.manifest]
+      end
+    end
+
+    module_manifests = env.modules.collect {|mod| mod.all_manifests}
+    manifests.concat(module_manifests).flatten.uniq
+  end
 end

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -1,0 +1,229 @@
+(ns puppetlabs.services.jruby.class-info-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [me.raynes.fs :as fs]
+            [cheshire.core :as cheshire])
+  (:import (java.util.concurrent LinkedBlockingDeque)))
+
+(deftest ^:integration class-info-test
+  (testing "class info properly enumerated for"
+    (let [pool (LinkedBlockingDeque. 1)
+          code-dir (ks/temp-dir)
+          conf-dir (ks/temp-dir)
+          config (jruby-testutils/jruby-puppet-config
+                   {:master-code-dir (.getAbsolutePath code-dir)
+                    :master-conf-dir (.getAbsolutePath conf-dir)})
+          instance (jruby-internal/create-pool-instance!
+                     pool 0 config #() nil)
+          jruby-puppet (:jruby-puppet instance)
+          container (:scripting-container instance)
+
+          env-dir (fn [env-name]
+                    (fs/file code-dir "environments" env-name))
+          create-file (fn [file content]
+                        (ks/mkdirs! (fs/parent file))
+                        (spit file content))
+          gen-classes (fn [[mod-dir manifests]]
+                        (let [manifest-dir (fs/file mod-dir "manifests")]
+                          (ks/mkdirs! manifest-dir)
+                          (doseq [manifest manifests]
+                            (spit (fs/file manifest-dir (str manifest ".pp"))
+                                  (str
+                                    "class " manifest "($" manifest "_a, Integer $"
+                                    manifest "_b, String $" manifest
+                                    "_c = 'c default value') { }\n"
+                                    "class " manifest "2($" manifest "2_a, Integer $"
+                                    manifest "2_b, String $" manifest
+                                    "2_c = 'c default value') { }\n")))))
+          create-env-conf (fn [env-dir content]
+                            (create-file (fs/file env-dir "environment.conf")
+                                         (str "environment_timeout = unlimited\n"
+                                              content)))
+          create-env (fn [[env-dir manifests]]
+                       (create-env-conf env-dir "")
+                       (gen-classes [env-dir manifests]))
+
+          _ (create-file (fs/file conf-dir "puppet.conf")
+                         "[main]\nenvironment_timeout=unlimited\nbasemodulepath=$codedir/modules\n")
+
+          env-1-dir (env-dir "env1")
+          env-1-dir-and-manifests [env-1-dir ["foo" "bar"]]
+          _ (create-env env-1-dir-and-manifests)
+
+          env-2-dir (env-dir "env2")
+          env-2-dir-and-manifests [env-2-dir ["baz" "bim" "boom"]]
+          _ (create-env env-2-dir-and-manifests)
+
+          env-1-mod-dir (fs/file env-1-dir "modules")
+          env-1-mod-1-dir-and-manifests [(fs/file env-1-mod-dir
+                                                  "envmod1")
+                                         ["envmod1baz" "envmod1bim"]]
+          _ (gen-classes env-1-mod-1-dir-and-manifests)
+          env-1-mod-2-dir (fs/file env-1-mod-dir "envmod2")
+          env-1-mod-2-dir-and-manifests [env-1-mod-2-dir
+                                         ["envmod2baz" "envmod2bim"]]
+          _ (gen-classes env-1-mod-2-dir-and-manifests)
+
+          env-3-dir-and-manifests [(env-dir "env3") ["dip" "dap" "dup"]]
+
+          base-mod-dir (fs/file code-dir "modules")
+          base-mod-1-and-manifests [(fs/file base-mod-dir "basemod1")
+                                    ["basemod1bap"]]
+          _ (gen-classes base-mod-1-and-manifests)
+
+          bogus-env-dir (env-dir "bogus-env")
+          _ (create-env [bogus-env-dir []])
+          _ (gen-classes [bogus-env-dir ["envbogus"]])
+          _ (gen-classes [(fs/file base-mod-dir "base-bogus") ["base-bogus1"]])
+
+          roundtrip-via-json (fn [obj]
+                               (-> obj
+                                   (cheshire/generate-string)
+                                   (cheshire/parse-string)))
+          expected-class-info (fn [class]
+                                    {"name" class
+                                     "params" [{"name" (str class "_a")}
+                                               {"name" (str class "_b"),
+                                                "type" "Integer"}
+                                               {"name" (str class "_c"),
+                                                "type" "String",
+                                                "default_literal" "c default value"}]})
+
+          expected-manifests-info (fn [manifests]
+                                        (into {}
+                                              (apply concat
+                                                     (for [[dir names] manifests]
+                                                       (do
+                                                         (for [name names]
+                                                           [(.getAbsolutePath
+                                                              (fs/file dir
+                                                                       "manifests"
+                                                                       (str name ".pp")))
+                                                            [(expected-class-info name)
+                                                             (expected-class-info
+                                                               (str name "2"))]]))))))
+          get-class-info (fn []
+                           (-> (.getClassInfoForAllEnvironments
+                                jruby-puppet)
+                              (roundtrip-via-json)))
+          get-class-info-for-env (fn [env]
+                                   (-> (.getClassInfoForEnvironment jruby-puppet
+                                                                    env)
+                                       (roundtrip-via-json)))]
+        (try
+          (testing "initial parse for"
+            (let [expected-envs-info {"env1" (expected-manifests-info
+                                               [env-1-dir-and-manifests
+                                                env-1-mod-1-dir-and-manifests
+                                                env-1-mod-2-dir-and-manifests
+                                                base-mod-1-and-manifests])
+                                      "env2" (expected-manifests-info
+                                               [env-2-dir-and-manifests
+                                                base-mod-1-and-manifests])}]
+              (testing "all environments"
+                (is (= expected-envs-info (get-class-info)))
+              (testing "one environment by name"
+                (is (= (expected-envs-info "env1")
+                       (get-class-info-for-env "env1"))
+                    "Unexpected info retrieved for 'env1'")
+                (is (= (expected-envs-info "env2")
+                       (get-class-info-for-env "env2"))
+                    "Unexpected info retrieved for 'env2'")))))
+
+          (testing "changes to module and manifest paths for"
+            (create-env-conf env-1-dir (str "manifest="
+                                            (.getAbsolutePath (fs/file env-1-dir
+                                                                       "manifests"
+                                                                       "foo.pp"))
+                                            "\nmodulepath="
+                                            (.getAbsolutePath (fs/file
+                                                                env-2-dir
+                                                                "modules"))
+                                            "\n"))
+            (create-env-conf env-2-dir (str "modulepath="
+                                            (.getAbsolutePath env-1-mod-dir)
+                                            "\n"))
+            (let [foo-manifest (.getAbsolutePath (fs/file env-1-dir
+                                                          "manifests"
+                                                          "foo.pp"))
+                  expected-envs-info {"env1" {foo-manifest
+                                              [(expected-class-info "foo")
+                                               (expected-class-info "foo2")]}
+                                      "env2" (expected-manifests-info
+                                               [env-2-dir-and-manifests
+                                                env-1-mod-1-dir-and-manifests
+                                                env-1-mod-2-dir-and-manifests])}]
+              (testing "all environments"
+                (is (= expected-envs-info (get-class-info))))
+              (testing "one environment by name"
+                (is (= (expected-envs-info "env1")
+                       (get-class-info-for-env "env1"))
+                    "Unexpected info retrieved for 'env1'")
+                (is (= (expected-envs-info "env2")
+                       (get-class-info-for-env "env2"))
+                    "Unexpected info retrieved for 'env2'"))))
+
+          (testing "changes to manifest content for"
+            (fs/delete-dir env-1-mod-2-dir)
+            (let [foo-manifest (.getAbsolutePath (fs/file env-1-dir
+                                                          "manifests"
+                                                          "foo.pp"))
+                  _ (create-file foo-manifest "class foo () {} \n")
+                  expected-envs-info {"env1" {foo-manifest
+                                              [{"name" "foo"
+                                                "params" []}]}
+                                      "env2" (expected-manifests-info
+                                               [env-2-dir-and-manifests
+                                                env-1-mod-1-dir-and-manifests])}]
+              (testing "all environments"
+                (is (= expected-envs-info (get-class-info))))
+              (testing "one environment by name"
+                (is (= (expected-envs-info "env1")
+                       (get-class-info-for-env "env1"))
+                    "Unexpected info retrieved for 'env1'")
+                (is (= (expected-envs-info "env2")
+                       (get-class-info-for-env "env2"))
+                    "Unexpected info retrieved for 'env2'"))))
+
+          (testing "changes to environments for"
+            (fs/delete-dir env-1-dir)
+            (let [_ (create-env env-3-dir-and-manifests)
+                  expected-envs-info {"env2" (expected-manifests-info
+                                               [env-2-dir-and-manifests])
+                                      "env3" (expected-manifests-info
+                                               [env-3-dir-and-manifests
+                                                base-mod-1-and-manifests])}]
+              (testing "all environments"
+                (is (= expected-envs-info (get-class-info))))
+              (testing "one environment by name"
+                (is (= (expected-envs-info "env2")
+                       (get-class-info-for-env "env2"))
+                    "Unexpected info retrieved for 'env2'")
+                (is (= (expected-envs-info "env3")
+                       (get-class-info-for-env "env3"))
+                    "Unexpected info retrieved for 'env3'"))))
+
+          (testing "all environments by key, without serialization"
+            (let [envs-info (.getClassInfoForAllEnvironments jruby-puppet)
+                  expected-envs-info {"env2" (expected-manifests-info
+                                               [env-2-dir-and-manifests])
+                                      "env3" (expected-manifests-info
+                                               [env-3-dir-and-manifests
+                                                base-mod-1-and-manifests])}]
+              (is (= 2 (count envs-info))
+                  "Unexpected number of environments retrieved")
+              (is (= (expected-envs-info "env2")
+                     (-> (get envs-info "env2") (roundtrip-via-json)))
+                  "Unexpected info retrieved for 'env2'")
+              (is (= (expected-envs-info "env3")
+                     (-> (get envs-info "env3") (roundtrip-via-json)))
+                  "Unexpected info retrieved for 'env3'")))
+
+          (testing "non-existent environment"
+            (is (nil? (get-class-info-for-env "bogus-env"))))
+
+        (finally
+          (.terminate jruby-puppet)
+          (.terminate container))))))

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -117,8 +117,8 @@
           _ (gen-classes [(fs/file base-mod-dir "base-bogus") ["base-bogus1"]])
 
           get-class-info (fn []
-            (-> (.getClassInfoForAllEnvironments jruby-puppet)
-                (roundtrip-via-json)))
+                           (-> (.getClassInfoForAllEnvironments jruby-puppet)
+                               (roundtrip-via-json)))
           get-class-info-for-env (fn [env]
                                    (-> (.getClassInfoForEnvironment jruby-puppet
                                                                     env)


### PR DESCRIPTION
This commit adds two new methods to the JRubyPuppet interface -
`getClassInfoForEnvironment` and `getClassInfoForAllEnvironments` - to
the JRubyPuppet interface.  A corresponding implementation of those in
the `Puppet::Server::Master` Ruby class uses the
`Puppet::InfoService::ClassInformationService` to get class information
for available manifests in environments.