### PR TITLE
(PE-8226) jruby events

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -75,6 +75,12 @@
   :deploy-repositories [["releases" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/releases/")]
                         ["snapshots" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/")]]
 
+  ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
+  ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
+  ;; depend on this test jar using a :classifier in their :dependencies to reuse the test utility
+  ;; code that we have.
+  :classifiers [["test" :testutils]]
+
   :profiles {:dev {:source-paths  ["dev"]
                    :dependencies  [[org.clojure/tools.namespace "0.2.4"]
                                    [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
@@ -87,6 +93,8 @@
                    :injections    [(require 'spyscope.core)]
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}
+
+             :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
 
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]

--- a/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_core.clj
@@ -100,7 +100,7 @@
   [jruby-service]
   {:post [(map? %)]}
   (jruby/with-jruby-puppet
-    jruby-puppet jruby-service
+    jruby-puppet jruby-service :get-puppet-config
     (let [config (get-puppet-config* jruby-puppet)]
       (assoc config :puppet-version (.puppetVersion jruby-puppet)))))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -67,23 +67,23 @@
                                            "you did not specify the --config option?")))))
 
 (schema/defn create-requested-event :- jruby-schemas/JRubyRequestedEvent
-  [action :- jruby-schemas/JRubyEventAction]
+  [reason :- jruby-schemas/JRubyEventReason]
   {:type :instance-requested
-   :action action})
+   :reason reason})
 
 (schema/defn create-borrowed-event :- jruby-schemas/JRubyBorrowedEvent
   [requested-event :- jruby-schemas/JRubyRequestedEvent
    instance :- jruby-schemas/JRubyPuppetBorrowResult]
   {:type :instance-borrowed
-   :action (:action requested-event)
+   :reason (:reason requested-event)
    :requested-event requested-event
    :instance instance})
 
 (schema/defn create-returned-event :- jruby-schemas/JRubyReturnedEvent
   [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry
-   action :- jruby-schemas/JRubyEventAction]
+   reason :- jruby-schemas/JRubyEventReason]
   {:type :instance-returned
-   :action action
+   :reason reason
    :instance instance})
 
 
