### PR TITLE
(MAINT) Bump puppet deps for 4.2.3 / agent 1.2.7

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.2.5", :string)
+                         "1.2.7", :string)
 
     @config = {
       :base_dir => base_dir,


### PR DESCRIPTION
This commit bumps the puppet submodule to 4.2.3 and puppet-agent
acceptance test dependency to 1.2.7.