### PR TITLE
(MAINT) Remove 'finish' assertion from the foreground acceptance test

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/foreground.rb
@@ -17,7 +17,7 @@ expected_messages = {
   /Initializing the JRuby service/ => "JRuby didn't initialize",
   /Starting web server/ => "Expected web server to start",
   /Puppet Server has successfully started and is now ready to handle requests/ => "puppetserver never finished starting",
-  /Finished shutdown sequence/ => "Test ended without puppetserver shutting down gracefully"
+  /Beginning shutdown sequence/ => "Test ended without puppetserver triggering shutdown"
 }
 
 # Start of test
@@ -28,7 +28,7 @@ step "Run #{cli} with foreground subcommand, wait for #{timout_length}"
 on(master, timeout_cmd, :acceptable_exit_codes => [124]) do |result|
   assert_no_match(/error:/i, result.stderr, "Unexpected error running puppetserver!")
 
-  step "Check that #{cli} ran successfully and shutdown gracefully"
+  step "Check that #{cli} ran successfully and shutdown triggered"
   expected_messages.each do |message, explanation|
     assert_match(message, result.stdout, explanation)
   end


### PR DESCRIPTION
This commit removes an assertion that the "Finished shutdown sequence"
message appears in the output of the puppetserver foreground test.  This
message has been seen to sometimes not appear when puppetserver is shut
down - because an OS may kill the process early if puppetserver's
shutdown hook takes too long to run.  For the OSes where this is
problematic - apparently RedHat-based ones but maybe not Debian-based
ones? - there doesn't appear to be any way to prolong the wait time
when running via "timeout" or pressing CTRL-C in the foreground.