### PR TITLE
(MAINT) Remove one httparty gem reference from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :test do
   if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
     gem 'sqa-utils', '0.13.3'
   end
-  gem 'httparty'
   gem 'uuidtools'
   gem 'httparty'
 end


### PR DESCRIPTION
The prior commit added an extra reference to the httparty gem in the
puppet-server Gemfile which is unnecessary.  This commit removes that
reference.