### PR TITLE
(MAINT) Bump project.clj version to 2.1.3-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.0")
 (def tk-jetty-version "1.3.0")
 (def ks-version "1.0.0")
-(def ps-version "2.1.0-2.1.x-SNAPSHOT")
+(def ps-version "2.1.3-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the version in the project.clj for puppet-server up to
2.1.3-SNAPSHOT.