### PR TITLE
(MAINT) Re-order default "deny all" rule

### DIFF
--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -109,7 +109,7 @@ authorization: {
             type: path
           }
           deny: "*"
-          sort-order: 600
+          sort-order: 999
           name: "puppetlabs deny all"
         }
     ]


### PR DESCRIPTION
The default "deny all" rule needs to come at the very end and not the
end of the Puppet Labs range, otherwise the entire "user space" range
would be rejected.