### PR TITLE
(PE-11857) Add with-lock macro to JRuby Service

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -112,3 +112,19 @@
            ~@body
            (finally
              (jruby/return-instance ~jruby-service pool-instance# ~reason)))))))
+
+(defmacro with-lock
+  "Acquires a lock on the pool, executes the body, and releases the lock."
+  [jruby-service & body]
+  `(let [pool# (-> ~jruby-service
+                   tk-services/service-context
+                   :pool-context
+                   core/get-pool)]
+     (log/debug "Acquiring lock on JRubyPool...")
+     (.lock pool#)
+     (log/debug "Lock acquired")
+     (try
+      ~@body
+      (finally
+       (.unlock pool#)
+       (log/debug "Lock on JRubyPool released")))))

--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -1,0 +1,53 @@
+(ns puppetlabs.services.jruby.jruby-locking-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby-service]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
+
+(deftest ^:integration with-lock-test
+  (bootstrap/with-puppetserver-running app {:jruby-puppet {:max-active-instances 1}}
+    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+          lock (jruby-testutils/get-lock app)]
+
+      (testing "initial state of write lock is unlocked"
+        (is (not (.isWriteLocked lock))))
+      (testing "with-lock macro holds write lock while executing body"
+        (jruby-service/with-lock jruby-service
+          (is (.isWriteLocked lock))))
+      (testing "with-lock macro releases write lock after exectuing body"
+        (is (not (.isWriteLocked lock)))))))
+
+(deftest ^:integration with-lock-exception-test
+  (bootstrap/with-puppetserver-running app {:jruby-puppet {:max-active-instances 1}}
+    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+          lock (jruby-testutils/get-lock app)]
+
+      (testing "initial state of write lock is unlocked"
+        (is (not (.isWriteLocked lock))))
+
+      (testing "with-lock macro releases lock even if body throws exception"
+        (is (thrown? RuntimeException
+                     (jruby-service/with-lock jruby-service
+                       (is (.isWriteLocked lock))
+                       (throw (RuntimeException. "exception")))))
+        (is (not (.isWriteLocked lock)))))))
+
+(deftest ^:integration borrow-and-return-affect-read-lock-test
+  (bootstrap/with-puppetserver-running app {:jruby-puppet {:max-active-instances 1}}
+    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+          lock (jruby-testutils/get-lock app)]
+
+      (is (= 0 (.getReadLockCount lock)))
+      (is (not (.isWriteLocked lock)))
+
+      (let [instance (jruby-protocol/borrow-instance jruby-service :test-borrow-and-read-lock)]
+        (testing "borrow-instance acquires a read lock and does not affect write lock"
+          (is (= 1 (.getReadLockCount lock)))
+          (is (not (.isWriteLocked lock))))
+
+        (testing "return-instance releases a read lock and does not affect write lock"
+          (jruby-protocol/return-instance jruby-service instance :test-return-and-read-lock)
+          (is (= 0 (.getReadLockCount lock)))
+          (is (not (.isWriteLocked lock))))))))


### PR DESCRIPTION
Add `with-lock` macro to JRuby service, which can be used by other services to
acquiring a lock on the JRubyPool, execute the body, then release the lock.

Add tests that `with-lock` actually does lock the write lock from the
JRubyPool, and add basic tests that `borrow-instance` and `return-instance`
affect the lock in the ways we expect. Add a `get-lock` helper function to get
access to the lock for tests.