@@ -99,8 +99,8 @@
 
 (schema/defn instance-requested :- jruby-schemas/JRubyRequestedEvent
   [event-callbacks :- [IFn]
-   action :- jruby-schemas/JRubyEventAction]
-  (notify-event-listeners event-callbacks (create-requested-event action)))
+   reason :- jruby-schemas/JRubyEventReason]
+  (notify-event-listeners event-callbacks (create-requested-event reason)))
 
 (schema/defn instance-borrowed :- jruby-schemas/JRubyBorrowedEvent
   [event-callbacks :- [IFn]
@@ -111,8 +111,8 @@
 (schema/defn instance-returned :- jruby-schemas/JRubyReturnedEvent
   [event-callbacks :- [IFn]
    instance :- jruby-schemas/JRubyPuppetInstanceOrRetry
-   action :- jruby-schemas/JRubyEventAction]
-  (notify-event-listeners event-callbacks (create-returned-event instance action)))
+   reason :- jruby-schemas/JRubyEventReason]
+  (notify-event-listeners event-callbacks (create-returned-event instance reason)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -88,7 +88,7 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Event Handlers
+;;; Support functions for event notification
 
 (schema/defn notify-event-listeners :- jruby-schemas/JRubyEvent
   [event-callbacks :- [IFn]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -39,6 +39,15 @@
   (CompatVersion/RUBY1_9))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def JRubyPuppetInternalBorrowResult
+  (schema/pred (some-fn nil?
+                 jruby-schemas/poison-pill?
+                 jruby-schemas/retry-poison-pill?
+                 jruby-schemas/jruby-puppet-instance?)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (schema/defn get-system-env :- jruby-schemas/EnvPersistentMap
@@ -134,7 +143,7 @@
     (.runScriptlet "require 'jar-dependencies'")
     (.runScriptlet "require 'puppet/server/master'")))
 
-(schema/defn borrow-with-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
+(schema/defn borrow-with-timeout-fn :- JRubyPuppetInternalBorrowResult
   [timeout :- schema/Int
    pool :- jruby-schemas/pool-queue-type]
   (.pollFirst pool timeout TimeUnit/MILLISECONDS))
@@ -219,11 +228,11 @@
   [context :- jruby-schemas/PoolContext]
   (get-in context [:config :max-active-instances]))
 
-(schema/defn borrow-without-timeout-fn :- jruby-schemas/JRubyPuppetBorrowResult
+(schema/defn borrow-without-timeout-fn :- JRubyPuppetInternalBorrowResult
   [pool :- jruby-schemas/pool-queue-type]
   (.takeFirst pool))
 
-(schema/defn borrow-from-pool!* :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+(schema/defn borrow-from-pool!* :- jruby-schemas/JRubyPuppetBorrowResult
   "Given a borrow function and a pool, attempts to borrow a JRuby instance from a pool.
   If successful, updates the state information and returns the JRuby instance.
   Returns nil if the borrow function returns nil; throws an exception if
@@ -257,7 +266,7 @@
                       (get-pool pool-context)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool-with-timeout :- (schema/maybe jruby-schemas/JRubyPuppetInstanceOrRetry)
+  borrow-from-pool-with-timeout :- jruby-schemas/JRubyPuppetBorrowResult
   "Borrows a JRubyPuppet interpreter from the pool, like borrow-from-pool but a
   blocking timeout is provided. If an instance is available then it will be
   immediately returned to the caller, if not then this function will block

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -195,22 +195,22 @@
   [e]
   (= :instance-returned (:type e)))
 
-(def JRubyEventAction
+(def JRubyEventReason
   schema/Any)
 
 (def JRubyRequestedEvent
   {:type (schema/eq :instance-requested)
-   :action JRubyEventAction})
+   :reason JRubyEventReason})
 
 (def JRubyBorrowedEvent
   {:type (schema/eq :instance-borrowed)
-   :action JRubyEventAction
+   :reason JRubyEventReason
    :requested-event JRubyRequestedEvent
    :instance JRubyPuppetBorrowResult})
 
 (def JRubyReturnedEvent
   {:type (schema/eq :instance-returned)
-   :action JRubyEventAction
+   :reason JRubyEventReason
    :instance JRubyPuppetInstanceOrRetry})
 
 (def JRubyEvent

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -165,7 +165,6 @@
 
 (def JRubyPuppetBorrowResult
   (schema/pred (some-fn nil?
-                        poison-pill?
                         retry-poison-pill?
                         jruby-puppet-instance?)))
 
@@ -183,3 +182,39 @@
   "Schema for a clojure persistent map for the system environment"
   (schema/both EnvMap
     (schema/either PersistentArrayMap PersistentHashMap)))
+
+(defn event-type-requested?
+  [e]
+  (= :instance-requested (:type e)))
+
+(defn event-type-borrowed?
+  [e]
+  (= :instance-borrowed (:type e)))
+
+(defn event-type-returned?
+  [e]
+  (= :instance-returned (:type e)))
+
+(def JRubyEventAction
+  schema/Any)
+
+(def JRubyRequestedEvent
+  {:type (schema/eq :instance-requested)
+   :action JRubyEventAction})
+
+(def JRubyBorrowedEvent
+  {:type (schema/eq :instance-borrowed)
+   :action JRubyEventAction
+   :requested-event JRubyRequestedEvent
+   :instance JRubyPuppetBorrowResult})
+
+(def JRubyReturnedEvent
+  {:type (schema/eq :instance-returned)
+   :action JRubyEventAction
+   :instance JRubyPuppetInstanceOrRetry})
+
+(def JRubyEvent
+  (schema/conditional
+    event-type-requested? JRubyRequestedEvent
+    event-type-borrowed? JRubyBorrowedEvent
+    event-type-returned? JRubyReturnedEvent))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -70,7 +70,7 @@
           {:keys [pool-context]} service-context]
       (jruby-agents/send-flush-pool! pool-context)))
 
-  (register-jruby-event-callback
+  (register-event-handler
     [this callback-fn]
     (let [event-callbacks (:event-callbacks (tk-services/service-context this))]
       (swap! event-callbacks conj callback-fn))))

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -4,17 +4,25 @@
   "Describes the JRubyPuppet provider service which pools JRubyPuppet instances."
 
   (borrow-instance
-    [this]
+    [this action]
     "Borrows an instance from the JRubyPuppet interpreter pool. If there are no
     interpreters left in the pool then the operation blocks until there is one
     available. A timeout (integer measured in milliseconds) can be configured
     which will either return an interpreter if one is available within the
     timeout length, or will return nil after the timeout expires if no
-    interpreters are available. This timeout defaults to 1200000 milliseconds.")
+    interpreters are available. This timeout defaults to 1200000 milliseconds.
+
+    `action` is an identifier (usually a map) describing the reason for borrowing the
+    JRuby instance.  It may be used for metrics and logging purposes.")
 
   (return-instance
-    [this jrubypuppet-instance]
-    "Returns the JRubyPuppet interpreter back to the pool.")
+    [this jrubypuppet-instance action]
+    "Returns the JRubyPuppet interpreter back to the pool.
+
+    `action` is an identifier (usually a map) describing the reason for borrowing the
+    JRuby instance.  It may be used for metrics and logging purposes, so for
+    best results it should be set to the same value as it was set during the
+    `borrow-instance` call.")
 
   (free-instance-count
     [this]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -38,4 +38,9 @@
 
   (flush-jruby-pool!
     [this]
-    "Flush all the current JRuby instances and repopulate the pool."))
+    "Flush all the current JRuby instances and repopulate the pool.")
+
+  (register-jruby-event-callback
+    [this callback]
+    "Register a callback function to receive notifications when JRuby service events occur.
+    The callback fn should accept a single arg, which will conform to the JRubyEvent schema."))

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -4,7 +4,7 @@
   "Describes the JRubyPuppet provider service which pools JRubyPuppet instances."
 
   (borrow-instance
-    [this action]
+    [this reason]
     "Borrows an instance from the JRubyPuppet interpreter pool. If there are no
     interpreters left in the pool then the operation blocks until there is one
     available. A timeout (integer measured in milliseconds) can be configured
@@ -12,14 +12,14 @@
     timeout length, or will return nil after the timeout expires if no
     interpreters are available. This timeout defaults to 1200000 milliseconds.
 
-    `action` is an identifier (usually a map) describing the reason for borrowing the
+    `reason` is an identifier (usually a map) describing the reason for borrowing the
     JRuby instance.  It may be used for metrics and logging purposes.")
 
   (return-instance
-    [this jrubypuppet-instance action]
+    [this jrubypuppet-instance reason]
     "Returns the JRubyPuppet interpreter back to the pool.
 
-    `action` is an identifier (usually a map) describing the reason for borrowing the
+    `reason` is an identifier (usually a map) describing the reason for borrowing the
     JRuby instance.  It may be used for metrics and logging purposes, so for
     best results it should be set to the same value as it was set during the
     `borrow-instance` call.")

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -40,7 +40,7 @@
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")
 
-  (register-jruby-event-callback
+  (register-event-handler
     [this callback]
     "Register a callback function to receive notifications when JRuby service events occur.
     The callback fn should accept a single arg, which will conform to the JRubyEvent schema."))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -279,7 +279,11 @@
   it available in the request as `:jruby-instance`"
   [f jruby-service]
   (fn [request]
-    (jruby/with-jruby-puppet jruby-instance jruby-service
+    (jruby/with-jruby-puppet
+      jruby-instance
+      jruby-service
+      {:request (dissoc request :ssl-client-cert)}
+      
       (f (assoc request :jruby-instance jruby-instance)))))
 
 (defn jruby-request-handler

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -155,8 +155,12 @@
     (bootstrap/with-puppetserver-running app {:jruby-puppet
                                               {:max-active-instances num-jrubies}}
       (let [jruby-service   (tk-app/get-service app :JRubyPuppetService)
-            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service)
-            return-jruby-fn (partial jruby-protocol/return-instance jruby-service)]
+            borrow-jruby-fn (partial jruby-protocol/borrow-instance jruby-service
+                              :environment-flush-integration-test)
+            return-jruby-fn (fn [instance] (jruby-protocol/return-instance
+                                             jruby-service
+                                             instance
+                                             :environment-flush-integration-test))]
         ;; wait for all of the jrubies to be ready so that we can
         ;; validate cache state differences between them.
         (wait-for-jrubies app)

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -37,7 +37,7 @@
 
         (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
           (jruby/with-jruby-puppet
-            jruby-puppet jruby-service
+            jruby-puppet jruby-service :ca-disabled-files-test
             (is (not (nil? (fs/list-dir ssl-dir))))
             (is (empty? (fs/list-dir (str ssl-dir "/ca"))))))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -19,12 +19,15 @@
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
+(def default-services
+  [jruby/jruby-puppet-pooled-service
+   profiler/puppet-profiler-service])
+
 (deftest basic-flush-test
   (testing "Flushing the pool results in all new JRuby instances"
     (tk-testutils/with-app-with-config
       app
-      [jruby/jruby-puppet-pooled-service
-       profiler/puppet-profiler-service]
+      default-services
       (-> (jruby-testutils/jruby-puppet-tk-config
             (jruby-testutils/jruby-puppet-config {:max-active-instances 4})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
@@ -48,8 +51,7 @@
   (testing "Flush puts a retry poison pill into the old pool"
     (tk-testutils/with-app-with-config
       app
-      [jruby/jruby-puppet-pooled-service
-       profiler/puppet-profiler-service]
+      default-services
       (-> (jruby-testutils/jruby-puppet-tk-config
             (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
@@ -78,8 +80,7 @@
   (testing "with-jruby-puppet retries if it encounters a RetryPoisonPill"
     (tk-testutils/with-app-with-config
       app
-      [jruby/jruby-puppet-pooled-service
-       profiler/puppet-profiler-service]
+      default-services
       (-> (jruby-testutils/jruby-puppet-tk-config
             (jruby-testutils/jruby-puppet-config {:max-active-instances 1})))
       (let [jruby-service (tk-app/get-service app :JRubyPuppetService)

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -62,7 +62,7 @@
                                     (remove-watch pool-state key)
                                     (deliver pool-state-swapped true)))]
         ; borrow an instance so we know that the pool is ready
-        (jruby/with-jruby-puppet jruby-puppet jruby-service)
+        (jruby/with-jruby-puppet jruby-puppet jruby-service :retry-poison-pill-test)
         (add-watch (:pool-state pool-context) :pool-state-watch pool-state-watch-fn)
         (jruby-protocol/flush-jruby-pool! jruby-service)
         ; wait until we know the new pool has been swapped in
@@ -97,6 +97,7 @@
           (jruby/with-jruby-puppet
             jruby-puppet
             jruby-service
+            :with-jruby-retry-test
             (is (instance? JRubyPuppet jruby-puppet))))
         (is (= 4 @num-borrows))))))
 

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -130,22 +130,22 @@
           requested (atom {})
           borrowed (atom {})
           returned (atom {})
-          callback (fn [{:keys [type action requested-event instance] :as event}]
+          callback (fn [{:keys [type reason requested-event instance] :as event}]
                      (case type
                        :instance-requested
                        (reset! requested {:sequence (swap! counter inc)
                                           :event event
-                                          :action action})
+                                          :reason reason})
 
                        :instance-borrowed
                        (reset! borrowed {:sequence (swap! counter inc)
-                                         :action action
+                                         :reason reason
                                          :requested-event requested-event
                                          :instance instance})
 
                        :instance-returned
                        (reset! returned {:sequence (swap! counter inc)
-                                         :action action
+                                         :reason reason
                                          :instance instance})))
           event-service (tk/service [[:JRubyPuppetService register-event-handler]]
                           (init [this context]
@@ -163,13 +163,13 @@
             jruby-puppet
             service
             :test-jruby-events)
-          (is (= {:sequence 1 :action :test-jruby-events}
+          (is (= {:sequence 1 :reason :test-jruby-events}
                 (dissoc @requested :event)))
-          (is (= {:sequence 2 :action :test-jruby-events}
+          (is (= {:sequence 2 :reason :test-jruby-events}
                 (dissoc @borrowed :instance :requested-event)))
           (is (jruby-schemas/jruby-puppet-instance? (:instance @borrowed)))
           (is (identical? (:event @requested) (:requested-event @borrowed)))
-          (is (= {:sequence 3 :action :test-jruby-events}
+          (is (= {:sequence 3 :reason :test-jruby-events}
                 (dissoc @returned :instance)))
           (is (= (:instance @borrowed) (:instance @returned)))
           (with-jruby-puppet

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -147,9 +147,9 @@
                        (reset! returned {:sequence (swap! counter inc)
                                          :action action
                                          :instance instance})))
-          event-service (tk/service [[:JRubyPuppetService register-jruby-event-callback]]
+          event-service (tk/service [[:JRubyPuppetService register-event-handler]]
                           (init [this context]
-                            (register-jruby-event-callback callback)
+                            (register-event-handler callback)
                             context))]
       (bootstrap/with-app-with-config
         app

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -131,7 +131,7 @@
           borrowed (atom {})
           returned (atom {})
           callback (fn [{:keys [type action requested-event instance] :as event}]
-                     (condp = type
+                     (case type
                        :instance-requested
                        (reset! requested {:sequence (swap! counter inc)
                                           :event event
@@ -153,11 +153,12 @@
                             context))]
       (bootstrap/with-app-with-config
         app
-        [jruby-puppet-pooled-service
-         profiler/puppet-profiler-service
-         event-service]
+        (conj default-services event-service)
         (jruby-service-test-config 1)
         (let [service (app/get-service app :JRubyPuppetService)]
+          ;; We're making an empty call to `with-jruby-puppet` here, because
+          ;; we want to trigger a borrow/return via the same code path that
+          ;; would be used in production.
           (with-jruby-puppet
             jruby-puppet
             service

--- a/test/unit/puppetlabs/services/master/master_service_test.clj
+++ b/test/unit/puppetlabs/services/master/master_service_test.clj
@@ -49,6 +49,7 @@
               (jruby/with-jruby-puppet
                 jruby-puppet
                 jruby-service
+                :ca-files-test
 
                 (letfn [(test-path!
                           [setting expected-path]

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -235,14 +235,14 @@
 
 (deftest request-handler-test
   (let [dummy-service (reify jruby/JRubyPuppetService
-                        (borrow-instance [_] {})
-                        (return-instance [_ _])
+                        (borrow-instance [_ _] {})
+                        (return-instance [_ _ _])
                         (free-instance-count [_])
                         (mark-all-environments-expired! [_])
                         (flush-jruby-pool! [_]))
         dummy-service-with-timeout (reify jruby/JRubyPuppetService
-                                     (borrow-instance [_] nil)
-                                     (return-instance [_ _])
+                                     (borrow-instance [_ _] nil)
+                                     (return-instance [_ _ _])
                                      (free-instance-count [_])
                                      (mark-all-environments-expired! [_])
                                      (flush-jruby-pool! [_]))]


### PR DESCRIPTION
This PR adds event notifications for whenever something interesting happens related to the JRuby pool. It's a pre-cursor to PE-8226, and replaces my earlier attempt at this that was in PR #632 .