### PR TITLE
(SERVER-763) Read client auth info from tk-authz when configured

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -2,10 +2,6 @@ global: {
     logging-config: ./dev/logback-dev.xml
 }
 
-master: {
-    allow-header-cert-info: false
-}
-
 product: {
     update-server-url: "http://localhost/"
     name: {group-id: puppetlabs.dev

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -263,7 +263,7 @@ which is in the range from 601 to 998 (inclusive).
 
 Note that, for backward compatibility, the values of other configuration
 settings control the specific endpoints for which `trapperkeeper-authorization`
-is usedr:
+is used:
 
 * [`jruby-puppet.use-legacy-auth-conf`](#puppetserverconf) - Controls the
  method to be used for authorizing access to the HTTP endpoints served by the
@@ -273,7 +273,7 @@ is usedr:
  For a value of `true`, also the default value if not specified, authorization
  will be done in core Ruby puppet-agent code via the legacy
  [`auth.conf`](https://docs.puppetlabs.com/puppet/4.2/reference/config_file_auth.html)
- file.  For a value of `false`, authorization will be done through via
+ file.  For a value of `false`, authorization will be done via
  `trapperkeeper-authorization`.
 
 * `puppet-admin.authorization-required` and `puppet-admin.client-whitelist` -

--- a/documentation/external_ssl_termination.markdown
+++ b/documentation/external_ssl_termination.markdown
@@ -15,11 +15,33 @@ You'll need to turn off SSL and have Puppet Server use the HTTP protocol instead
 
 When using external SSL termination, Puppet Server expects to receive client certificate information via some HTTP headers.
 
-By default, reading this data from headers is disabled. To allow Puppet Server to recognize it, edit (or create) `config.d/master.conf` and add  `allow-header-cert-info: true` to the `master` config section. See [Puppet Server Configuration](./configuration.markdown) for more information on the `master.conf` file.
+By default, reading this data from headers is disabled.  To allow Puppet Server
+to recognize it, you'll need to set the `allow-header-cert-info` setting to `true`.
+
+Prior to the inclusion of `trapperkeeper-authorization` and an `auth.conf` file
+specific to Puppet Server, you would need to edit (or create) `conf.d/master.conf`
+and add `allow-header-cert-info: true` to the `master` config section.  See
+[Puppet Server Configuration](./configuration.markdown) for more information on
+the `master.conf` file.  This approach, however, is now deprecated.
+
+Instead, it is preferred to enable `trapperkeeper-authorization` and
+set the `allow-header-cert-info` setting via the `authorization` config
+section.  This involves the following steps:
+
+* Migrate any custom authorization rule definitions that you may have made to core Puppet's
+ `/etc/puppetlabs/puppet/auth.conf` file over to the
+ `/etc/puppetlabs/puppetserver/conf.d/auth.conf` file.
+* Set the `jruby-puppet.use-legacy-auth-conf` setting in the
+ `conf.d/puppetserver.conf` file to `false`.
+* Add `allow-header-cert-info: true` to the `authorization` config section in
+ the `/etc/puppetlabs/puppetserver/conf.d/auth.conf` file.
+
+See [Puppet Server Configuration](./configuration.markdown) for more information
+on the `puppetserver.conf` and `auth.conf` files.
 
 > **WARNING**: Setting `allow-header-cert-info` to 'true' puts Puppet Server in an incredibly vulnerable state. Take extra caution to ensure it is **absolutely not reachable** by an untrusted network.
 >
-> With `allow-header-cert-info` set to 'true', core Ruby Puppet application code will use only the client HTTP header values---not an SSL-layer client certificate---to determine the client subject name, authentication status, and trusted facts. This is true even if the web server is hosting an HTTPS connection. This applies to validation of the client via rules in the [auth.conf](https://docs.puppetlabs.com/guides/rest_auth_conf.html) file and any [trusted facts][trusted] extracted from certificate extensions.
+> With `allow-header-cert-info` set to 'true', authorization code will use only the client HTTP header values---not an SSL-layer client certificate---to determine the client subject name, authentication status, and trusted facts. This is true even if the web server is hosting an HTTPS connection. This applies to validation of the client via rules in the [auth.conf](https://docs.puppetlabs.com/guides/rest_auth_conf.html) file and any [trusted facts][trusted] extracted from certificate extensions.
 >
 > If the `client-auth` setting in the `webserver` config block is set to `need` or `want`, the Jetty web server will still validate the client certificate against a certificate authority store, but it will only verify the SSL-layer client certificate---not a certificate in an  `X-Client-Cert` header.
 
@@ -38,19 +60,32 @@ The headers you'll need to set are `X-Client-Verify`, `X-Client-DN`, and `X-Clie
 
 Mandatory. Must be either `SUCCESS` if the certificate was validated, or something else if not. (The convention seems to be to use `NONE` for when a certificate wasn't presented, and `FAILED:reason` for other validation failures.) Puppet Server uses this to authorize requests; only requests with a value of `SUCCESS` will be considered authenticated.
 
-You can change this header name with [the `ssl_client_verify_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientverifyheader)
+When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_verify_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientverifyheader)
 
 This setting (and its twin, `ssl_client_header`) is a bit odd: its value should be the result of transforming the desired HTTP header name into a CGI-style environment variable name. That is, to change the HTTP header to `X-SSL-Client-Verify`, you would set the setting to `HTTP_X_SSL_CLIENT_VERIFY`. (Add `HTTP_` to the front, change hyphens to underscores, and uppercase everything.)
 
 (Puppet Server will eventually UN-munge the CGI variable name to get a valid HTTP header name, and use that name to interact directly with an HTTP request. This is a legacy quirk to ensure that the setting works the same for both Puppet Server and a Rack Puppet master; note that Rack actually does use CGI environment variables.)
 
+Note that if you are using the `authorization.allow-header-cert-info: true`
+setting, the name of the client verify header in the request must be
+`X-Client-Verify`; the `ssl_client_verify_header` setting in the `puppet.conf`
+file has no effect on how the client verify header is processed.
+
 ### `X-Client-DN`
 
 Mandatory. Must be the [Subject DN][] of the agent's certificate, if a certificate was presented. Puppet Server uses this to authorize requests.
 
-> **Note:** Currently, the DN must be in RFC-2253 format (comma-delimited). Due to a bug ([SERVER-213](https://tickets.puppetlabs.com/browse/SERVER-213)), Puppet Server can't decode OpenSSL-style DNs (slash-delimited). Note that Apache's `mod_ssl` `SSL_CLIENT_S_DN` variable uses OpenSSL-style DNs.
+> **Note:** Currently, when using `master.allow-header-cert-info: true`, the DN must be in RFC-2253 format (comma-delimited). Due to a bug ([SERVER-213](https://tickets.puppetlabs.com/browse/SERVER-213)), Puppet Server can't decode OpenSSL-style DNs (slash-delimited). Note that Apache's `mod_ssl` `SSL_CLIENT_S_DN` variable uses OpenSSL-style DNs.  Note
+ that the bug does not apply when `authorization.allow-header-cert-info` is set
+ to true.  `trapperkeeper-authorization` supports decoding both the RFC-2253
+ and OpenSSL "slash-delimited" DN formats.
 
-You can change this header name with [the `ssl_client_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientheader) See the note above for more info about this setting's expected values.
+When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientheader) See the note above for more info about this setting's expected values.
+
+Note that if you are using the `authorization.allow-header-cert-info: true`
+setting, the name of the client DN header in the request must be
+`X-Client-DN`; the `ssl_client_header` setting in the `puppet.conf` file has no
+effect on how the client DN header is processed.
 
 [subject dn]: https://docs.puppetlabs.com/background/ssl/cert_anatomy.html#the-subject-dn-cn-certname-etc
 

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  ;; end version conflict resolution dependencies
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-authorization "0.1.3"]
+                 [puppetlabs/trapperkeeper-authorization "0.1.3-SNAPSHOT"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  ;; end version conflict resolution dependencies
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-authorization "0.1.3-SNAPSHOT"]
+                 [puppetlabs/trapperkeeper-authorization "0.1.4"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -18,11 +18,11 @@
          puppet-version (get-in-config [:puppet-server :puppet-version])]
      (if (not-empty (:access-control settings))
        (log/warn
-         (str "The 'client-whitelist' and 'authorization-required' settings in "
-              "the 'certificate-authority.certificate-status' section are "
-              "deprecated and will be removed in a future release.  Remove these "
-              "settings and instead create an appropriate authorization rule in "
-              "the /etc/puppetlabs/puppetserver/conf.d/auth.conf file.")))
+         "The 'client-whitelist' and 'authorization-required' settings in the"
+         "'certificate-authority.certificate-status' section are deprecated and"
+         "will be removed in a future release.  Remove these settings and create"
+         "an appropriate authorization rule in the"
+         "/etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
      (ca/initialize! settings)
      (log/info "CA Service adding a ring handler")
      (add-ring-handler

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -29,12 +29,12 @@
       (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
       (if (:use-legacy-auth-conf config)
-        (log/warn
-          (str "The 'use-legacy-auth-conf' setting in the 'jruby-puppet' section "
-               "is deprecated and will be removed in a future release.  Change "
-               "the value of this setting to 'false' and migrate your authorization "
-               "rule definitions in the /etc/puppetlabs/puppet/auth.conf file to "
-               "the /etc/puppetlabs/puppetserver/conf.d/auth.conf file.")))
+        (log/warn "The 'jruby-puppet.use-legacy-auth-conf' setting is set to"
+                  "'true'.  Support for the legacy Puppet auth.conf file is"
+                  "deprecated and will be removed in a future release.  Change"
+                  "this setting to 'false' and migrate your authorization rule"
+                  "definitions in the /etc/puppetlabs/puppet/auth.conf file to"
+                  "the /etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
       (core/add-facter-jar-to-system-classloader (:ruby-load-path config))
       (let [pool-context (core/create-pool-context config profiler agent-shutdown-fn)]
         (jruby-agents/send-prime-pool! pool-context)

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
@@ -19,11 +19,11 @@
                                settings)]
       (if (not-empty whitelist-settings)
         (log/warn
-          (str "The 'client-whitelist' and 'authorization-required' settings in "
-               "the 'puppet-admin' section are deprecated and will be removed "
-               "in a future release.  Remove these settings and instead create an "
-               "appropriate authorization rule in the "
-               "/etc/puppetlabs/puppetserver/conf.d file.")))
+          "The 'client-whitelist' and 'authorization-required' settings in"
+          "the 'puppet-admin' section are deprecated and will be removed"
+          "in a future release.  Remove these settings and create an"
+          "appropriate authorization rule in the"
+          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
       (add-ring-handler
         this
         (core/build-ring-handler route

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -4,11 +4,11 @@
            (com.puppetlabs.puppetserver JRubyPuppetResponse))
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
-            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [ring.util.codec :as ring-codec]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
+            [puppetlabs.trapperkeeper.authorization.ring :as ring-auth]
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]))
 
@@ -210,9 +210,9 @@
   * request - Ring request containing client data"
   [config request]
   (if-let [authorization (:authorization request)]
-    {:client-cert    (:certificate authorization)
-     :client-cert-cn (:name authorization)
-     :authenticated  (true? (:authentic? authorization))}
+    {:client-cert    (ring-auth/authorized-certificate request)
+     :client-cert-cn (ring-auth/authorized-name request)
+     :authenticated  (true? (ring-auth/authorized-authentic? request))}
     (let [headers (:headers request)
           header-dn-name (:ssl-client-header config)
           header-dn-val (get headers header-dn-name)

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -229,12 +229,12 @@
           (doseq [[header-name header-val]
                   {header-dn-name header-dn-val
                    header-auth-name header-auth-val
-                   header-client-cert-name header-cert-val}]
-            (if header-val
-              (log/warn "The HTTP header" header-name "was specified,"
-                        "but the master config option allow-header-cert-info"
-                        "was either not set, or was set to false."
-                        "This header will be ignored.")))
+                   header-client-cert-name header-cert-val}
+                  :when header-val]
+            (log/warn "The HTTP header" header-name "was specified,"
+                      "but the master config option allow-header-cert-info"
+                      "was either not set, or was set to false."
+                      "This header will be ignored."))
           (let [ssl-cert (:ssl-client-cert request)]
             (-> (ssl-auth-info ssl-cert)
                 (assoc :client-cert ssl-cert))))))))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -2,15 +2,33 @@
   (:require [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.protocols.request-handler :as handler]
             [puppetlabs.services.request-handler.request-handler-core :as request-handler-core]
-            [puppetlabs.trapperkeeper.services :as tk-services]))
+            [puppetlabs.trapperkeeper.services :as tk-services]
+            [clojure.tools.logging :as log]))
 
 (tk/defservice request-handler-service
   handler/RequestHandlerService
   [[:PuppetServerConfigService get-config]]
   (init [this context]
     (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
-          config (request-handler-core/config->request-handler-settings (get-config))]
-      (assoc context :request-handler (request-handler-core/build-request-handler jruby-service config))))
+          config (get-config)]
+      (when (contains? (:master config) :allow-header-cert-info)
+        (if (true? (get-in config [:jruby-puppet :use-legacy-auth-conf]))
+          (log/warn "The 'master.allow-header-cert-info' setting is deprecated. "
+                    "Remove it, set 'jruby-puppet.use-legacy-auth-conf' to"
+                    "'false', migrate your authorization rule definitions in"
+                    "the /etc/puppetlabs/puppet/auth.conf file to the"
+                    "/etc/puppetlabs/puppetserver/conf.d/auth.conf file, and set"
+                    "'authorization.allow-header-cert-info' to the desired value.")
+          (log/warn "The 'master.allow-header-cert-info' setting is deprecated"
+                    "and will be ignored in favor of the"
+                    "'authorization.allow-header-cert-info' setting because"
+                    "the 'jruby-puppet.use-legacy-auth-conf' setting is 'false'. "
+                    "Remove the 'master.allow-header-cert-info' setting.")))
+      (assoc context :request-handler
+                     (request-handler-core/build-request-handler
+                      jruby-service
+                      (request-handler-core/config->request-handler-settings
+                       config)))))
   (handle-request
     [this request]
     (let [handler (:request-handler (tk-services/service-context this))]

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -1,12 +1,17 @@
 (ns puppetlabs.puppetserver.auth-conf-test
   (:require [clojure.test :refer :all]
+            [clojure.string :as str]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [puppetlabs.ssl-utils.simple :as ssl-simple]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.test :as schema-test]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [me.raynes.fs :as fs]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
+            [ring.util.codec :as ring-codec])
+  (:import (java.io StringWriter)))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/puppetserver/auth_conf_test")
@@ -55,13 +60,15 @@
               (is (= 403 (:status response))
                   (ks/pprint-to-string response)))))))))
 
