### PR TITLE
(MAINT) Allow unauthenticated requests to /status

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -129,11 +129,8 @@ with_puppet_running_on(master, {}) do
   end
 
   step 'status endpoint' do
-    curl_authenticated('/puppet/v3/status/foo?environment=production')
-    assert_allowed
-
     curl_unauthenticated('/puppet/v3/status/foo?environment=production')
-    assert_denied(/denied by rule 'puppetlabs status'/)
+    assert_allowed
   end
 
   step 'certificate_revocation_list endpoint' do

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -97,7 +97,7 @@ authorization: {
                 type: path
                 method: get
             }
-            allow: "*"
+            allow-unauthenticated: true
             sort-order: 500
             name: "puppetlabs status"
         },


### PR DESCRIPTION
This commit changes the default auth.conf to allow unauthenticated
requests to the /puppet/v3/status endpoint. This same change will be
made to the auth.conf in pe-puppetserver.