### PR TITLE
(MAINT) Prefer clj-time/seconds over clj-time/secs

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -163,7 +163,7 @@
   [ca-ttl :- schema/Int]
   (let [now        (time/now)
         not-before (time/minus now (time/days 1))
-        not-after  (time/plus now (time/secs ca-ttl))]
+        not-after  (time/plus now (time/seconds ca-ttl))]
     {:not-before (.toDate not-before)
      :not-after  (.toDate not-after)}))
 


### PR DESCRIPTION
The latter is deprecated in favor of the former; we should no longer see
deprecation warnings during `lein test` for this.