### PR TITLE
(MAINT) Bump Puppet submodule for upstart vivid test fix

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "f36260b5bcc15dca37bdebc43986db4fb2d4494a", :string)
+                         "ea26968d5d57fedda32b62b449ea83924f31ff77", :string)
 
     @config = {
       :base_dir => base_dir,

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.2.3')
+      expect(subject).to eq('4.3.0')
     end
   end
 


### PR DESCRIPTION
This commit bumps the Ruby Puppet submodule up in order to pick up a
Puppet acceptance test "fix" which skips execution of the handle_upstart
test case when running on later systemd-based Ubuntus.