### PR TITLE
(maint) Update puppet version to fix acceptance test failures

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -29,7 +29,7 @@ module PuppetServerExtensions
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "11a8920f232e78b4eca2467a9d11caab0337daa9")
+                         "PUPPET_BUILD_VERSION", "b10da7d8f61d99f5ca7ce6c9fe69c50d44874908")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
Previously, puppet-server stable tests were running against a build of
puppet-agent that was from the per-commit pipeline. This meant that it was not
available on all platforms we run puppet-server stable acceptance tests against.
The first commit in this PR bumps the puppet build version to a puppet-agent package version in
nightlies, which is built for all the platforms.

PUP-4824 had some incorrectly written tests that caused errors for our CI.
These have now been fixed in puppet stable. The second commit updates the submodule
(and therefore the acceptance tests we are running) for these fixes.

The second commit does not update the puppet agent/puppet build version in
`acceptance/lib/helper.rb` since the only changes that have been made since the
package we currently have specified there are test changes.