### PR TITLE
(MAINT) Change enumeration in gem test cleanup to use key as name

### DIFF
--- a/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
+++ b/acceptance/suites/tests/010-puppetserver-cli/subcommand/gem.rb
@@ -22,7 +22,7 @@ gem_cleanup = "#{cli} gem cleanup"
 # teardown
 teardown do
   step "Teardown: Remove all installed gems."
-  gems.each do |gem_name|
+  gems.keys.each do |gem_name|
     on(master, "#{gem_uninstall} #{gem_name}")
   end
   step "Teardown: Remove all gems not required to meet a dependency."


### PR DESCRIPTION
This commit changes the enumeration of gems in the gem test cleanup to
use just the key name instead of the full key/value pair.  The original
approach would have used the key/value pair as an array representing the
name of the gem to uninstall, which was incorrect.