### PR TITLE
(MAINT) Remove default "deny all" rule

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -100,17 +100,6 @@ authorization: {
             allow: "*"
             sort-order: 500
             name: "puppetlabs status"
-        },
-        {
-          # Deny everything else. This ACL is not strictly
-          # necessary, but illustrates the default policy
-          match-request: {
-            path: "/"
-            type: path
-          }
-          deny: "*"
-          sort-order: 600
-          name: "puppetlabs deny all"
         }
     ]
 }


### PR DESCRIPTION
We can longer have a "deny all" rule in the default auth.conf as users
need to be able to provide custom rules that come after the default
Puppet Labs rules.