### PR TITLE
(MAINT) Fix broken puppet-agent debian dependency

### DIFF
--- a/resources/ext/ezbake.conf
+++ b/resources/ext/ezbake.conf
@@ -34,7 +34,7 @@ ezbake: {
                ]
              }
 
-      debian: { dependencies: ["puppet-agent >= (4.3.0)"],
+      debian: { dependencies: ["puppet-agent (>= 4.3.0)"],
                # see redhat comments on why this is terrible
                postinst: [
                  "install --owner={{user}} --group={{user}} -d /opt/puppetlabs/server/data/puppetserver/jruby-gems",


### PR DESCRIPTION
This commit fixes a syntax problem in how the minimum puppet-agent
dependency was previously expressed for Debian - moving a paren to
the left of the version string.