### PR TITLE
(MAINT) Delete `upgrade_package` method from helper.rb

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -155,20 +155,6 @@ module PuppetServerExtensions
     end
   end
 
-  def upgrade_package(host, name)
-    variant, _, _, _ = master['platform'].to_array
-    case variant
-      when /^(fedora|centos|eos|el)$/
-        on(host, "rm -f $(rpm --verify #{name} | cut -f 4)")
-        on(host, "yum -y reinstall #{name}")
-        on(host, "yum -y upgrade #{name}")
-      when /^(ubuntu|debian|cumulus)$/
-        on(host, "apt-get install -o Dpkg::Options::='--force-confnew' -y --force-yes #{name}")
-      else
-        raise "Package #{name} cannot be upgraded on #{host}"
-    end
-  end
-
   def get_defaults_var(host, varname)
     package_name = options['puppetserver-package']
     variant, version, _, _ = master['platform'].to_array


### PR DESCRIPTION
This commit deletes the `upgrade_package` method from the helper.rb file.
With it present, the call to `rm -f` that it made for EL-7 systems was
failing because it wasn't handling directories to be removed instead of
files.  By removing this, the test helpers should now be able to use the
beaker-provided `upgrade_package` function instead.