### PR TITLE
(MAINT) Upgrade lein-ezbake

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -110,7 +110,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.18"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.21"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
Utopic has reached EOL and we no longer build packages for it, yet our
version of ezbake was old enough that it still attempted to build
packages for it and would fail.

This commit bumps us up to a newer version of lein-ezbake which will
allow for local ezbake builds to work properly. Jenkins CI isn't failing
because we override the platforms in ci-job-configs and thus don't rely
on the default platforms defined in lein-ezbake.