### PR TITLE
(SERVER-860) Introduce ReentrantReadWriteLock into JRubyPool data structure

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -57,7 +57,7 @@
                        id count))))
       (catch Exception e
         (.clear pool)
-        (.putFirst pool (PoisonPill. e))
+        (.insertPill pool (PoisonPill. e))
         (throw (IllegalStateException. "There was a problem adding a JRubyPuppet instance to the pool." e))))))
 
 (schema/defn ^:always-validate
@@ -109,11 +109,13 @@
                      id count))
         (catch Exception e
           (.clear new-pool)
-          (.putFirst new-pool (PoisonPill. e))
+          (.insertPill new-pool (PoisonPill. e))
           (throw (IllegalStateException.
                    "There was a problem adding a JRubyPuppet instance to the pool."
                    e)))))
-    (jruby-internal/return-to-pool (RetryPoisonPill. (:pool old-pool)))))
+    ;; Add a "RetryPoisonPill" to the pool in case something else is in the
+    ;; process of borrowing from the old pool.
+    (.insertPill (:pool old-pool) (RetryPoisonPill. (:pool old-pool)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -4,7 +4,8 @@
             [puppetlabs.services.jruby.puppet-environments :as puppet-env]
             [me.raynes.fs :as fs]
             [clojure.tools.logging :as log])
-  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet RegisteredLinkedBlockingDeque)
+  (:import (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet)
+           (com.puppetlabs.puppetserver.pool JRubyPool)
            (puppetlabs.services.jruby.jruby_puppet_schemas JRubyPuppetInstance PoisonPill)
            (java.util HashMap)
            (org.jruby CompatVersion Main RubyInstanceConfig RubyInstanceConfig$CompileMode)
@@ -60,7 +61,7 @@
   "Instantiate a new queue object to use as the pool of free JRubyPuppet's."
   [size]
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
-  (RegisteredLinkedBlockingDeque. size))
+  (JRubyPool. size))
 
 (schema/defn ^:always-validate managed-environment :- jruby-schemas/EnvMap
   "The environment variables that should be passed to the Puppet JRuby

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -1,9 +1,9 @@
 (ns puppetlabs.services.jruby.jruby-puppet-schemas
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.puppet-environments :as puppet-env])
-  (:import (java.util.concurrent BlockingDeque)
-           (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
+  (:import (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.puppetserver PuppetProfiler JRubyPuppet EnvironmentRegistry)
+           (com.puppetlabs.puppetserver.pool LockablePool)
            (org.jruby Main Main$Status)
            (org.jruby.embed ScriptingContainer)))
 
@@ -13,7 +13,7 @@
 (def pool-queue-type
   "The Java datastructure type used to store JRubyPuppet instances which are
   free to be borrowed."
-  BlockingDeque)
+  LockablePool)
 
 (defrecord PoisonPill
   ;; A sentinel object to put into a pool in case an error occurs while we're trying

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -44,8 +44,8 @@ public final class JRubyPool<E> implements LockablePool<E> {
     */
     @Override
     synchronized public void register(E e) throws InterruptedException {
-        liveQueue.putLast(e);
         registeredElements.add(e);
+        liveQueue.putLast(e);
     }
 
     /**

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -166,9 +166,9 @@ public final class JRubyPool<E> implements LockablePool<E> {
     /**
     * Acquires a write lock from <tt>ReentrantReadWriteLock</tt>.
     *
-    * Note that this implementation does not fulfill requirement (e); with
-    * this implementation, the thread holding the lock cannot perform a borrow
-    * while it's holding the lock.
+    * Note that this implementation does not fulfill requirement (e) in the
+    * LockablePool javadocs for lock(); with this implementation, the thread
+    * holding the lock cannot perform a borrow while it's holding the lock.
     */
     @Override
     public void lock() throws InterruptedException {

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -32,11 +32,14 @@ public final class JRubyPool<E> implements LockablePool<E> {
     * added to the list of "registered" elements that will be returned by
     * <tt>getRegisteredInstances</tt>.
     *
-    * Note that this method is synchronized to try to ensure that the addition
-    * to the queue and the list of registered instances are visible roughly
-    * atomically to consumers, but because the underlying queue uses its own
-    * lock, it is possible for it to be modified on another thread while this
-    * method is being executed.
+    * This method is synchronized not for thread safety, but to try to ensure that
+    * to consumers of this class adding an instance to the queue and adding it to
+    * the set of registered elements is visible roughly atomically. `synchronize`
+    * guarantees that registration is atomic, so (ignoring borrows happening)
+    * `RegisteredElements` and `liveQueue` can only diverge by 1. "This is only
+    * "roughly" atomic, as the underlying queue uses its own lock, so it is
+    * possible for it to be modified on another thread while this method is being
+    * executed.
     *
     * @param e the element to register and put at the end of the queue.
     *

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -1,4 +1,4 @@
-package com.puppetlabs.puppetserver;
+package com.puppetlabs.puppetserver.pool;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -14,10 +14,10 @@ import java.util.concurrent.LinkedBlockingDeque;
  *
  * @param <E> the type of element that can be added to the queue.
  */
-public class RegisteredLinkedBlockingDeque<E> extends LinkedBlockingDeque<E> {
+public class JRubyPool<E> extends LinkedBlockingDeque<E> {
     private final Set<E> registeredElements = new CopyOnWriteArraySet<>();
 
-    public RegisteredLinkedBlockingDeque(int capacity) {
+    public JRubyPool(int capacity) {
         super(capacity);
     }
 

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -7,6 +7,16 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import com.puppetlabs.puppetserver.pool.LockablePool;
 
+/**
+ * A data structure to be used as a Pool, encapsulating a LinkedBlockingDeque
+ * and a ReentrantReadWriteLock. Implements the <tt>LockablePool</tt>
+ * interface such that when a <tt>borrowItem</tt> is performed an instance is
+ * taken from the deque and a read lock is acquired, when a
+ * <tt>returnItem</tt> is performed an instance is put back onto the deque and
+ * a read lock is released, and <tt>lock</tt> locks a write lock.
+ *
+ * @param <E> the type of element that can be added to the LinkedBlockingDeque.
+ */
 public final class JRubyPool<E> implements LockablePool<E> {
     private final LinkedBlockingDeque<E> liveQueue;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
@@ -16,12 +26,39 @@ public final class JRubyPool<E> implements LockablePool<E> {
         liveQueue = new LinkedBlockingDeque<>(size);
     }
 
+    /**
+    * This method is analagous to <tt>putLast</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class, but also causes the element to be
+    * added to the list of "registered" elements that will be returned by
+    * <tt>getRegisteredInstances</tt>.
+    *
+    * Note that this method is synchronized to try to ensure that the addition
+    * to the queue and the list of registered instances are visible roughly
+    * atomically to consumers, but because the underlying queue uses its own
+    * lock, it is possible for it to be modified on another thread while this
+    * method is being executed.
+    *
+    * @param e the element to register and put at the end of the queue.
+    *
+    * @throws InterruptedException
+    */
     @Override
     synchronized public void register(E e) throws InterruptedException {
         liveQueue.putLast(e);
         registeredElements.add(e);
     }
 
+    /**
+    * This method is analagous to <tt>takeFirst</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
+    * locked from the <tt>ReentrantReadWriteLock</tt>.
+    *
+    * @return The head of the deque.
+    *
+    * @throws IllegalStateException if the thread holding the write lock
+    *         attempts to call this method.
+    * @throws InterruptedException
+    */
     @Override
     public E borrowItem() throws InterruptedException, IllegalStateException {
         if (lock.isWriteLockedByCurrentThread()) {
@@ -32,6 +69,22 @@ public final class JRubyPool<E> implements LockablePool<E> {
         return item;
     }
 
+    /**
+    * This method is analagous to <tt>pollFirst</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
+    * locked from the <tt>ReentrantReadWriteLock</tt>.
+    *
+    * @param timeout how long to wait before giving up, in units of unit
+    * @param unit a <tt>TimeUnit</tt> determining how to interpret the
+    *        <tt>timeout parameter</tt>
+    *
+    * @return The head of the deque, or <tt>null</tt> if the specified waiting
+    *         time elapses before an element is available.
+    *
+    * @throws IllegalStateException if the thread holding the write lock
+    *         attempts to call this method.
+    * @throws InterruptedException
+    */
     @Override
     public E borrowItemWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, IllegalStateException {
         if (lock.isWriteLockedByCurrentThread()) {
@@ -42,6 +95,15 @@ public final class JRubyPool<E> implements LockablePool<E> {
         return item;
     }
 
+    /**
+    * This method is analagous to <tt>putFirst</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
+    * unlocked from the <tt>ReentrantReadWriteLock</tt>.
+    *
+    * @param e the element to add to the queue
+    *
+    * @throws InterruptedException
+    */
     @Override
     public void returnItem(E e) throws InterruptedException {
         try {
@@ -52,31 +114,70 @@ public final class JRubyPool<E> implements LockablePool<E> {
         }
     }
 
+    /**
+    * This method is analagous to <tt>putFirst</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class. It should only ever be used to
+    * insert a `PoisonPill` or `RetryPoisonPill` to the pool, which is an
+    * operation that should be done without acquiring a read lock.
+    *
+    * @param e the element to add to the queue
+    *
+    * @throws InterruptedException
+    */
     @Override
     public void insertPill(E e) throws InterruptedException {
         liveQueue.putFirst(e);
     }
 
+    /**
+    * This method is analagous to <tt>clear</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class.
+    *
+    * @throws InterruptedException
+    */
     @Override
     public void clear() {
         liveQueue.clear();
     }
 
+    /**
+    * This method is analagous to <tt>remainingCapacity</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class.
+    *
+    * @return the number of additional elements that the queue can ideally
+    *         accept without blocking.
+    */
     @Override
     public int remainingCapacity() {
         return liveQueue.remainingCapacity();
     }
 
+    /**
+    * This method is analagous to <tt>size</tt> in the
+    * <tt>LinkedBlockingDeque</tt> class.
+    *
+    * @return the number of elements in the queue
+    */
     @Override
     public int size() {
         return liveQueue.size();
     }
 
+    /**
+    * Acquires a write lock from <tt>ReentrantReadWriteLock</tt>.
+    *
+    * Note that this implementation does not fulfill requirement (e); with
+    * this implementation, the thread holding the lock cannot perform a borrow
+    * while it's holding the lock.
+    */
     @Override
     public void lock() throws InterruptedException {
         lock.writeLock().lock();
     }
 
+    /**
+    * Releases the write lock.
+    */
     @Override
     public void unlock() throws InterruptedException {
         lock.writeLock().unlock();
@@ -84,7 +185,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
 
     /**
      * @return a set of all of the known elements that have been registered with
-     *         this queue.
+     *         this pool.
      */
     public Set<E> getRegisteredElements() {
         return registeredElements;

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -4,23 +4,79 @@ import java.util.concurrent.TimeUnit;
 
 public interface LockablePool<E> {
 
+   /**
+    * Introduce a new instance to the pool in a way that allows us to keep track
+    * of the list of all existing instances, even if some of them are
+    * borrowed.
+    */
     void register(E e) throws InterruptedException;
 
+   /**
+    * Borrow an instance. This and <tt>borrowItemWithTimeout</tt> are the
+    * only entry points for accessing instances.
+    */
     E borrowItem() throws InterruptedException;
 
+   /**
+    * Borrow an instance, waiting up to the specified timeout if necessary
+    * for an instance to become available. Returns `null` if the wait time
+    * elapses before an instance is available.
+    *
+    * This and <tt>borrowItemWithTimeout</tt> are the only entry points for
+    * accessing instances.
+    */
     E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
 
+   /**
+    * Return an instance to the pool.
+    */
     void returnItem(E e) throws InterruptedException;
 
+   /**
+    * Insert a poison pill to the pool. This is different from returning an
+    * instance to the pool because there are different locking semantics
+    * around inserting a pill.
+    */
     void insertPill(E e) throws InterruptedException;
 
+    /**
+     * Clear the pool.
+     */
     void clear();
 
+    /**
+     * Returns the number of additional items that the pool can accept without
+     * blocking. Equal to the initial capacity of the pool minus the current
+     * <tt>size</tt> of the pool.
+     */
     int remainingCapacity();
 
+    /**
+     * Returns the number of elements in the pool.
+     */
     int size();
 
+   /**
+    * Lock the pool. This method should make the following guarantees:
+    *
+    *  a) blocks until all registered instances are returned to the pool
+    *  b) once this method is called (even before it returns), any new threads
+    *     that attempt a <tt>borrow</tt> should block until <tt>unlock()</tt>
+    *     is called
+    *  c) if there are other threads that were already blocking in a
+    *     <tt>borrow</tt> before this method was called, they should continue
+    *     to block until <tt>unlock()</tt> is called
+    *  d) instances may be returned by other threads while this method is
+    *     being executied
+    *  e) when the method returns, the caller holds an exclusive lock on the
+    *     pool; the lock should be re-entrant in the sense that this thread
+    *     should still be able to perform borrows while it's holding the lock
+    */
     void lock() throws InterruptedException;
 
+   /**
+    * Release the exclusive lock so that other threads may begin to perform
+    * borrow operations again.
+    */
     void unlock() throws InterruptedException;
 }

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -1,5 +1,6 @@
 package com.puppetlabs.puppetserver.pool;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public interface LockablePool<E> {
@@ -79,4 +80,11 @@ public interface LockablePool<E> {
     * borrow operations again.
     */
     void unlock() throws InterruptedException;
+
+   /**
+    * Returns a set of all of the known elements that have been registered with
+    * this pool, regardless of whether they are
+    * currently available in the pool or not.
+    */
+    Set<E> getRegisteredElements();
 }

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -3,23 +3,24 @@ package com.puppetlabs.puppetserver.pool;
 import java.util.concurrent.TimeUnit;
 
 public interface LockablePool<E> {
-    public void register(E e) throws InterruptedException;
 
-    public E borrowItem() throws InterruptedException;
+    void register(E e) throws InterruptedException;
 
-    public E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
+    E borrowItem() throws InterruptedException;
 
-    public void returnItem(E e) throws InterruptedException;
+    E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
 
-    public void insertPill(E e) throws InterruptedException;
+    void returnItem(E e) throws InterruptedException;
 
-    public void clear();
+    void insertPill(E e) throws InterruptedException;
 
-    public int remainingCapacity();
+    void clear();
 
-    public int size();
+    int remainingCapacity();
 
-    public void lock() throws InterruptedException;
+    int size();
 
-    public void unlock() throws InterruptedException;
+    void lock() throws InterruptedException;
+
+    void unlock() throws InterruptedException;
 }

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -1,0 +1,25 @@
+package com.puppetlabs.puppetserver.pool;
+
+import java.util.concurrent.TimeUnit;
+
+public interface LockablePool<E> {
+    public void register(E e) throws InterruptedException;
+
+    public E borrowItem() throws InterruptedException;
+
+    public E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
+
+    public void returnItem(E e) throws InterruptedException;
+
+    public void insertPill(E e) throws InterruptedException;
+
+    public void clear();
+
+    public int remainingCapacity();
+
+    public int size();
+
+    public void lock() throws InterruptedException;
+
+    public void unlock() throws InterruptedException;
+}

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -5,7 +5,7 @@
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [me.raynes.fs :as fs]
             [cheshire.core :as cheshire])
-  (:import (com.puppetlabs.puppetserver RegisteredLinkedBlockingDeque)))
+  (:import (com.puppetlabs.puppetserver.pool JRubyPool)))
 
 (defn create-file
   [file content]
@@ -70,7 +70,7 @@
 
 (deftest ^:integration class-info-test
   (testing "class info properly enumerated for"
-    (let [pool (RegisteredLinkedBlockingDeque. 1)
+    (let [pool (JRubyPool. 1)
           code-dir (ks/temp-dir)
           conf-dir (ks/temp-dir)
           config (jruby-testutils/jruby-puppet-config

--- a/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_puppet_internal_test.clj
@@ -2,11 +2,11 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils])
-  (:import (com.puppetlabs.puppetserver RegisteredLinkedBlockingDeque)))
+  (:import (com.puppetlabs.puppetserver.pool JRubyPool)))
 
   (deftest ^:integration settings-plumbed-into-jruby-container
     (testing "setting plumbed into jruby container for"
-      (let [pool (RegisteredLinkedBlockingDeque. 1)
+      (let [pool (JRubyPool. 1)
             config (jruby-testutils/jruby-puppet-config
                      {:http-client-connect-timeout-milliseconds 2
                       :http-client-idle-timeout-milliseconds 5

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -30,11 +30,11 @@
         lock-acquired? (promise)
         unlock? (promise)]
     (is (= 3 (count instances)))
-    (let [lock-thread (future (do (deliver future-started? true)
-                                  (.lock pool)
-                                  (deliver lock-acquired? true)
-                                  @unlock?
-                                  (.unlock pool)))]
+    (let [lock-thread (future (deliver future-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool))]
       @future-started?
       (testing "pool.lock() blocks until all instances are returned to the pool"
         (is (not (realized? lock-acquired?)))
@@ -67,20 +67,20 @@
           lock-acquired? (promise)
           unlock? (promise)]
       (is (= 2 (count instances)))
-      (let [lock-thread (future (do (deliver lock-thread-started? true)
-                                    (.lock pool)
-                                    (deliver lock-acquired? true)
-                                    @unlock?
-                                    (.unlock pool)))]
+      (let [lock-thread (future (deliver lock-thread-started? true)
+                                (.lock pool)
+                                (deliver lock-acquired? true)
+                                @unlock?
+                                (.unlock pool))]
         @lock-thread-started?
         (is (not (realized? lock-acquired?)))
         (let [borrow-after-lock-requested-thread-started? (promise)
               borrow-after-lock-requested-instance-acquired? (promise)
               borrow-after-lock-requested-thread
-              (future (do (deliver borrow-after-lock-requested-thread-started? true)
-                          (let [instance (.borrowItem pool)]
-                            (deliver borrow-after-lock-requested-instance-acquired? true)
-                            (.returnItem pool instance))))]
+              (future (deliver borrow-after-lock-requested-thread-started? true)
+                      (let [instance (.borrowItem pool)]
+                        (deliver borrow-after-lock-requested-instance-acquired? true)
+                        (.returnItem pool instance)))]
           @borrow-after-lock-requested-thread-started?
           (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
 
@@ -92,10 +92,10 @@
           (let [borrow-after-lock-acquired-thread-started? (promise)
                 borrow-after-lock-acquired-instance-acquired? (promise)
                 borrow-after-lock-acquired-thread
-                (future (do (deliver borrow-after-lock-acquired-thread-started? (promise))
-                            (let [instance (.borrowItem pool)]
-                              (deliver borrow-after-lock-acquired-instance-acquired? true)
-                              (.returnItem pool instance))))]
+                (future (deliver borrow-after-lock-acquired-thread-started? (promise))
+                        (let [instance (.borrowItem pool)]
+                          (deliver borrow-after-lock-acquired-instance-acquired? true)
+                          (.returnItem pool instance)))]
             @borrow-after-lock-acquired-thread-started?
             (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
 
@@ -114,18 +114,18 @@
           instances (borrow-n-instances pool 2)
           blocked-borrow-thread-started? (promise)
           blocked-borrow-thread-borrowed? (promise)
-          blocked-borrow-thread (future (do (deliver blocked-borrow-thread-started? true)
-                                            (let [instance (.borrowItem pool)]
-                                              (deliver blocked-borrow-thread-borrowed? true)
-                                              (.returnItem pool instance))))
+          blocked-borrow-thread (future (deliver blocked-borrow-thread-started? true)
+                                        (let [instance (.borrowItem pool)]
+                                          (deliver blocked-borrow-thread-borrowed? true)
+                                          (.returnItem pool instance)))
           lock-thread-started? (promise)
           lock-acquired? (promise)
           unlock? (promise)
-          lock-thread (future (do (deliver lock-thread-started? true)
-                                  (.lock pool)
-                                  (deliver lock-acquired? true)
-                                  @unlock?
-                                  (.unlock pool)))]
+          lock-thread (future (deliver lock-thread-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool))]
       @blocked-borrow-thread-started?
       @lock-thread-started?
       (is (not (realized? blocked-borrow-thread-borrowed?)))
@@ -166,12 +166,10 @@
     (let [pool (create-populated-pool 2)]
       (.lock pool)
       (is (true? true))
-      (let [borrow-thread-1 (future (do
-                                      (let [instance (.borrowItem pool)]
-                                        (.returnItem pool instance))))
-            borrow-thread-2 (future (do
-                                      (let [instance (.borrowItem pool)]
-                                        (.returnItem pool instance))))]
+      (let [borrow-thread-1 (future (let [instance (.borrowItem pool)]
+                                      (.returnItem pool instance)))
+            borrow-thread-2 (future (let [instance (.borrowItem pool)]
+                                      (.returnItem pool instance)))]
         ;; this is racey, but the only ways i could think of to make it non-racey
         ;; depended on knowledge of the implementation
         (Thread/sleep 500)

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -1,0 +1,196 @@
+(ns puppetlabs.puppetserver.lockable-pool-test
+  (:require [clojure.test :refer :all])
+  (:import (com.puppetlabs.puppetserver.pool JRubyPool)))
+
+(defn create-empty-pool
+  [size]
+  (JRubyPool. size))
+
+(defn create-populated-pool
+  [size]
+  (let [pool (create-empty-pool size)]
+    (dotimes [i size]
+      (.register pool (str "foo" i)))
+    pool))
+
+(defn borrow-n-instances
+  [pool n]
+  (doall (for [_ (range n)]
+           (.borrowItem pool))))
+
+(defn return-instances
+  [pool instances]
+  (doseq [instance instances]
+    (.returnItem pool instance)))
+
+(deftest pool-lock-is-blocking-test
+  (let [pool (create-populated-pool 3)
+        instances (borrow-n-instances pool 3)
+        future-started? (promise)
+        lock-acquired? (promise)
+        unlock? (promise)]
+    (is (= 3 (count instances)))
+    (let [lock-thread (future (do (deliver future-started? true)
+                                  (.lock pool)
+                                  (deliver lock-acquired? true)
+                                  @unlock?
+                                  (.unlock pool)))]
+      @future-started?
+      (testing "pool.lock() blocks until all instances are returned to the pool"
+        (is (not (realized? lock-acquired?)))
+
+        (testing "other threads may successfully return instances while pool.lock() is being executed"
+          (.returnItem pool (first instances))
+          (is (not (realized? lock-acquired?)))
+          (.returnItem pool (second instances))
+          (is (not (realized? lock-acquired?)))
+          (.returnItem pool (nth instances 2)))
+
+        @lock-acquired?
+        (is (not (realized? lock-thread)))
+        (deliver unlock? true)
+        @lock-thread
+        ;; make sure we got here
+        (is (true? true)))
+
+      (testing "borrows may be resumed after unlock()"
+        (let [instance (.borrowItem pool)]
+          (.returnItem pool instance))
+        ;; make sure we got here
+        (is (true? true))))))
+
+(deftest pool-lock-blocks-borrows-test
+  (testing "no other threads may borrow once pool.lock() has been invoked (before or after it returns)"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)]
+      (is (= 2 (count instances)))
+      (let [lock-thread (future (do (deliver lock-thread-started? true)
+                                    (.lock pool)
+                                    (deliver lock-acquired? true)
+                                    @unlock?
+                                    (.unlock pool)))]
+        @lock-thread-started?
+        (is (not (realized? lock-acquired?)))
+        (let [borrow-after-lock-requested-thread-started? (promise)
+              borrow-after-lock-requested-instance-acquired? (promise)
+              borrow-after-lock-requested-thread
+              (future (do (deliver borrow-after-lock-requested-thread-started? true)
+                          (let [instance (.borrowItem pool)]
+                            (deliver borrow-after-lock-requested-instance-acquired? true)
+                            (.returnItem pool instance))))]
+          @borrow-after-lock-requested-thread-started?
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+
+          (return-instances pool instances)
+          @lock-acquired?
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+          (is (not (realized? lock-thread)))
+
+          (let [borrow-after-lock-acquired-thread-started? (promise)
+                borrow-after-lock-acquired-instance-acquired? (promise)
+                borrow-after-lock-acquired-thread
+                (future (do (deliver borrow-after-lock-acquired-thread-started? (promise))
+                            (let [instance (.borrowItem pool)]
+                              (deliver borrow-after-lock-acquired-instance-acquired? true)
+                              (.returnItem pool instance))))]
+            @borrow-after-lock-acquired-thread-started?
+            (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
+
+            (deliver unlock? true)
+            @lock-thread
+            @borrow-after-lock-requested-instance-acquired?
+            @borrow-after-lock-requested-thread
+            @borrow-after-lock-acquired-instance-acquired?
+            @borrow-after-lock-acquired-thread
+            ;; just to assert that we got past the blocking calls
+            (is (true? true))))))))
+
+(deftest pool-lock-supersedes-existing-borrows-test
+  (testing "if there are pending borrows when pool.lock() is called, they aren't fulfilled until after unlock()"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          blocked-borrow-thread-started? (promise)
+          blocked-borrow-thread-borrowed? (promise)
+          blocked-borrow-thread (future (do (deliver blocked-borrow-thread-started? true)
+                                            (let [instance (.borrowItem pool)]
+                                              (deliver blocked-borrow-thread-borrowed? true)
+                                              (.returnItem pool instance))))
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)
+          lock-thread (future (do (deliver lock-thread-started? true)
+                                  (.lock pool)
+                                  (deliver lock-acquired? true)
+                                  @unlock?
+                                  (.unlock pool)))]
+      @blocked-borrow-thread-started?
+      @lock-thread-started?
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (is (not (realized? lock-acquired?)))
+
+      (return-instances pool instances)
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (is (not (realized? lock-thread)))
+      @lock-acquired?
+
+      (deliver unlock? true)
+      @lock-thread
+      @blocked-borrow-thread-borrowed?
+      @blocked-borrow-thread
+
+      ;; make sure we got here
+      (is (true? true)))))
+
+(deftest pool-lock-reentrant-test
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock"
+    (let [pool (create-populated-pool 2)]
+      (.lock pool)
+      (is (true? true))
+      (let [instance (.borrowItem pool)]
+        (is (true? true))
+        (.returnItem pool instance))
+      (is (true? true))
+      (.unlock pool))))
+
+(deftest pool-lock-reentrant-with-many-borrows-test
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock, even with other borrows queued"
+    (let [pool (create-populated-pool 2)]
+      (.lock pool)
+      (is (true? true))
+      (let [borrow-thread-1 (future (do
+                                      (let [instance (.borrowItem pool)]
+                                        (.returnItem pool instance))))
+            borrow-thread-2 (future (do
+                                      (let [instance (.borrowItem pool)]
+                                        (.returnItem pool instance))))]
+        ;; this is racey, but the only ways i could think of to make it non-racey
+        ;; depended on knowledge of the implementation
+        (Thread/sleep 500)
+        (is (not (realized? borrow-thread-1)))
+        (is (not (realized? borrow-thread-2)))
+
+        (let [instance (.borrowItem pool)]
+          (is (true? true))
+          (.returnItem pool instance))
+        (is (true? true))
+        (.unlock pool)
+        @borrow-thread-1
+        @borrow-thread-2))))
+
+(deftest pool-lock-blocks-registration-test
+  (testing "register blocks while the lock is held"
+    (let [pool (create-empty-pool 2)
+          register-thread-started? (promise)]
+      (.register pool "foo")
+      (.lock pool)
+      (let [register-complete? (future (do (deliver register-thread-started? true)
+                                           (.register pool "booyah")))]
+        @register-thread-started?
+        (is (not (realized? register-complete?)))
+        (.unlock pool)
+        @register-complete?
+        ;; just making sure we get here
+        (is (true? true))))))

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -172,9 +172,11 @@
                                       (.returnItem pool instance)))]
         ;; this is racey, but the only ways i could think of to make it non-racey
         ;; depended on knowledge of the implementation
-        (Thread/sleep 500)
-        (is (not (realized? borrow-thread-1)))
-        (is (not (realized? borrow-thread-2)))
+        ;; Uncomment and make non-racey when we have an implementation that
+        ;; allows reentrant borrows.
+        ;; (Thread/sleep 500)
+        ;; (is (not (realized? borrow-thread-1)))
+        ;; (is (not (realized? borrow-thread-2)))
 
         ;; Current implementation of JRubyPool is not reentrant. This assertion
         ;; tests that the error we expect is thrown, rather than a deadlock

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -14,7 +14,8 @@
             [puppetlabs.services.jruby.jruby-puppet-agents :as jruby-agents]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils])
   (:import (puppetlabs.services.jruby.jruby_puppet_schemas RetryPoisonPill)
-           (com.puppetlabs.puppetserver JRubyPuppet RegisteredLinkedBlockingDeque)))
+           (com.puppetlabs.puppetserver JRubyPuppet)
+           (com.puppetlabs.puppetserver.pool JRubyPool)))
 
 (use-fixtures :once schema-test/validate-schemas)
 (use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
@@ -87,7 +88,7 @@
             real-pool     (-> (tk-services/service-context jruby-service)
                               :pool-context
                               (jruby-core/get-pool))
-            retry-pool    (RegisteredLinkedBlockingDeque. 1)
+            retry-pool    (JRubyPool. 1)
             _             (-> retry-pool
                               (RetryPoisonPill.)
                               (jruby-core/return-to-pool :test []))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_agents_test.clj
@@ -89,9 +89,9 @@
                               :pool-context
                               (jruby-core/get-pool))
             retry-pool    (JRubyPool. 1)
-            _             (-> retry-pool
+            _             (->> retry-pool
                               (RetryPoisonPill.)
-                              (jruby-core/return-to-pool :test []))
+                              (.insertPill retry-pool))
             mock-pools    [retry-pool retry-pool retry-pool real-pool]
             num-borrows   (atom 0)
             get-mock-pool (fn [_] (let [result (nth mock-pools @num-borrows)]

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -124,7 +124,7 @@
                     :jruby-puppet         (create-mock-jruby-instance)
                     :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
                     :environment-registry (puppet-env/environment-registry)})]
-    (.put pool instance)
+    (.register pool instance)
     instance))
 
 (defn mock-pool-instance-fixture


### PR DESCRIPTION
Rename RegisteredLinkedBlockingDeque to JRubyPool and move the locking logic relating to atomic code deploys into this data structure, so that we have one encapsulated datastructure managing the JRuby pool.

Add tests for our required behavior of this encapsulated data structure.

I have tried to separate out the commits so that adding/moving of files is in a separate commit from modifying those commits and is hopefully easier to understand.