### PR TITLE
(SERVER-915) Enable trapperkeeper-authorization for empty whitelists

### DIFF
--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -129,8 +129,9 @@ This file contains the settings for Puppet Server itself.
     present a valid client certificate mentioned in this list will be denied
     access.
 
-   If neither the `authorization-required` nor the `client-whitelist` setting
-   is specified, authorization to the admin API endpoints is controlled by
+   If `authorization-required` is not set or set to `true` and the
+   `client-whitelist` setting is not set or set to an empty list,
+   authorization to the admin API endpoints is controlled by
    `trapperkeeper-authorization`, through settings specified in the
    [`auth.conf`](#authconf) file.
 
@@ -430,25 +431,25 @@ is used:
  `trapperkeeper-authorization`.
 
 * `puppet-admin.authorization-required` and `puppet-admin.client-whitelist` -
- If either of these settings is present in the configuration, requests made to
- Puppet Server's administrative API will be performed per the values for these
- settings.  See the [`puppetserver.conf/puppet-admin`](#puppetserverconf)
- section for more information on these settings.  If neither the
- `puppet-admin.authorization-required` nor the `puppet-admin.client-whitelist`
- setting is specified, requests to Puppet Server's administrative API will be
+ If `authorization-required` is set to `false` or if the `client-whitelist` has
+ one or more entries, requests made to Puppet Server's administrative API
+ will be performed per the values for these settings.  See the
+ [`puppetserver.conf/puppet-admin`](#puppetserverconf)
+ section for more information on these settings.  If `authorization-required`
+ is not set or set to `true` and the `client-whitelist` is not set or set to
+ an empty list, requests to Puppet Server's administrative API will be
  done via `trapperkeeper-authorization`.
 
  * `certificate-authority.certificate-status.authorization-required` and
   `certificate-authority.certificate-status.client-whitelist` -
-  If either of these settings is present in the configuration, requests made
-  to Puppet Server's
+  If `authorization-required` is set to `false` or if the `client-whitelist`
+  has one or more entries, requests made to Puppet Server's
   [Certificate Status](https://github.com/puppetlabs/puppet/blob/master/api/docs/http_certificate_status.md)
   API will be performed per the values for these settings.  See the
   [`ca.conf`](#caconf) section for more information on these settings.  If
-  neither the `certificate-authority.certificate-status.authorization-required`
-  nor the `certificate-authority.certificate-status.client-whitelist` setting is
-  specified, requests to Puppet Server's administrative API will be done via
-  `trapperkeeper-authorization`.
+  `authorization-required` is not set or set to `true` and the
+  `client-whitelist` is not set or set to an empty list, requests to Puppet
+  Server's administrative API will be done via `trapperkeeper-authorization`.
 
 Support for the use of the legacy `auth.conf` for the "master" endpoints and
 for the client whitelists for the Puppet admin and certificate status endpoints
@@ -540,10 +541,11 @@ the `ca.conf` file no longer appears in a Puppet Server package.
      endpoint that do not present a valid client certificate mentioned in this
      list will be denied access.
 
-   If neither the `authorization-required` nor the `client-whitelist` setting
-   is specified, authorization to the certificate status(es) endpoints is
-   controlled by `trapperkeeper-authorization`, through settings specified in
-   the [`auth.conf`](#authconf) file.
+   If `authorization-required` is not set or set to `true` and the
+   `client-whitelist` setting is not set or set to an empty list,
+   authorization to the admin API endpoints is controlled by
+   `trapperkeeper-authorization`, through settings specified in the
+   [`auth.conf`](#authconf) file.
 
 ~~~
 # CA-related settings - deprecated in favor of "auth.conf"

--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                  ;; begin version conflict resolution dependencies
                  [puppetlabs/typesafe-config "0.1.4"]
                  [org.clojure/tools.reader "0.9.1"]
+                 [ring/ring-core "1.4.0"]
                  ;; end version conflict resolution dependencies
 
                  [puppetlabs/trapperkeeper ~tk-version]

--- a/src/clj/puppetlabs/puppetserver/ringutils.clj
+++ b/src/clj/puppetlabs/puppetserver/ringutils.clj
@@ -16,7 +16,7 @@
 
 (def RingRequest
   {:uri schema/Str
-   (schema/optional-key :ssl-client-cert) X509Certificate
+   (schema/optional-key :ssl-client-cert) (schema/maybe X509Certificate)
    schema/Keyword schema/Any})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -139,7 +139,8 @@
    whitelist-settings :- (schema/maybe WhitelistSettings)]
   (let [handler-with-trapperkeeper-authorization (authorization-fn base-handler)]
     (if-let [handler-with-client-whitelist-authorization
-             (if (not-empty whitelist-settings)
+             (if (or (false? (:authorization-required whitelist-settings))
+                     (not-empty (:client-whitelist whitelist-settings)))
                (wrap-with-cert-whitelist-check base-handler whitelist-settings))]
       (fn [request]
         (if (and (.startsWith (:uri request) whitelist-path)

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -15,14 +15,33 @@
    [this context]
    (let [path           (get-route this)
          settings       (ca/config->ca-settings (get-config))
-         puppet-version (get-in-config [:puppet-server :puppet-version])]
-     (if (not-empty (:access-control settings))
-       (log/warn
-         "The 'client-whitelist' and 'authorization-required' settings in the"
-         "'certificate-authority.certificate-status' section are deprecated and"
-         "will be removed in a future release.  Remove these settings and create"
-         "an appropriate authorization rule in the"
-         "/etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
+         puppet-version (get-in-config [:puppet-server :puppet-version])
+         certificate-status-access-control (get-in settings
+                                                   [:access-control
+                                                    :certificate-status])
+         certificate-status-whitelist (:client-whitelist
+                                       certificate-status-access-control)]
+     (cond
+       (or (false? (:authorization-required certificate-status-access-control))
+           (not-empty certificate-status-whitelist))
+         (log/warn
+          "The 'client-whitelist' and 'authorization-required' settings in the"
+          "'certificate-authority.certificate-status' section are deprecated and"
+          "will be removed in a future release.  Remove these settings and create"
+          "an appropriate authorization rule in the"
+          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.")
+       (not (nil? certificate-status-whitelist))
+         (log/warn
+          "The 'client-whitelist' and 'authorization-required' settings in the"
+          "'certificate-authority.certificate-status' section are deprecated"
+          "and will be removed in a future release.  Because the"
+          "'client-whitelist' is empty and 'authorization-required' is set to"
+          "'false', the 'certificate-authority.certificate-status' settings"
+          "will be ignored and authorization for the 'certificate_status'"
+          "endpoints will be done per the authorization rules in the"
+          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.  To suppress"
+          "this warning, remove the 'certificate-authority' configuration"
+          "settings."))
      (ca/initialize! settings)
      (log/info "CA Service adding a ring handler")
      (add-ring-handler

--- a/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
+++ b/src/clj/puppetlabs/services/puppet_admin/puppet_admin_service.clj
@@ -16,14 +16,27 @@
           settings (core/config->puppet-admin-settings (get-config))
           jruby-service (services/get-service this :JRubyPuppetService)
           whitelist-settings (core/puppet-admin-settings->whitelist-settings
-                               settings)]
-      (if (not-empty whitelist-settings)
-        (log/warn
-          "The 'client-whitelist' and 'authorization-required' settings in"
-          "the 'puppet-admin' section are deprecated and will be removed"
-          "in a future release.  Remove these settings and create an"
-          "appropriate authorization rule in the"
-          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file."))
+                               settings)
+          client-whitelist (:client-whitelist whitelist-settings)]
+      (cond
+        (or (false? (:authorization-required whitelist-settings))
+            (not-empty client-whitelist))
+          (log/warn
+           "The 'client-whitelist' and 'authorization-required' settings in"
+           "the 'puppet-admin' section are deprecated and will be removed"
+           "in a future release.  Remove these settings and create an"
+           "appropriate authorization rule in the"
+           "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.")
+        (not (nil? client-whitelist))
+          (log/warn
+           "The 'client-whitelist' and 'authorization-required' settings in"
+           "the 'puppet-admin' section are deprecated and will be removed"
+           "in a future release.  Because the 'client-whitelist' is empty"
+           "and 'authorization-required' is set to 'false', the 'puppet-admin'"
+           "settings will be ignored and authorization for the 'puppet-admin'"
+           "endpoints will be done per the authorization rules in the"
+           "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.  To suppress"
+           "this warning, remove the 'puppet-admin' configuration settings."))
       (add-ring-handler
         this
         (core/build-ring-handler route

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -106,6 +106,38 @@
               (is (= 200 (:status response))
                   (ks/pprint-to-string response)))))))))
 
+(deftest ^:integration empty-whitelist-defined-test
+  (testing "requests made when no whitelist is defined"
+    (logutils/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app
+      {:certificate-authority {:certificate-status
+                               {:client-whitelist []}}
+       :authorization {:version 1
+                       :rules [{:match-request
+                                {:path "^/puppet-ca/v1/certificate_status(?:es)?/([^/]+)$"
+                                 :type "regex"}
+                                :allow ["$1"]
+                                :sort-order 1
+                                :name "cert status"}]}}
+      (testing "are allowed for matching client"
+        (doseq [ca-mount-point ca-mount-points
+                endpoint ["certificate_status/localhost"
+                          "certificate_statuses/localhost"]]
+          (testing (str "for the " endpoint " endpoint")
+            (let [response (http-get (str ca-mount-point endpoint))]
+              (is (= 200 (:status response))
+                  (ks/pprint-to-string response))))))
+      (logutils/with-test-logging
+       (testing "are denied for non-matching client"
+         (doseq [ca-mount-point ca-mount-points
+                 endpoint ["certificate_status/nonlocalhost"
+                           "certificate_statuses/nonlocalhost"]]
+           (testing (str "for the " endpoint " endpoint")
+             (let [response (http-get (str ca-mount-point endpoint))]
+               (is (= 403 (:status response))
+                   (ks/pprint-to-string response)))))))))))
+
 (deftest ^:integration no-whitelist-defined-test
   (testing "requests made when no whitelist is defined"
     (bootstrap/with-puppetserver-running

--- a/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
+++ b/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
@@ -68,6 +68,21 @@
               (is (= 204 (:status response))
                   (ks/pprint-to-string response))))))))
 
+  (testing "access allowed when whitelist disabled and no cert provided"
+    (logutils/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app
+      {:puppet-admin {:authorization-required false}
+       :authorization {:version 1 :rules []}}
+      (doseq [endpoint endpoints]
+        (testing (str "for " endpoint " endpoint")
+          (let [response (http-client/delete
+                          (str "https://localhost:8140/puppet-admin-api/v1"
+                               endpoint)
+                          (select-keys ssl-request-options [:ssl-ca-cert]))]
+            (is (= 204 (:status response))
+                (ks/pprint-to-string response))))))))
+
   (testing "access denied when cert denied by rule"
     (bootstrap/with-puppetserver-running
       app
@@ -88,7 +103,7 @@
               (is (= 403 (:status response))
                   (ks/pprint-to-string response))))))))
 
-  (testing "access allowed when cert allowed by rule"
+  (testing "access allowed when cert allowed by rule and whitelist not configured"
     (bootstrap/with-puppetserver-running
       app
       {:puppet-admin  nil
@@ -106,6 +121,26 @@
                           ssl-request-options)]
             (is (= 204 (:status response))
                 (ks/pprint-to-string response)))))))
