### PR TITLE
(MAINT) Bump puppet-server project.clj to 2.2.1-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.2.0")
+(def ps-version "2.2.1-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the puppet-server project.clj version up to
2.2.1-SNAPSHOT.