### PR TITLE
(SERVER-846) Default tk-authz auth.conf rules

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -107,6 +107,7 @@ profiler: {
 
 # authorization rules for web service endpoints
 authorization: {
+    version: 1
     rules: [
         {
             match-request: {
@@ -114,6 +115,8 @@ authorization: {
                 type: "path"
             }
             allow-unauthenticated: true
+            sort-order: 1
+            name: "allow all"
         }
     ]
 }

--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -42,10 +42,13 @@
                           :puppetlabs.services.master.master-service/master-service                           "/puppet"
                           :puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service         "/puppet-admin-api"
                           :puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service      ""}
-     :authorization      {:rules [{:match-request
-                                          {:path "/"
-                                           :type "path"}
-                                   :allow-unauthenticated true}]}}))
+     :authorization      {:version 1
+                          :rules [{:match-request
+                                   {:path "/"
+                                    :type "path"}
+                                   :allow-unauthenticated true
+                                   :sort-order 1
+                                   :name "allow all"}]}}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Basic system life cycle

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -1,39 +1,116 @@
 authorization: {
-    # TODO: Fill these in with real default rule definitions - SERVER-846.
-    # Putting just the ones for the certificate authority in for now since
-    # these are always evaluated by trapperkeeper-authorization and are
-    # needed to complete a successful agent run.
+    version: 1
     rules: [
         {
+            # Allow nodes to retrieve their own catalog
             match-request: {
-                path: "/puppet-ca/v1/certificate_revocation_list/ca"
-                type: path
-                method: get
+                path: "^/puppet/v3/catalog/([^/]+)$"
+                type: regex
+                method: [get, post]
             }
-            allow: "*"
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs catalog"
         },
         {
-            match-request: {
-                path: "/puppet-ca/v1/certificate/ca"
-                type: path
-                method: get
-            }
-            allow-unauthenticated: true
-        },
-        {
+            # Allow nodes to retrieve the certificate they requested earlier
             match-request: {
                 path: "/puppet-ca/v1/certificate/"
                 type: path
                 method: get
             }
             allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs certificate"
         },
         {
+            # Allow all nodes to access the certificate revocation list
+            match-request: {
+                path: "/puppet-ca/v1/certificate_revocation_list/ca"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs crl"
+        },
+        {
+            # Allow nodes to request a new certificate
             match-request: {
                 path: "/puppet-ca/v1/certificate_request"
                 type: path
+                method: [get, put]
             }
             allow-unauthenticated: true
+            sort-order: 500
+            name: "puppetlabs csr"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/environments"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs environments"
+        },
+        {
+            # Allow nodes to access all file services; this is necessary for
+            # pluginsync, file serving from modules, and file serving from
+            # custom mount points (see fileserver.conf). Note that the `/file`
+            # prefix matches requests to file_metadata, file_content, and
+            # file_bucket_file paths.
+            match-request: {
+                path: "/puppet/v3/file"
+                type: path
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs file"
+        },
+        {
+            # Allow nodes to retrieve only their own node definition
+            match-request: {
+                path: "^/puppet/v3/node/([^/]+)$"
+                type: regex
+                method: get
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs node"
+        },
+        {
+            # Allow nodes to store only their own reports
+            match-request: {
+                path: "^/puppet/v3/report/([^/]+)$"
+                type: regex
+                method: put
+            }
+            allow: "$1"
+            sort-order: 500
+            name: "puppetlabs report"
+        },
+        {
+            match-request: {
+                path: "/puppet/v3/status"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs status"
+        },
+        {
+          # Deny everything else. This ACL is not strictly
+          # necessary, but illustrates the default policy
+          match-request: {
+            path: "/"
+            type: path
+          }
+          deny: "*"
+          sort-order: 600
+          name: "puppetlabs deny all"
         }
     ]
 }

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  ;; end version conflict resolution dependencies
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-authorization "0.1.2"]
+                 [puppetlabs/trapperkeeper-authorization "0.1.3"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -61,13 +61,18 @@
       (bootstrap/with-puppetserver-running
         app
         {:jruby-puppet  {:use-legacy-auth-conf false}
-         :authorization {:rules
+         :authorization {:version 1
+                         :rules
                          [{:match-request {:path "^/puppet/v3/catalog/private$"
                                            :type "regex"}
-                           :allow         ["private" "localhost"]}
+                           :allow         ["private" "localhost"]
+                           :sort-order 1
+                           :name "catalog"}
                           {:match-request {:path "^/puppet/v3/node/private$"
                                            :type "regex"}
-                           :allow         ["private" "localhost"]}]}}
+                           :allow         ["private" "localhost"]
+                           :sort-order 1
+                           :name "node"}]}}
         (logutils/with-test-logging
           (testing "for puppet 4 routes"
             (let [response (http-get "puppet/v3/node/public?environment=production")]

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -55,8 +55,11 @@
   {:product       {:name              "puppet-server"
                    :update-server-url "http://localhost:11111"}
    :jruby-puppet  pool-config
-   :authorization {:rules
-                   [{:match-request {:path "/" :type "path"} :allow "*"}]}})
+   :authorization {:version 1
+                   :rules [{:match-request {:path "/" :type "path"}
+                            :allow "*"
+                            :sort-order 1
+                            :name "allow all"}]}})
 
 (schema/defn ^:always-validate
   jruby-puppet-config :- jruby-schemas/JRubyPuppetConfig


### PR DESCRIPTION
This commit fills out the new auth.conf with default rules as they're
specified in the legacy Ruby auth.conf. Tests and developer resources
have also been updated to include new required fields.

Planning to do a follow-up pull request including some simple acceptance
tests for these default rules.