### PR TITLE
(MAINT) Bump project.clj to puppet-server 2.2.0 for release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.2.0-stable-SNAPSHOT")
+(def ps-version "2.2.0")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the version in the project.clj to 2.2.0 for release.