### PR TITLE
(MAINT) null out http client reference on close

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/http_client.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/http_client.rb
@@ -87,8 +87,9 @@ class Puppet::Server::HttpClient
   end
 
   def self.terminate
-    unless self.client.nil?
-      self.client.close
+    unless @client.nil?
+      @client.close
+      @client = nil
     end
   end
 


### PR DESCRIPTION
This commit nulls out the reference to the http client object
inside of the JRuby instances when we close them, just to
make 100% sure that they are eligible for garbage collection.