-(deftest ^:integration tk-auth-used-when-legacy-auth-conf-false
-  (testing "Authorization is done per trapperkeeper auth.conf when :use-legacy-auth-conf false"
+(deftest ^:integration request-with-ssl-cert-handled-via-tk-auth
+  (testing (str "Request with SSL certificate via trapperkeeper-authorization "
+                "handled")
     (logutils/with-test-logging
       (bootstrap/with-puppetserver-running
         app
         {:jruby-puppet  {:use-legacy-auth-conf false}
          :authorization {:version 1
+                         :allow-header-cert-info false
                          :rules
                          [{:match-request {:path "^/puppet/v3/catalog/private$"
                                            :type "regex"}
@@ -100,3 +107,74 @@
             (let [response (http-get "production/catalog/private")]
               (is (= 200 (:status response))
                   (ks/pprint-to-string response)))))))))
+
+(deftest ^:integration request-with-x-client-headers-handled-via-tk-auth
+  (testing (str "Request with X-Client headers via trapperkeeper-authorization "
+                "handled")
+    (let [extension-value "UUUU-IIIII-DDD"
+          cert (:cert (ssl-simple/gen-self-signed-cert
+                       "ssl-client"
+                       1
+                       {:keylength 512
+                        :extensions [{:oid "1.3.6.1.4.1.34380.1.1.1"
+                                      :critical false
+                                      :value extension-value}]}))
+          url-encoded-cert (let [cert-writer (StringWriter.)
+                                 _ (ssl-utils/cert->pem! cert cert-writer)]
+                             (ring-codec/url-encode cert-writer))
+          http-get-no-ssl (fn [path]
+                            (http-client/get
+                             (str "http://localhost:8080/" path)
+                             {:headers {"Accept" "pson"
+                                        "X-Client-Cert" url-encoded-cert
+                                        "X-Client-DN" "CN=private"
+                                        "X-Client-Verify" "SUCCESS"}
+                              :as :text}))]
+      (logutils/with-test-logging
+       (bootstrap/with-puppetserver-running
+        app
+        {:jruby-puppet  {:use-legacy-auth-conf false}
+         :authorization {:version 1
+                         :allow-header-cert-info true
+                         :rules
+                         [{:match-request {:path "^/puppet/v3/catalog/private$"
+                                           :type "regex"}
+                           :allow ["private" "localhost"]
+                           :sort-order 1
+                           :name "catalog"}]}
+         :webserver     {:host "localhost"
+                         :port 8080}}
+        (testing "as 403 for unauthorized user"
+          (logutils/with-test-logging
+           (let [response (http-get-no-ssl
+                           "puppet/v3/catalog/public?environment=production")]
+             (is (= 403 (:status response))
+                 (ks/pprint-to-string response)))))
+        (testing "for certificate when provided"
+          (let [environment-dir (fs/file jruby-testutils/code-dir
+                                         "environments")
+                manifest-dir (fs/file environment-dir
+                                      "production"
+                                      "manifests")]
+            (try
+              (fs/mkdirs manifest-dir)
+              (spit (fs/file manifest-dir "site.pp")
+                    (str/join "\n"
+                              ["notify {'trusty_info':"
+                               "  message => $trusted[extensions][pp_uuid]"
+                               "}\n"]))
+              (let [response
+                    (http-get-no-ssl
+                     "puppet/v3/catalog/private?environment=production")
+                    expected-content-in-catalog
+                    (str
+                     "\"parameters\":{\"message\":\""
+                     extension-value
+                     "\"}")]
+                (is (= 200 (:status response))
+                    (ks/pprint-to-string response))
+                (is (.contains (:body response) expected-content-in-catalog)
+                    (str "Did not find '" expected-content-in-catalog
+                         "' in full response body: " (:body response))))
+              (finally
+                (fs/delete-dir environment-dir))))))))))

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -2,6 +2,7 @@
   (:import (java.io StringReader ByteArrayInputStream))
   (:require [puppetlabs.services.request-handler.request-handler-core :as core]
             [puppetlabs.ssl-utils.core :as ssl-utils]
+            [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.puppetserver.certificate-authority :as cert-authority]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [clojure.test :refer :all]
@@ -34,15 +35,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests
-
-(deftest get-cert-common-name-test
-  (testing (str "expected common name can be extracted from the certificate on "
-                "a request")
-    (let [cert (ssl-utils/pem->cert
-                 (str test-resources-dir "/localhost.pem"))]
-      (is (= "localhost" (core/get-cert-common-name cert)))))
-  (testing "nil returned for cn when certificate on request is nil"
-    (is (nil? (core/get-cert-common-name nil)))))
 
 (deftest wrap-params-for-jruby-test
   (testing "get with no query parameters returns empty params"
@@ -120,6 +112,39 @@
            "x-client-verify"))
     (is (= (core/unmunge-http-header-name "HTTP_X_CLIENT_DN")
            "x-client-dn"))))
+
+(deftest cert-info-from-authorization
+  (testing "authorization section in request"
+    (let [url-encoded-cert (-> (str test-resources-dir "/localhost.pem")
+                               slurp
+                               ring-codec/url-encode)
+          cert-from-authorization (:cert (ssl-simple/gen-self-signed-cert
+                                          "authorization-client"
+                                          1
+                                          {:keylength 512}))
+          cert-from-ssl (:cert (ssl-simple/gen-self-signed-cert
+                                "ssl-client"
+                                1
+                                {:keylength 512}))]
+      (doseq [allow-header-cert-info [false true]]
+        (testing (str "for allow-header-cert-info " allow-header-cert-info)
+          (let [req (core/as-jruby-request
+                     (puppet-server-config allow-header-cert-info)
+                     {:request-method :GET
+                      :authorization {:name "authorization-client"
+                                      :authentic? true
+                                      :certificate cert-from-authorization}
+                      :headers {"x-client-verify" "SUCCESS"
+                                "x-client-dn" "CN=x-client"
+                                "x-client-cert" url-encoded-cert}
+                      :ssl-client-cert cert-from-ssl})]
+            (testing "has proper authenticated value"
+              (is (true? (get req :authenticated))))
+            (testing "has proper name"
+              (is (= "authorization-client" (get req :client-cert-cn))))
+            (testing "has proper cert"
+              (is (identical? cert-from-authorization
+                              (get req :client-cert))))))))))
 
 (deftest cert-info-in-headers
   "In the case where Puppet Server is running under HTTP with an upstream HTTPS


### PR DESCRIPTION
This commit changes the Ruby request handler to read client
authentication info from trapperkeeper-authorization when tk-authz is
enabled via the `use-legacy-auth-conf: false` setting.  Support for the
pre-existing method of getting this info - via X-Client headers or an
SSL certificate, depending upon how the `master.allow-header-cert-info`
setting is configured - is preserved in the case that no information can
be derived from tk-authz.  tk-authz is presumed to provide client
authentication info via an `authorization` map within the Ring request
map.