### PR TITLE
(MAINT) Fix repl per break in SERVER-813

### DIFF
--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -39,7 +39,12 @@
      :webserver             {:client-auth "want"
                              :ssl-host    "localhost"
                              :ssl-port    8140}
-     :certificate-authority {:certificate-status {:client-whitelist []}}}))
+     :certificate-authority {:certificate-status {:client-whitelist []}}
+     :web-router-service    {:puppetlabs.services.ca.certificate-authority-service/certificate-authority-service ""
+                             :puppetlabs.services.master.master-service/master-service ""
+                             :puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service "/puppet-admin-api"}
+     :puppet-admin          {:client-whitelist       []
+                             :authorization-required false}}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Basic system life cycle
@@ -102,7 +107,7 @@
 (defn jruby-pool
   "Returns a reference to the current pool of JRuby interpreters."
   []
-  (jruby-core/pool->vec (context [:JRubyPuppetService :pool-context])))
+  (jruby-core/registered-instances (context [:JRubyPuppetService :pool-context])))
 
 (defn puppet-environment-state
   "Given a JRuby instance, return the state information about the environments


### PR DESCRIPTION
This commit fixes the user_repl.clj, previously broken by changes
introduced in SERVER-813.  The primary change in the commit is to rename
`pool->vec` to `registered-instances` per the name change made as part
of the work on that ticket.  The commit also includes some web-routing
and puppet-admin sections missing from the sample repl configuration.