### PR TITLE
(SERVER-828) Maximum supported puppet-agent <1.3.0

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent"],
+      redhat: { dependencies: ["puppet-agent < 1.3.0"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -34,7 +34,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent"],
+      debian: { dependencies: ["puppet-agent < 1.3.0"],
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",


### PR DESCRIPTION
This commit caps the puppet-agent dependency to < 1.3.0 (i.e. 1.2.z)