### PR TITLE
(SERVER-1016) Minor improvements to lock unit tests

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -24,7 +24,7 @@
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock app)]
+          lock (jruby-testutils/get-lock-from-app app)]
 
       (testing "initial state of write lock is unlocked"
         (is (not (.isWriteLocked lock))))
@@ -41,7 +41,7 @@
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock app)]
+          lock (jruby-testutils/get-lock-from-app app)]
 
       (testing "initial state of write lock is unlocked"
         (is (not (.isWriteLocked lock))))
@@ -96,7 +96,7 @@
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock app)]
+          lock (jruby-testutils/get-lock-from-app app)]
 
       (is (= 0 (.getReadLockCount lock)))
       (is (not (.isWriteLocked lock)))


### PR DESCRIPTION
This commit fixes a typo in one of the test description strings, and
also makes the assertions in the tests a little more meaningful.