### PR TITLE
(MAINT) Bump master Puppet submodule to 2873a96

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "ea26968d5d57fedda32b62b449ea83924f31ff77", :string)
+                         "2b6b9db87bb5e6329a5cc6520b6c6db569d4113f", :string)
 
     @config = {
       :base_dir => base_dir,

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.1.2-master-SNAPSHOT")
+(def ps-version "2.2.0-master-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the Puppet submodule for the master branch to 2873a96
and the corresponding puppet agent package version to 2b6b9db.  This
commit also bumps the project.clj version up to a SNAPSHOT for the next
planned Puppet Server release, 2.2.0-master-SNAPSHOT.