### PR TITLE
(SERVER-914) Allow middleware params in jruby requests

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -92,19 +92,10 @@
    body into the ring request map.  Includes some special processing for
    a request destined for JRubyPuppet."
   [request]
-  (let [body-for-jruby (body-for-jruby request)
-        request-with-params (-> request
-                                (assoc :body body-for-jruby)
-                                pl-ring-params/params-request)]
-    ; :params may or may not been populated by ring middleware at this point.
-    ; Even if they were, though, they may have key/value pairs in them that
-    ; originated from the comidi route destructuring.  Ignore whatever may
-    ; have been there and repopulate it with what ring pulled from the form
-    ; and query params.
-    (assoc request-with-params :params
-                               (merge-with merge
-                                           (:form-params request-with-params)
-                                           (:query-params request-with-params)))))
+  (let [body-for-jruby (body-for-jruby request)]
+    (-> request
+        (assoc :body body-for-jruby)
+        pl-ring-params/params-request)))
 
 (def unauthenticated-client-info
   "Return a map with default info for an unauthenticated client"

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -59,7 +59,8 @@
                              :content-type "text/plain"
                              :query-string "one=1%201&two=2&arr[]=3&arr[]=4"
                              :params       {:bogus ""}})]
-      (is (= {"one" "1 1", "two" "2", "arr[]" ["3", "4"]}
+      (is (= {"one" "1 1", "two" "2", "arr[]" ["3", "4"]
+              :bogus ""}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
       (is (= "" (:body wrapped-request))
@@ -70,7 +71,8 @@
                             {:body         (StringReader. body-string)
                              :content-type "application/x-www-form-urlencoded"
                              :params       {:bogus ""}})]
-      (is (= {"one" "1", "two" "2 2", "arr[]" ["3" "4"]}
+      (is (= {"one" "1", "two" "2 2", "arr[]" ["3" "4"]
+              :bogus ""}
              (:params wrapped-request))
           "Unexpected params in wrapped request")
       (is (= body-string (:body wrapped-request))
@@ -81,7 +83,7 @@
                             {:body         (StringReader. body-string)
                              :content-type "text/plain"
                              :params       {:bogus ""}})]
-      (is (= {} (:params wrapped-request))
+      (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
       (is (= body-string (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))
@@ -97,7 +99,7 @@
                              :content-type       "text/plain"
                              :character-encoding "UTF-16"
                              :params             {:bogus ""}})]
-      (is (= {} (:params wrapped-request))
+      (is (= {:bogus ""} (:params wrapped-request))
           "Unexpected params in wrapped request")
       (is (= body-string-from-utf16 (:body wrapped-request))
           "Unexpected body for jruby in wrapped request")))


### PR DESCRIPTION
Prior to this commit, the JRuby request handler code would
filter out any :params that had been added to the ring request
map by other middleware.  We now have concrete use cases for
this capability, so this commit loosens the restrictions and
allows other middlewares to add to :params, and have those
params still be visible to JRuby.