### PR TITLE
(MAINT) Bump puppet-agent dep

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -29,7 +29,7 @@ module PuppetServerExtensions
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
-                         "PUPPET_BUILD_VERSION", "746a14bb9584120f2228107d15ec6f00f9a9bad4")
+                         "PUPPET_BUILD_VERSION", "d5b768cd20d39a5a04da7ba88006e5dd7b788087")
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
This commit bumps the puppet-agent dependency for CI testing to
d5b768cd20d39a5a04da7ba88006e5dd7b788087.