### PR TITLE
(SERVER-1069) add logback json encoder in jar file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,6 +41,7 @@
                  [org.jruby/jruby-stdlib "1.7.20.1"]
                  [org.clojure/data.json "0.2.3"]
                  [org.clojure/tools.macro "0.1.5"]
+                 [net.logstash.logback/logstash-logback-encoder "4.5.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [joda-time "2.7"]
                  [clj-time "0.10.0"]
                  [liberator "0.12.0"]


### PR DESCRIPTION
We're using this extension to logback to have puppet-server generate JSON-encoded logs, which makes them easier to process downstream (indexing into elasticsearch for instance).

This doesn't alter the way puppet-server works, it would only give the user more configuration options available in `logback.xml` and `request-logging.xml`.

I'm not sure this is the right way to submit changes to puppet-server. Should I also open an issue in JIRA ?

Should this get accepted, `documentation/configuration.markdown` should probably be amended too, to mention the additional logging capabilities.