+
+  (testing "access allowed when cert allowed by rule and whitelist empty"
+    (logutils/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app
+      {:puppet-admin {:client-whitelist []}
+       :authorization {:version 1
+                       :rules [{:match-request
+                                {:path "/puppet-admin-api/v1"
+                                 :type "path"}
+                                :allow "localhost"
+                                :sort-order 1
+                                :name "admin api"}]}}
+      (doseq [endpoint endpoints]
+        (testing (str "for " endpoint " endpoint")
+          (let [response (http-client/delete
+                          (str "https://localhost:8140/puppet-admin-api/v1" endpoint)
+                          ssl-request-options)]
+            (is (= 204 (:status response))
+                (ks/pprint-to-string response))))))))
 
   (testing "server tolerates client specifying an 'Accept: */*' header"
     (bootstrap/with-puppetserver-running app

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -621,7 +621,7 @@
   (testing "a request with a certificate not on the whitelist is rejected"
     (let [settings (assoc (testutils/ca-settings cadir)
                      :access-control {:certificate-status
-                                      {:client-whitelist []}})
+                                      {:client-whitelist ["not-localhost"]}})
           test-app (build-ring-handler settings "1.2.3.4")]
       (doseq [endpoint ["certificate_status" "certificate_statuses"]]
         (testing endpoint


### PR DESCRIPTION
This commit changes the 'puppet-admin' and 'certificate-status'
endpoints to use trapperkeeper-authorization instead of the client
whitelists for authorization when the whitelist is present in
configuration but empty.

This commit also has a couple of somewhat unrelated changes:

1) Adds an explicit ring-core 1.4.0 conflict resolution dependency to
   the project.clj.  comidi 0.1.1 pulls in ring-core 1.3.2, which
   conflicts with the ring-core version that
   trapperkeeper-authorization pulls in, 1.4.0.

2) Allows the `X509Certificate` for an `ssl-client-cert` to be optional
   in a Ring request map.  This is needed because Ring will populate
   this key with 'nil' when no SSL client certificate was provided for
   the request.  Found this after adding a test for calling
   'puppet-admin' with 'authorization-required: false'.