### PR TITLE
(MAINT) Disable firewall management in PuppetDB test

### DIFF
--- a/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
+++ b/acceptance/suites/tests/00_smoke/puppetdb_integration.rb
@@ -24,7 +24,9 @@ step 'Configure PuppetDB via site.pp' do
   sitepp = '/etc/puppetlabs/code/environments/production/manifests/site.pp'
   create_remote_file(master, sitepp, <<SITEPP)
 node default {
-  class { 'puppetdb': }
+  class { 'puppetdb':
+    manage_firewall => false,
+  }
   class { 'puppetdb::master::config':
     puppet_service_name     => #{options['puppetservice']},
     manage_report_processor => true,


### PR DESCRIPTION
Since the firewall is off by default and managing it will turn it on for
some/all platforms which causes subsequent tests to fail with connection
errors.