### PR TITLE
(maint) Add handler for /environment/:environment route

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -51,6 +51,8 @@
                    (request-handler request))
     (comidi/GET ["/resource_types/" [#".*" :rest]] request
                    (request-handler request))
+    (comidi/GET ["/environment/" [#".*" :rest]] request
+                   (request-handler request))
     (comidi/GET "/environments" request
                    (request-handler request))
     (comidi/GET ["/status/" [#".*" :rest]] request

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -24,6 +24,7 @@
     (doseq [[method paths]
             {:get ["catalog"
                    "node"
+                   "environment"
                    "facts"
                    "file_content"
                    "file_metadatas"


### PR DESCRIPTION
This route is used for retrieving information about an environment
catalog. This just passes through handling of the route to puppet, as
with all the similar routes.