### PR TITLE
(PUP-4536) Add docs comment about module code compatibility

### DIFF
--- a/documentation/puppetserver_vs_passenger.markdown
+++ b/documentation/puppetserver_vs_passenger.markdown
@@ -30,6 +30,10 @@ If you have server-side Ruby code in your modules, Puppet Server will run it via
 JRuby. Generally speaking, this only affects custom parser functions and report
 processors. For the vast majority of cases, this shouldn't pose any problems, as JRuby is highly compatible with vanilla Ruby.
 
+## Ruby Compatibility For Extensions
+
+Ruby extension code in your modules needs to run under both Ruby 1.9 and Ruby 2.1. This is because Puppet Server runs Puppet functions and custom resource types under JRuby (which is a Ruby 1.9-compatible interpreter), and the official `puppet-agent` releases run custom facts and types/providers under MRI Ruby 2.1.
+
 ## Installing And Removing Gems
 
 We isolate the Ruby load paths that are accessible to Puppet Server's

--- a/documentation/puppetserver_vs_passenger.markdown
+++ b/documentation/puppetserver_vs_passenger.markdown
@@ -32,7 +32,7 @@ processors. For the vast majority of cases, this shouldn't pose any problems, as
 
 ## Ruby Compatibility For Extensions
 
-Ruby extension code in your modules needs to run under both Ruby 1.9 and Ruby 2.1. This is because Puppet Server runs Puppet functions and custom resource types under JRuby (which is a Ruby 1.9-compatible interpreter), and the official `puppet-agent` releases run custom facts and types/providers under MRI Ruby 2.1.
+Ruby extension code in your modules needs to run under both Ruby 1.9 and Ruby 2.1. This is because Puppet Server runs Puppet functions and custom resource types under JRuby 1.7 (which is a Ruby 1.9-compatible interpreter), and the official `puppet-agent` releases run custom facts and types/providers under MRI Ruby 2.1.
 
 ## Installing And Removing Gems
 


### PR DESCRIPTION
Previously we didn't have a message to users describing the different
Ruby runtime versions between Puppet Server and the Agent.

This commit adds a section to the Apache/Passenger->Puppet Server
doc describing the Ruby compatibility requirements for code that
runs on the server vs agent.