### PR TITLE
(MAINT) Bump puppet submodule to 91097ad

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.2.2')
+      expect(subject).to eq('4.2.3')
     end
   end
 


### PR DESCRIPTION
This commit bumps the Puppet submodule up to 91097ad in order to pick up
some recent Puppet acceptance test changes, including the ctime/mtime
fix to the `source_attribute.rb` test for PUP-5272.