### PR TITLE
(maint) Add java 8 as travis target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ lein: lein2
 jdk:
 - oraclejdk7
 - openjdk7
+- oraclejdk8
 script: "./ext/travisci/test.sh"
 sudo: false
 notifications:


### PR DESCRIPTION
Given that some of our packages now require java 8, it seems like a good idea
to add travis for it.