### PR TITLE
(maint) Stop using .lan addresses

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -48,7 +48,7 @@ source][genconfig].
 You'll need to provide a couple environment variables that specify which build
 of puppet-server to install and test against.
 
-1. Go to http://builds.puppetlabs.lan/puppetserver/
+1. Go to http://builds.delivery.puppetlabs.net/puppetserver/
 2. Scroll down to the most recent build at the bottom.  This will look like:
    `0.1.4.SNAPSHOT.2014.05.15T1118`
 3. Copy the text (not the link address) - this will be `PACKAGE_BUILD_VERSION`

--- a/acceptance/README_LOCAL_VM.md
+++ b/acceptance/README_LOCAL_VM.md
@@ -28,7 +28,7 @@ This will not use Vagrant or a Rakefile, but instead a local pre-installed VM an
 
 You'll need to provide a couple environment variables that specify which build of puppet-server to install and test against.
 
-1. Go to http://builds.puppetlabs.lan/puppetserver/
+1. Go to http://builds.delivery.puppetlabs.net/puppetserver/
 2. Scroll down to the most recent build at the bottom
    - This will look like: 0.1.4.SNAPSHOT.2014.05.15T1118
 3. Copy the text (not the link address) - this will be ```PACKAGE_BUILD_VERSION```

--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -26,7 +26,7 @@ module PuppetServerExtensions
                          get_puppet_version
 
     # puppet-agent version corresponds to packaged development version located at:
-    # http://builds.puppetlabs.lan/puppet-agent/
+    # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION", "1.2.2")

--- a/acceptance/suites/pre_suite/foss/70_install_puppet.rb
+++ b/acceptance/suites/pre_suite/foss/70_install_puppet.rb
@@ -40,7 +40,7 @@ step "Install MRI Puppet Agents."
 
     if /windows/.match(platform)
       arch = host[:ruby_arch] || 'x86'
-      base_url = ENV['MSI_BASE_URL'] || "http://builds.puppetlabs.lan/puppet-agent/#{test_config[:puppet_build_version]}/artifacts/windows"
+      base_url = ENV['MSI_BASE_URL'] || "http://builds.delivery.puppetlabs.net/puppet-agent/#{test_config[:puppet_build_version]}/artifacts/windows"
       filename = ENV['MSI_FILENAME'] || "puppet-agent-#{arch}.msi"
       install_puppet_from_msi(host, :url => "#{base_url}/#{filename}")
     elsif puppet_version


### PR DESCRIPTION
We've been asked to stop using puppetlabs.lan addresses, so I've swapped
them for the preferred names/URIS.