### PR TITLE
(SERVER-836) Bump puppet-agent dep to 1.3.0, puppet submodule to 4.3.0

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "d5a07cfe7746c3bb9236388cdc5f7a88aa473731", :string)
+                         "1.3.0", :string)
 
     @config = {
       :base_dir => base_dir,

--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -7,7 +7,7 @@
 ezbake: {
    pe: {}
    foss: {
-      redhat: { dependencies: ["puppet-agent"],
+      redhat: { dependencies: ["puppet-agent >= 4.3.0"],
                # This is terrible, but we need write access to puppet's
                # var/conf dirs, so we need to add ourselves to the group.
                # Then we need to chmod some dirs until the Puppet packaging
@@ -34,7 +34,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent"],
+      debian: { dependencies: ["puppet-agent >= (4.3.0)"],
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",


### PR DESCRIPTION
This commit bumps the puppet-agent dependency to 1.3.0 and the
corresponding puppet submodule dependency to 4.3.0.