### PR TITLE
(PDB-2071) Add PuppetDBTerminusState class

### DIFF
--- a/src/java/com/puppetlabs/puppetserver/PuppetDBTerminusState.java
+++ b/src/java/com/puppetlabs/puppetserver/PuppetDBTerminusState.java
@@ -1,0 +1,12 @@
+package com.puppetlabs.puppetserver;
+
+import clojure.lang.Atom;
+
+/**
+  The PuppetDB terminus sometimes has occasion to store data that should be
+  shared between all JRuby instances. This class provides a place to put it.
+ */
+public final class PuppetDBTerminusState {
+    private static final Atom sharedStateAtom = new Atom(null);
+    public static final Atom getSharedStateAtom() { return sharedStateAtom; }
+}


### PR DESCRIPTION
In order to support high availability, the PuppetDB terminus needs
to implement sticky failover. That is, after failing over to another
PuppetDB instance, it should keep using that instance for future
requests as long as possible. This is tricky when running in
PuppetServer, since it hosts JRuby instances. 

This adds the PuppetDBTerminusState java class as a place for the
PuppetDB terminus to put the data it needs to share between all
JRubies in the process.