### PR TITLE
(MAINT) Add stable branch name to 2.1.2-SNAPSHOT version string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.1.2-SNAPSHOT")
+(def ps-version "2.1.2-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit adds the "stable" branch name to the 2.1.2-SNAPSHOT
project.clj version in order to distinguish OSS puppet-server versions
being built from the stable branch from those being built from the
master branch.