### PR TITLE
Bug/stable/server 813 env cache flush while borrowed

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -51,9 +51,10 @@
   (jruby-internal/get-pool context))
 
 (schema/defn ^:always-validate
-  pool->vec :- [JRubyPuppetInstance]
+  registered-instances :- [JRubyPuppetInstance]
   [context :- jruby-schemas/PoolContext]
   (-> (get-pool context)
+      .getRegisteredElements
       .iterator
       iterator-seq
       vec))
@@ -119,7 +120,7 @@
   mark-environment-expired!
   [context :- jruby-schemas/PoolContext
    env-name :- schema/Str]
-  (doseq [jruby-instance (pool->vec context)]
+  (doseq [jruby-instance (registered-instances context)]
     (-> jruby-instance
       :environment-registry
       (puppet-env/mark-environment-expired! env-name))))
@@ -127,7 +128,7 @@
 (schema/defn ^:always-validate
   mark-all-environments-expired!
   [context :- jruby-schemas/PoolContext]
-  (doseq [jruby-instance (pool->vec context)]
+  (doseq [jruby-instance (registered-instances context)]
     (-> jruby-instance
         :environment-registry
         puppet-env/mark-all-environments-expired!)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -4,12 +4,12 @@
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [me.raynes.fs :as fs]
             [clojure.tools.logging :as log])
-  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet RegisteredLinkedBlockingDeque)
            (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
            (java.util HashMap)
            (org.jruby CompatVersion Main RubyInstanceConfig RubyInstanceConfig$CompileMode)
            (org.jruby.embed ScriptingContainer LocalContextScope)
-           (java.util.concurrent LinkedBlockingDeque TimeUnit)
+           (java.util.concurrent TimeUnit)
            (clojure.lang IFn)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -51,7 +51,7 @@
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
-  (LinkedBlockingDeque. size))
+  (RegisteredLinkedBlockingDeque. size))
 
 (schema/defn ^:always-validate managed-environment :- {schema/Str schema/Str}
   "The environment variables that should be passed to the Puppet JRuby
@@ -198,7 +198,7 @@
                                                            JRubyPuppet)
                         :scripting-container  scripting-container
                         :environment-registry env-registry})]
-        (.putLast pool instance)
+        (.registerLast pool instance)
         instance))))
 
 (schema/defn ^:always-validate

--- a/src/java/com/puppetlabs/puppetserver/RegisteredLinkedBlockingDeque.java
+++ b/src/java/com/puppetlabs/puppetserver/RegisteredLinkedBlockingDeque.java
@@ -1,0 +1,49 @@
+package com.puppetlabs.puppetserver;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * A LinkedBlockingDeque that assumes the structure will be used as a Pool,
+ * where elements are recycled over time.  Adds a <tt>registerLast</tt> method
+ * that can be used to register new elements when they are first introduced to
+ * the Pool, and a <tt>getRegisteredElements</tt> method that can be used to
+ * get a set of all of the known elements, regardless of whether they are
+ * currently available in the pool or not.
+ *
+ * @param <E> the type of element that can be added to the queue.
+ */
+public class RegisteredLinkedBlockingDeque<E> extends LinkedBlockingDeque<E> {
+    private final Set<E> registeredElements = new CopyOnWriteArraySet<>();
+
+    public RegisteredLinkedBlockingDeque(int capacity) {
+        super(capacity);
+    }
+
+    /**
+     * This method is analagous to <tt>putLast</tt> in the parent class, but
+     * also causes the element to be added to the list of "registered" elements
+     * that will be returned by <tt>getRegisteredInstances</tt>.
+     *
+     * Note that this method is synchronized to try to ensure that the addition
+     * to the queue and the list of registered instances are visible roughly
+     * atomically to consumers, but because the underlying queue uses
+     * its own lock, it is possible for it to be modified on another thread while
+     * this method is being executed.
+     *
+     * @param e the element to register and put at the end of the queue.
+     */
+    synchronized public void registerLast(E e) throws InterruptedException {
+        registeredElements.add(e);
+        putLast(e);
+    }
+
+    /**
+     * @return a set of all of the known elements that have been registered with
+     *         this queue.
+     */
+    public Set<E> getRegisteredElements() {
+        return registeredElements;
+    }
+}

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
@@ -2,11 +2,11 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils])
-  (:import (java.util.concurrent LinkedBlockingDeque)))
+  (:import (com.puppetlabs.puppetserver RegisteredLinkedBlockingDeque)))
 
   (deftest ^:integration settings-plumbed-into-jruby-container
     (testing "setting plumbed into jruby container for"
-      (let [pool (LinkedBlockingDeque. 1)
+      (let [pool (RegisteredLinkedBlockingDeque. 1)
             config (jruby-testutils/jruby-puppet-config
                      {:http-client-connect-timeout-milliseconds 2
                       :http-client-idle-timeout-milliseconds 5

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -13,8 +13,7 @@
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
-           (com.puppetlabs.puppetserver JRubyPuppet)
-           (java.util.concurrent LinkedBlockingDeque)))
+           (com.puppetlabs.puppetserver JRubyPuppet RegisteredLinkedBlockingDeque)))
 
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -86,7 +85,7 @@
             real-pool     (-> (tk-services/service-context jruby-service)
                               :pool-context
                               (jruby-core/get-pool))
-            retry-pool    (LinkedBlockingDeque. 1)
+            retry-pool    (RegisteredLinkedBlockingDeque. 1)
             _             (-> retry-pool (RetryPoisonPill.) jruby-core/return-to-pool)
             mock-pools    [retry-pool retry-pool retry-pool real-pool]
             num-borrows   (atom 0)


### PR DESCRIPTION
This commit fixes a bug where, if any JRuby instances were borrowed from the pool when a request came in to flush the environment cache,  those instances would not have their cache flushed.

The implementation of the cache flush was simply grabbing a reference to all of the instances *currently* in the pool, and then manipulating some Clojure state associated with those instances to notify the Ruby code that the environment cache should be flushed.  It did not take into account any instances that weren't in the pool at the time when this action transpired.

This commit adds a simple subclass of the java.util.concurrent data structure that we have been using to implement the pool, and a "register" method that can be used to add items to the data structure in a way where the list of all known instances is available for retrieval at any time, regardless of which instances are currently in the pool and which are borrowed.