### PR TITLE
(SERVER-1016) Add pool releaseItem variant for unlocking item w/o return

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -105,7 +105,10 @@
               instance  (jruby-internal/borrow-from-pool!*
                           jruby-internal/borrow-without-timeout-fn
                           (:pool old-pool))]
-          (flush-instance! pool-context instance new-pool id config profiler)
+          (try
+            (flush-instance! pool-context instance new-pool id config profiler)
+            (finally
+              (.releaseItem (:pool old-pool) instance false)))
           (log/infof "Finished creating JRubyPuppet instance %d of %d"
                      id count))
         (catch Exception e

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -299,8 +299,10 @@
                           "maximum number of requests (%s)")
                      (:id instance)
                      max-requests)
-          (flush-instance-fn pool instance)
-          (.releaseItem pool instance false))
+          (try
+            (flush-instance-fn pool instance)
+            (finally
+              (.releaseItem pool instance false))))
         (.releaseItem pool instance)))
     ;; if we get here, it was from a borrow and we got a Retry, so we just
     ;; return it to the pool.

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -247,7 +247,7 @@
   (let [instance (borrow-fn pool)]
     (cond (instance? PoisonPill instance)
           (do
-            (.returnItem pool instance)
+            (.releaseItem pool instance)
             (throw (IllegalStateException.
                      "Unable to borrow JRuby instance from pool"
                      (:err instance))))
@@ -299,11 +299,12 @@
                           "maximum number of requests (%s)")
                      (:id instance)
                      max-requests)
-          (flush-instance-fn pool instance))
-        (.returnItem pool instance)))
+          (flush-instance-fn pool instance)
+          (.releaseItem pool instance false))
+        (.releaseItem pool instance)))
     ;; if we get here, it was from a borrow and we got a Retry, so we just
     ;; return it to the pool.
-    (.returnItem (:pool instance) instance)))
+    (.releaseItem (:pool instance) instance)))
 
 (schema/defn ^:always-validate new-main :- jruby-schemas/JRubyMain
   "Return a new JRuby Main instance which should only be used for CLI purposes,

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -36,9 +36,15 @@ public interface LockablePool<E> {
     E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
 
    /**
-    * Return an instance to the pool.
+    * Release an item back into the pool.
     */
-    void returnItem(E e) throws InterruptedException;
+    void releaseItem(E e) throws InterruptedException;
+
+   /**
+    * Release an item.  For a returnToPool value of 'true', return the item
+    * back to the pool.  For a value of 'false', discard the item.
+    */
+    void releaseItem(E e, boolean returnToPool) throws InterruptedException;
 
    /**
     * Insert a poison pill to the pool. This is different from returning an

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -21,7 +21,7 @@
 (defn return-instances
   [pool instances]
   (doseq [instance instances]
-    (.returnItem pool instance)))
+    (.releaseItem pool instance)))
 
 (deftest pool-lock-is-blocking-test
   (let [pool (create-populated-pool 3)
@@ -40,11 +40,11 @@
         (is (not (realized? lock-acquired?)))
 
         (testing "other threads may successfully return instances while pool.lock() is being executed"
-          (.returnItem pool (first instances))
+          (.releaseItem pool (first instances))
           (is (not (realized? lock-acquired?)))
-          (.returnItem pool (second instances))
+          (.releaseItem pool (second instances))
           (is (not (realized? lock-acquired?)))
-          (.returnItem pool (nth instances 2)))
+          (.releaseItem pool (nth instances 2)))
 
         @lock-acquired?
         (is (not (realized? lock-thread)))
@@ -55,7 +55,7 @@
 
       (testing "borrows may be resumed after unlock()"
         (let [instance (.borrowItem pool)]
-          (.returnItem pool instance))
+          (.releaseItem pool instance))
         ;; make sure we got here
         (is (true? true))))))
 
@@ -80,7 +80,7 @@
               (future (deliver borrow-after-lock-requested-thread-started? true)
                       (let [instance (.borrowItem pool)]
                         (deliver borrow-after-lock-requested-instance-acquired? true)
-                        (.returnItem pool instance)))]
+                        (.releaseItem pool instance)))]
           @borrow-after-lock-requested-thread-started?
           (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
 
@@ -95,7 +95,7 @@
                 (future (deliver borrow-after-lock-acquired-thread-started? (promise))
                         (let [instance (.borrowItem pool)]
                           (deliver borrow-after-lock-acquired-instance-acquired? true)
-                          (.returnItem pool instance)))]
+                          (.releaseItem pool instance)))]
             @borrow-after-lock-acquired-thread-started?
             (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
 
@@ -117,7 +117,7 @@
           blocked-borrow-thread (future (deliver blocked-borrow-thread-started? true)
                                         (let [instance (.borrowItem pool)]
                                           (deliver blocked-borrow-thread-borrowed? true)
-                                          (.returnItem pool instance)))
+                                          (.releaseItem pool instance)))
           lock-thread-started? (promise)
           lock-acquired? (promise)
           unlock? (promise)
@@ -156,7 +156,7 @@
       (is (thrown? IllegalStateException (.borrowItem pool)))
       ;; (let [instance (.borrowItem pool)]
       ;;   (is (true? true))
-      ;;   (.returnItem pool instance))
+      ;;   (.releaseItem pool instance))
 
       (is (true? true))
       (.unlock pool))))
@@ -167,9 +167,9 @@
       (.lock pool)
       (is (true? true))
       (let [borrow-thread-1 (future (let [instance (.borrowItem pool)]
-                                      (.returnItem pool instance)))
+                                      (.releaseItem pool instance)))
             borrow-thread-2 (future (let [instance (.borrowItem pool)]
-                                      (.returnItem pool instance)))]
+                                      (.releaseItem pool instance)))]
         ;; this is racey, but the only ways i could think of to make it non-racey
         ;; depended on knowledge of the implementation
         ;; Uncomment and make non-racey when we have an implementation that
@@ -185,7 +185,7 @@
         (is (thrown? IllegalStateException (.borrowItem pool)))
         ;; (let [instance (.borrowItem pool)]
         ;;   (is (true? true))
-        ;;   (.returnItem pool instance))
+        ;;   (.releaseItem pool instance))
 
         (is (true? true))
         (.unlock pool)

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -191,3 +191,27 @@
         (.unlock pool)
         @borrow-thread-1
         @borrow-thread-2))))
+
+(deftest pool-release-item-test
+  (testing (str "releaseItem call with value 'false' does not return item to "
+                "pool but does allow pool to still be lockable")
+    (let [pool (create-populated-pool 1)
+          instance (.borrowItem pool)]
+      (is (= 0 (.size pool)))
+      (.releaseItem pool instance false)
+      (is (= 0 (.size pool)))
+      (.lock pool)
+      (is (true? true))
+      (.unlock pool)
+      (is (true? true))))
+  (testing (str "releaseItem call with value 'true' does not return item to "
+                "pool and allows pool to still be lockable")
+    (let [pool (create-populated-pool 1)
+          instance (.borrowItem pool)]
+      (is (= 0 (.size pool)))
+      (.releaseItem pool instance true)
+      (is (= 1 (.size pool)))
+      (.lock pool)
+      (is (true? true))
+      (.unlock pool)
+      (is (true? true)))))


### PR DESCRIPTION
This commit renames the returnItem method in the JRubyPool and
LockablePool to releaseItem and adds a variant of the method which can
be used to determine whether the item should be released back into the
pool or just discarded.  For cases where an item is flushed, the item is
just discarded without going back into the pool - but with the
associated release lock for the thread being unlocked.