### PR TITLE
(MAINT) Bump sqa-utils version to 0.13.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rspec'
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.14.0')
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
-    gem 'sqa-utils', '0.12.1'
+    gem 'sqa-utils', '0.13.3'
   end
   gem 'httparty'
   gem 'uuidtools'


### PR DESCRIPTION
This commit bumps the Gemfile sqa-utils version up to 0.13.3.  This is
needed to pick up support for Ubuntu 15.04 and other newer platforms for
genconfig2.