### PR TITLE
(MAINT) Introduce PuppetDB testing 

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -28,9 +28,15 @@ module PuppetServerExtensions
     # puppet-agent version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppet-agent/
     puppet_build_version = get_option_value(options[:puppet_build_version],
-                         nil, "Puppet Development Build Version",
+                         nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
                          "2b6b9db87bb5e6329a5cc6520b6c6db569d4113f", :string)
+
+    # puppetdb version corresponds to packaged development version located at:
+    # http://builds.delivery.puppetlabs.net/puppetdb/
+    puppetdb_build_version =
+      get_option_value(options[:puppetdb_build_version], nil,
+                       "PuppetDB Version", "PUPPETDB_BUILD_VERSION", "3.2.1", :string)
 
     @config = {
       :base_dir => base_dir,
@@ -39,11 +45,27 @@ module PuppetServerExtensions
       :puppetserver_version => puppetserver_version,
       :puppet_version => puppet_version,
       :puppet_build_version => puppet_build_version,
+      :puppetdb_build_version => puppetdb_build_version,
     }
 
     pp_config = PP.pp(@config, "")
 
     Beaker::Log.notify "Puppet Server Acceptance Configuration:\n\n#{pp_config}\n\n"
+  end
+
+  # PuppetDB development packages aren't available on as many platforms as
+  # Puppet Server's packages, so we need to restrict the PuppetDB-related
+  # testing to a subset of the platforms.
+  # This guards both the installation of the PuppetDB package repository file
+  # and the running of the PuppetDB test(s).
+  def puppetdb_supported_platforms()
+    [
+      /debian-7/,
+      /debian-8/,
+      /el/, # includes cent6,7 and redhat6,7
+      /ubuntu-12/,
+      /ubuntu-14/,
+    ]
   end
 
   class << self

--- a/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
+++ b/acceptance/suites/pre_suite/foss/30_install_dev_repos.rb
@@ -25,3 +25,24 @@ if puppet_build_version
     end
   end
 end
+
+confine_block(:to, {:platform => puppetdb_supported_platforms}, master) do
+  step "Install PuppetDB repository" do
+    install_puppetlabs_dev_repo(
+      master, 'puppetdb', test_config[:puppetdb_build_version],
+      repo_config_dir, install_opts)
+
+    # Internal packages on ubuntu/debian aren't authenticated and thus apt
+    # will fail to install PuppetDB on those platforms.
+    # This hack tells apt that we can trust the PuppetDB packages until RE-6014
+    # is resolved, at which point this [trusted=yes] will already be in the file
+    # and we can delete the on(master, "sed ...") block below.
+    # This should make the puppetlabs-puppetdb module happily install PuppetDB on
+    # ubuntu/debian.
+    on(master, <<TRUSTPACKAGES)
+if [ -e /etc/apt/sources.list.d/pl-puppetdb* ]; then
+  sed -i -e 's/deb/deb [trusted=yes]/1' /etc/apt/sources.list.d/pl-puppetdb*
+fi
+TRUSTPACKAGES
+  end
+end

--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -1,0 +1,52 @@
+## Tests that PuppetDB can be integrated with Puppet Server in a simple
+## monolithic install (i.e. PuppetDB on same node as Puppet Server).
+##
+## In this context 'integrated' just means that Puppet Server is able to
+## communicate over HTTP/S with PuppetDB to send it information, such as
+## agent run reports.
+##
+## This test validates communication is successful by querying the PuppetDB HTTP
+## API and asserting the agent's report timestamp is not null. This means that
+## PuppetDB successfully received the agent's report sent from Puppet Server.
+## We can just run the agent that's on the master for this.
+
+confine :to, {:platform => puppetdb_supported_platforms}, master
+
+require 'json'
+
+test_name 'PuppetDB integration'
+
+step 'Install PuppetDB module' do
+  on(master, puppet('module install puppetlabs-puppetdb'))
+end
+
+step 'Configure PuppetDB via site.pp' do
+  sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
+  create_remote_file(master, sitepp, <<SITEPP)
+node default {
+  class { 'puppetdb': }
+  class { 'puppetdb::master::config':
+    puppet_service_name     => #{options['puppetservice']},
+    manage_report_processor => true,
+    enable_reports          => true,
+  }
+}
+SITEPP
+  on(master, "chmod 644 #{sitepp}")
+  teardown do
+    on(master, "rm -f #{sitepp}")
+  end
+end
+
+step 'Install PuppetDB with agent run' do
+  with_puppet_running_on(master, {}) do
+    on(master, puppet_agent("--test --server #{master}"), :acceptable_exit_codes => [0,2])
+  end
+end
+
+step 'Validate server sent agent report to PuppetDB' do
+  fqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
+  query = "curl http://localhost:8080/pdb/query/v4/nodes/#{fqdn}"
+  response = JSON.parse(on(master, query).stdout.chomp)
+  assert(response['report_timestamp'] != nil)
+end

--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -57,6 +57,8 @@ def report_query(node)
 end
 
 with_puppet_running_on(master, {}) do
+  masterfqdn = on(master, '/opt/puppetlabs/bin/facter fqdn').stdout.chomp
+
   step 'environments endpoint' do
     curl_authenticated('/puppet/v3/environments')
     assert_allowed
@@ -66,35 +68,35 @@ with_puppet_running_on(master, {}) do
   end
 
   step 'catalog endpoint' do
-    curl_authenticated("/puppet/v3/catalog/#{master}?environment=production")
+    curl_authenticated("/puppet/v3/catalog/#{masterfqdn}?environment=production")
     assert_allowed
 
     curl_authenticated('/puppet/v3/catalog/notme?environment=production')
     assert_denied(/denied by rule 'puppetlabs catalog'/)
 
-    curl_unauthenticated("/puppet/v3/catalog/#{master}?environment=production")
+    curl_unauthenticated("/puppet/v3/catalog/#{masterfqdn}?environment=production")
     assert_denied(/denied by rule 'puppetlabs catalog'/)
   end
 
   step 'node endpoint' do
-    curl_authenticated("/puppet/v3/node/#{master}?environment=production")
+    curl_authenticated("/puppet/v3/node/#{masterfqdn}?environment=production")
     assert_allowed
 
     curl_authenticated('/puppet/v3/node/notme?environment=production')
     assert_denied(/denied by rule 'puppetlabs node'/)
 
-    curl_unauthenticated("/puppet/v3/node/#{master}?environment=production")
+    curl_unauthenticated("/puppet/v3/node/#{masterfqdn}?environment=production")
     assert_denied(/denied by rule 'puppetlabs node'/)
   end
 
   step 'report endpoint' do
-    curl_authenticated(report_query(master))
+    curl_authenticated(report_query(masterfqdn))
     assert_allowed
 
     curl_authenticated(report_query('notme'))
     assert_denied(/denied by rule 'puppetlabs report'/)
 
-    curl_unauthenticated(report_query(master))
+    curl_unauthenticated(report_query(masterfqdn))
     assert_denied(/denied by rule 'puppetlabs report'/)
   end
 


### PR DESCRIPTION
This commit adds support for installing PuppetDB and writing tests.
Since PuppetDB packages aren't built for as many platforms as Puppet
Server we need to keep a list of supported platforms to protect the
pre-suite step and any tests against PuppetDB from breaking CI.

The PuppetDB in this commit is a relatively simple smoke test that
validates Puppet Server can communicate with PuppetDB and send it agent
information.