### PR TITLE
(SERVER-972) Register dummy AuthConfigLoader when not using legacy auth

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "5822f8db47601bea39de3168564026d5695e6b94", :string)
+                         "f36260b5bcc15dca37bdebc43986db4fb2d4494a", :string)
 
     @config = {
       :base_dir => base_dir,

--- a/src/ruby/puppet-server-lib/puppet/server/auth_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/auth_config.rb
@@ -1,0 +1,11 @@
+## This is a "dummy" AuthConfig that Puppet Server registers with core
+## Puppet for cases where Puppet Server decides that it should be in charge of
+## authorizing requests at the Clojure / Ring handler level - depending upon
+## the configuration of the 'use_legacy_auth_conf' setting - and not core
+## Puppet.
+
+class Puppet::Server::AuthConfig
+  def check_authorization(method, path, params)
+    Puppet.info "Using PuppetServer AuthConfig for master routes"
+  end
+end

--- a/src/ruby/puppet-server-lib/puppet/server/auth_config_loader.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/auth_config_loader.rb
@@ -1,0 +1,13 @@
+## This is a "dummy" AuthConfigLoader that Puppet Server registers with core
+## Puppet for cases where Puppet Server decides that it should be in charge of
+## authorizing requests at the Clojure / Ring handler level - depending upon
+## the configuration of the 'use_legacy_auth_conf' setting - and not core
+## Puppet.
+
+require 'puppet/server/auth_config'
+
+class Puppet::Server::AuthConfigLoader
+  def self.authconfig
+    Puppet::Server::AuthConfig.new
+  end
+end

--- a/src/ruby/puppet-server-lib/puppet/server/config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/config.rb
@@ -6,6 +6,7 @@ require 'puppet/environments'
 require 'puppet/server/logger'
 require 'puppet/server/jvm_profiler'
 require 'puppet/server/http_client'
+require 'puppet/server/auth_config_loader'
 require 'puppet/server/auth_provider'
 require 'puppet/server/execution'
 require 'puppet/server/environments/cached'
@@ -28,7 +29,10 @@ class Puppet::Server::Config
     Puppet::Network::HttpPool.http_client_class = Puppet::Server::HttpClient
 
     if !puppet_server_config["use_legacy_auth_conf"]
-      Puppet::Network::AuthConfig.authprovider_class = Puppet::Server::AuthProvider
+      Puppet::Network::Authorization.authconfigloader_class =
+          Puppet::Server::AuthConfigLoader
+      Puppet::Network::AuthConfig.authprovider_class =
+          Puppet::Server::AuthProvider
     end
 
     Puppet::Server::Execution.initialize_execution_stub


### PR DESCRIPTION
This commit registers a dummy AuthConfigLoader with core Ruby Puppet
when Puppet Server is configured with a `use-legacy-auth-conf` of
`false`.  This is done to avoid having the auth.conf be parsed (and
corresponding messages logged) by core Ruby Puppet.