### PR TITLE
(MAINT) Cache AuthConfig to reduce logging

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/auth_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/auth_config.rb
@@ -5,7 +5,10 @@
 ## Puppet.
 
 class Puppet::Server::AuthConfig
+  def initialize
+    Puppet.debug 'Using PuppetServer AuthConfig for master routes'
+  end
+
   def check_authorization(method, path, params)
-    Puppet.info "Using PuppetServer AuthConfig for master routes"
   end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/auth_config_loader.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/auth_config_loader.rb
@@ -8,6 +8,6 @@ require 'puppet/server/auth_config'
 
 class Puppet::Server::AuthConfigLoader
   def self.authconfig
-    Puppet::Server::AuthConfig.new
+    @cached_authconfig ||= Puppet::Server::AuthConfig.new
   end
 end


### PR DESCRIPTION
To avoid excessive logging, this commit moves the log statement into the
object constructor and then caches the object from the AuthConfigLoader
class. The log statement is also lowered from INFO level to DEBUG.