### PR TITLE
(SERVER-1006) Unregister jruby instances on flush

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -65,11 +65,12 @@
   "Flush a single JRuby instance.  Create a new replacement instance
   and insert it into the specified pool."
   [pool-context :- jruby-schemas/PoolContext
-   {:keys [scripting-container id]} :- JRubyPuppetInstance
+   {:keys [scripting-container id pool] :as instance} :- JRubyPuppetInstance
    new-pool :- jruby-schemas/pool-queue-type
    new-id   :- schema/Int
    config   :- jruby-schemas/JRubyPuppetConfig
    profiler :- (schema/maybe PuppetProfiler)]
+  (.unregister pool instance)
   (.terminate scripting-container)
   (log/infof "Cleaned up old JRuby instance with id %s, creating replacement."
              id)

--- a/src/java/com/puppetlabs/puppetserver/RegisteredLinkedBlockingDeque.java
+++ b/src/java/com/puppetlabs/puppetserver/RegisteredLinkedBlockingDeque.java
@@ -40,6 +40,21 @@ public class RegisteredLinkedBlockingDeque<E> extends LinkedBlockingDeque<E> {
     }
 
     /**
+     * This method removes an element from the list of "registered" elements,
+     * such that it will no longer be returned by calls to
+     * <tt>getRegisteredInstances</tt>.
+     *
+     * This method does not remove the element from the underlying queue; it
+     * is assumed that the caller has already done so via the methods of the
+     * parent class.
+     *
+     * @param e the element to remove from the list of registered instances.
+     */
+    synchronized public void unregister(E e) throws InterruptedException {
+        registeredElements.remove(e);
+    }
+
+    /**
      * @return a set of all of the known elements that have been registered with
      *         this queue.
      */

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -145,12 +145,16 @@
       (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
         (is (= id (:id instance))))))
   (testing "JRuby instance is flushed after exceeding max requests"
-    (let [pool-context  (create-pool-context 1)
-          instance      (jruby-core/borrow-from-pool pool-context :test [])
-          id            (:id instance)]
-      (jruby-core/return-to-pool instance :test [])
-      (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-        (is (not= id (:id instance))))))
+    (let [pool-context  (create-pool-context 1)]
+      (is (= 1 (count (jruby-core/registered-instances pool-context))))
+      (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+            id (:id instance)]
+        (jruby-core/return-to-pool instance :test [])
+        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+          (is (not= id (:id instance))))
+        (testing "instance is removed from registered elements after flushing"
+          (is (= 1 (count (jruby-core/registered-instances pool-context))))))))
+
   (testing "JRuby instance is not flushed if max requests setting is set to 0"
     (let [pool-context  (create-pool-context 0)
           instance      (jruby-core/borrow-from-pool pool-context :test [])

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -114,7 +114,7 @@
                     :jruby-puppet         (create-mock-jruby-instance)
                     :scripting-container  (ScriptingContainer. LocalContextScope/SINGLETHREAD)
                     :environment-registry (puppet-env/environment-registry)})]
-    (.put pool instance)
+    (.registerLast pool instance)
     instance))
 
 (defn mock-pool-instance-fixture


### PR DESCRIPTION
Prior to this commit, when a JRuby instance was added to the pool,
it was also added to the list of "registered" instances for the pool
so that we could find an authoritative list of all of the instances
even when some were out on loan.

However, we did not have the corresponding logic to *unregister*
instances from this list when an instance was flushed via
max-requests-per-instance.  This resulted in a reference being
kept to the flushed instances even after they were flushed,
meaning that we could not reclaim all of the memory during
garbage collection.  This caused memory to leak over time.

This commit adds code to unregister instances when they are
flushed, so that we do not retain the extra reference to the
flushed instances, and we are able to garbage collect them
and free up the memory.