### PR TITLE
(MAINT) Remove facts and facts_search endpoints from routing

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -26,8 +26,6 @@
   (comidi/routes
     (comidi/GET ["/node/" [#".*" :rest]] request
                    (request-handler request))
-    (comidi/GET ["/facts/" [#".*" :rest]] request
-                   (request-handler request))
     (comidi/GET ["/file_content/" [#".*" :rest]] request
                    (request-handler request))
     (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
@@ -54,12 +52,6 @@
     (comidi/GET "/environments" request
                    (request-handler request))
     (comidi/GET ["/status/" [#".*" :rest]] request
-                   (request-handler request))
-
-    ;; TODO: when we get rid of the legacy dashboard after 3.4, we should remove
-    ;; this endpoint as well.  It makes more sense for this type of query to be
-    ;; directed to PuppetDB.
-    (comidi/GET ["/facts_search/" [#".*" :rest]] request
                    (request-handler request))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -24,15 +24,13 @@
     (doseq [[method paths]
             {:get ["catalog"
                    "node"
-                   "facts"
                    "file_content"
                    "file_metadatas"
                    "file_metadata"
                    "file_bucket_file"
                    "resource_type"
                    "resource_types"
-                   "status"
-                   "facts_search"]
+                   "status"]
              :post ["catalog"]
              :put ["file_bucket_file"
                    "report"]


### PR DESCRIPTION
This commit removes the facts and facts_search endpoints from the master
service routing layer.  These endpoints are no longer supported as of
Puppet 4 and so are no longer necessary to route through from Puppet
Server.