### PR TITLE
(MAINT) Extract puppet server config file name

### DIFF
--- a/acceptance/config/beaker/options.rb
+++ b/acceptance/config/beaker/options.rb
@@ -9,5 +9,6 @@
   "puppetserver-package" => 'puppetserver',
   "use-service" => true,
   "master-start-curl-retries" => 60,
-  "puppetserver-confdir" => '/etc/puppetlabs/puppetserver/conf.d'
+  "puppetserver-confdir" => '/etc/puppetlabs/puppetserver/conf.d',
+  "puppetserver-config" => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
 }

--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -12,17 +12,13 @@
 test_name 'Default auth.conf rules'
 
 step 'Turn on new auth support' do
-  modify_tk_config(
-    master,
-    File.join(master['puppetserver-confdir'], 'puppetserver.conf'),
-    {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
+  modify_tk_config(master, options['puppetserver-config'],
+                   {'jruby-puppet' => {'use-legacy-auth-conf' => false}})
 end
 
 teardown do
-  modify_tk_config(
-    master,
-    File.join(master['puppetserver-confdir'], 'puppetserver.conf'),
-    {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
+  modify_tk_config(master, options['puppetserver-config'],
+                   {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
 end
 
 def curl_authenticated(path)


### PR DESCRIPTION
This commits moves the name of the config file to options.rb so we can
set it to the PE-specific name in pe-puppet-server-extensions.