### PR TITLE
(SERVER-964) Support multi-webserver config

### DIFF
--- a/src/clj/puppetlabs/services/config/puppet_server_config_service.clj
+++ b/src/clj/puppetlabs/services/config/puppet_server_config_service.clj
@@ -26,7 +26,9 @@
           "Initializing with the following settings from core Puppet:\n%s"
           (ks/pprint-to-string puppet-config))
         (core/init-webserver! override-webserver-settings!
-                              (get-in tk-config [:webserver])
+                              (get-in tk-config
+                                      [:webserver :puppet-server]
+                                      (get-in tk-config [:webserver]))
                               puppet-config)
         (assoc context :puppet-config
                        {:puppet-server puppet-config}))))

--- a/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_service_test.clj
@@ -91,3 +91,27 @@
                                                             :cacert "meow")
                 ; do nothing - bootstrap should throw the exception
                 )))))))
+
+(deftest multi-webserver-setting-override
+  (let [webserver-config {:ssl-cert "thehostcert"
+                          :ssl-key "thehostprivkey"
+                          :ssl-ca-cert "thelocalcacert"
+                          :ssl-crl-path "thecacrl"
+                          :port 8081}]
+    (testing (str "webserver settings not overridden when mult-webserver config is provided"
+                  "and full ssl cert configuration is available")
+      (with-test-logging
+        (tk-testutils/with-app-with-config
+          app
+          service-and-deps
+          (assoc required-config :webserver {:puppet-server webserver-config})
+          (is (logged? #"Not overriding webserver settings with values from core Puppet")))))
+
+    (testing (str "webserver settings not overridden when single webserver is provided"
+                  "and full ssl cert configuration is available")
+      (with-test-logging
+        (tk-testutils/with-app-with-config
+          app
+          service-and-deps
+          (assoc required-config :webserver webserver-config)
+          (is (logged? #"Not overriding webserver settings with values from core Puppet")))))))


### PR DESCRIPTION
Previously, Puppet Server explicitly checked the contents of the
`:webserver` key in determining whether or not it needed to
override webserver settings with those from ruby puppet, meaning
that the settings would always be overridden if a multi-webserver
style configuration is used.

This commit modifies Puppet Server to use the contents of the
configuration at `[:webserver :puppet-server]`, or `:webserver` if
`[:webserver :puppet-server]` does not exist so as to support
multi-webserver configs.