### PR TITLE
(SERVER-862) Enable jruby pool write locker to borrow pool instances

### DIFF
--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -1,62 +1,100 @@
 package com.puppetlabs.puppetserver.pool;
 
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import com.puppetlabs.puppetserver.pool.LockablePool;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A data structure to be used as a Pool, encapsulating a LinkedBlockingDeque
- * and a ReentrantReadWriteLock. Implements the <tt>LockablePool</tt>
- * interface such that when a <tt>borrowItem</tt> is performed an instance is
- * taken from the deque and a read lock is acquired, when a
- * <tt>releaseItem</tt> is performed an instance is put back onto the deque and
- * a read lock is released, and <tt>lock</tt> locks a write lock.
+ * A data structure to be used as a Pool, encapsulating a ReentrantLock around
+ * a LinkedList.
  *
- * @param <E> the type of element that can be added to the LinkedBlockingDeque.
+ * @param <E> the type of element that can be added to the LinkedList.
  */
 public final class JRubyPool<E> implements LockablePool<E> {
-    private final LinkedBlockingDeque<E> liveQueue;
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
+    // Underlying queue which holds the elements that clients can borrow.
+    private final LinkedList<E> liveQueue;
+
+    // Lock which guards all accesses to the underlying queue and registered
+    // element set.  Constructed as "nonfair" for performance, like the lock
+    // that a <tt>LinkedBlockingDeque</tt> does.  Not clear that we need this
+    // to be a "fair" lock.
+    private final ReentrantLock lock = new ReentrantLock();
+
+    // Condition signaled when all elements that have been registered have been
+    // returned to the queue.  Awaited when a lock has been requested but
+    // one or more registered elements has been borrowed from the pool.
+    private final Condition allRegisteredInQueue = lock.newCondition();
+
+    // Condition signaled when an element has been added into the queue.
+    // Awaited when a request has been made to borrow an item but no elements
+    // currently exist in the queue.
+    private final Condition notEmpty = lock.newCondition();
+
+    // Condition signaled when the pool has been unlocked.  Awaited when a
+    // request has been made to borrow an item or lock the pool but the pool
+    // is currently locked.
+    private final Condition notLocked = lock.newCondition();
+
+    // Holds a reference to all of the elements that have been registered.
+    // Newly registered elements are also added into the <tt>liveQueue</tt>.
+    // Elements only exist in the <tt>liveQueue</tt> when not currently
+    // borrowed whereas elements that have been registered (but not
+    // yet unregistered) will be accessible via <tt>registeredElements</tt>
+    // even while they are borrowed.
     private final Set<E> registeredElements = new CopyOnWriteArraySet<>();
 
+    // Maximum size that the underlying queue can grow to.
+    private int maxSize;
+
+    // Id of the thread which currenly holds the write lock.  -1 indicates that
+    // there is no current write lock holder.
+    private volatile long lockThreadId = -1;
+
+    /**
+     * Create a JRubyPool
+     *
+     * @param size maximum capacity for the pool.
+     */
     public JRubyPool(int size) {
-        liveQueue = new LinkedBlockingDeque<>(size);
+        liveQueue = new LinkedList<>();
+        maxSize = size;
     }
 
     /**
-    * This method is analagous to <tt>putLast</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class, but also causes the element to be
-    * added to the list of "registered" elements that will be returned by
-    * <tt>getRegisteredInstances</tt>.
-    *
-    * This method is synchronized not for thread safety, but to try to ensure that
-    * to consumers of this class adding an instance to the queue and adding it to
-    * the set of registered elements is visible roughly atomically. `synchronize`
-    * guarantees that registration is atomic, so (ignoring borrows happening)
-    * `RegisteredElements` and `liveQueue` can only diverge by 1. "This is only
-    * "roughly" atomic, as the underlying queue uses its own lock, so it is
-    * possible for it to be modified on another thread while this method is being
-    * executed.
-    *
-    * @param e the element to register and put at the end of the queue.
-    *
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>addLast</tt> in the <tt>LinkedList</tt>
+     * class, but also causes the element to be added to the list of
+     * "registered" elements that will be returned by
+     * <tt>getRegisteredInstances</tt>.
+     *
+     * @param e the element to register and put at the end of the queue.
+     * @throws IllegalStateException if an attempt is made to register an
+     *                               element but the number of registered
+     *                               instances is already equal to the maximum
+     *                               capacity for the pool.
+     */
     @Override
-    synchronized public void register(E e) throws InterruptedException {
-        registeredElements.add(e);
-        liveQueue.putLast(e);
+    public void register(E e) {
+        lock.lock();
+        try {
+            if (registeredElements.size() == maxSize)
+                throw new IllegalStateException(
+                        "Unable to register additional instance, pool full");
+            registeredElements.add(e);
+            liveQueue.addLast(e);
+            signalNotEmpty();
+        } finally {
+            lock.unlock();
+        }
     }
-
 
     /**
      * This method removes an element from the list of "registered" elements,
      * such that it will no longer be returned by calls to
      * <tt>getRegisteredInstances</tt>.
-     *
+     * <p>
      * This method does not remove the element from the underlying queue; it
      * is assumed that the caller has already done so via the methods of the
      * parent class.
@@ -64,163 +102,253 @@ public final class JRubyPool<E> implements LockablePool<E> {
      * @param e the element to remove from the list of registered instances.
      */
     @Override
-    synchronized public void unregister(E e) throws InterruptedException {
-        registeredElements.remove(e);
+    public void unregister(E e) {
+        lock.lock();
+        try {
+            registeredElements.remove(e);
+            signalIfAllRegisteredInQueue();
+        } finally {
+            lock.unlock();
+        }
     }
 
-
     /**
-    * This method is analagous to <tt>takeFirst</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
-    * locked from the <tt>ReentrantReadWriteLock</tt>.
-    *
-    * @return The head of the deque.
-    *
-    * @throws IllegalStateException if the thread holding the write lock
-    *         attempts to call this method.
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>removeFirst</tt> in the
+     * <tt>LinkedList</tt> class.  An element will not be returned until
+     * the queue is unlocked and an element can be pulled out of the queue
+     * for return.
+     *
+     * @return The head of the queue.
+     * @throws InterruptedException if the calling thread is interrupted
+     *                              while waiting for the pool to be
+     *                              unlocked or for an element to
+     *                              be available in the queue for borrowing.
+     */
     @Override
-    public E borrowItem() throws InterruptedException, IllegalStateException {
-        if (lock.isWriteLockedByCurrentThread()) {
-          throw new IllegalStateException("The current implementation has a risk of deadlock if you attempt to borrow a JRuby instance while holding the write lock!");
+    public E borrowItem() throws InterruptedException {
+        E item = null;
+
+        lock.lock();
+        try {
+            long currentThreadId = getThreadId(Thread.currentThread());
+            while (item == null) {
+                if (lockThreadId != -1 && lockThreadId != currentThreadId) {
+                    notLocked.await();
+                } else if (liveQueue.size() < 1) {
+                    notEmpty.await();
+                } else {
+                    item = liveQueue.removeFirst();
+                }
+            }
+        } finally {
+            lock.unlock();
         }
-        E item = liveQueue.takeFirst();
-        lock.readLock().lock();
+
         return item;
     }
 
     /**
-    * This method is analagous to <tt>pollFirst</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
-    * locked from the <tt>ReentrantReadWriteLock</tt>.
-    *
-    * @param timeout how long to wait before giving up, in units of unit
-    * @param unit a <tt>TimeUnit</tt> determining how to interpret the
-    *        <tt>timeout parameter</tt>
-    *
-    * @return The head of the deque, or <tt>null</tt> if the specified waiting
-    *         time elapses before an element is available.
-    *
-    * @throws IllegalStateException if the thread holding the write lock
-    *         attempts to call this method.
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>removeFirst</tt> in the
+     * <tt>LinkedList</tt> class but with a timed maximum wait for an element
+     * to be available in the queue for borrowing.
+     *
+     * @param timeout how long to wait before giving up, in units of unit
+     * @param unit    a <tt>TimeUnit</tt> determining how to interpret the
+     *                <tt>timeout parameter</tt>
+     * @return The head of the queue, or <tt>null</tt> if the specified waiting
+     *         time elapses before an element is available.
+     * @throws InterruptedException if the calling thread is interrupted while
+     *                              waiting for the pool to be unlocked or for
+     *                              an element to be available in the queue
+     *                              for borrowing.
+     */
     @Override
-    public E borrowItemWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, IllegalStateException {
-        if (lock.isWriteLockedByCurrentThread()) {
-          throw new IllegalStateException("The current implementation has a risk of deadlock if you attempt to borrow a JRuby instance while holding the write lock!");
+    public E borrowItemWithTimeout(long timeout, TimeUnit unit) throws
+            InterruptedException {
+        E item = null;
+
+        long remainingMaxTimeToWait = unit.toNanos(timeout);
+        lock.lockInterruptibly();
+        try {
+            long currentThreadId = getThreadId(Thread.currentThread());
+            while (item == null && remainingMaxTimeToWait > 0) {
+                if (lockThreadId != -1 && lockThreadId != currentThreadId) {
+                    remainingMaxTimeToWait =
+                            notLocked.awaitNanos(remainingMaxTimeToWait);
+                } else if (liveQueue.size() < 1) {
+                    remainingMaxTimeToWait =
+                            notEmpty.awaitNanos(remainingMaxTimeToWait);
+                } else {
+                    item = liveQueue.removeFirst();
+                }
+            }
+        } finally {
+            lock.unlock();
         }
-        E item = liveQueue.pollFirst(timeout, unit);
-        lock.readLock().lock();
+
         return item;
     }
 
     /**
-    * This method is analogous to <tt>putFirst</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
-    * unlocked from the <tt>ReentrantReadWriteLock</tt>.  This method should
-    * only be called from the same thread that was running when the item was
-    * originally borrowed.
-    *
-    * @param e the element to return to the pool
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>addLast</tt> in the <tt>LinkedList</tt>
+     * class.
+     *
+     * @param e the element to return to the pool
+     */
     @Override
-    public void releaseItem(E e) throws InterruptedException {
+    public void releaseItem(E e) {
         releaseItem(e, true);
     }
 
     /**
-    * This method is analogous to <tt>putFirst</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class, but also causes a read lock to be
-    * unlocked from the <tt>ReentrantReadWriteLock</tt>.  This method should
-    * only be called from the same thread that was running when the item was
-    * originally borrowed.
-    *
-    * @param e the element to return to the pool
-    * @param returnToPool whether to return the element to the pool (true)
-    *                     or just throw the element away (false)
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>addFirst</tt> in the <tt>LinkedList</tt>
+     * class.
+     *
+     * @param e            the element to return to the pool
+     * @param returnToPool whether to return the element to the pool (true)
+     *                     or just throw the element away (false)
+     */
     @Override
-    public void releaseItem(E e, boolean returnToPool)
-            throws InterruptedException {
+    public void releaseItem(E e, boolean returnToPool) {
+        lock.lock();
         try {
             if (returnToPool) {
-                liveQueue.putFirst(e);
+                addFirst(e);
             }
         } finally {
-            lock.readLock().unlock();
+            lock.unlock();
         }
     }
 
     /**
-    * This method is analagous to <tt>putFirst</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class. It should only ever be used to
-    * insert a `PoisonPill` or `RetryPoisonPill` to the pool, which is an
-    * operation that should be done without acquiring a read lock.
-    *
-    * @param e the element to add to the queue
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>addFirst</tt> in the
+     * <tt>LinkedList</tt> class.  It should only ever be used to
+     * insert a `PoisonPill` or `RetryPoisonPill` to the pool.  The
+     * implementation of this method is equivalent to calling
+     * releaseItem(e, true).
+     *
+     * @param e the element to add to the queue
+     */
     @Override
-    public void insertPill(E e) throws InterruptedException {
-        liveQueue.putFirst(e);
+    public void insertPill(E e) {
+        lock.lock();
+        try {
+            addFirst(e);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
-    * This method is analagous to <tt>clear</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class.
-    *
-    * @throws InterruptedException
-    */
+     * This method is analogous to <tt>clear</tt> in the
+     * <tt>LinkedList</tt> class.
+     */
     @Override
     public void clear() {
-        liveQueue.clear();
+        lock.lock();
+        try {
+            liveQueue.clear();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
-    * This method is analagous to <tt>remainingCapacity</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class.
-    *
-    * @return the number of additional elements that the queue can ideally
-    *         accept without blocking.
-    */
+     * This method calculates the remaining capacity in the queue from
+     * the supplied <tt>size</tt> at construction minus the current number of
+     * elements in the underlying <tt>LinkedList</tt>.
+     *
+     * @return the number of additional elements that the queue can accept.
+     */
     @Override
     public int remainingCapacity() {
-        return liveQueue.remainingCapacity();
+        int remainingCapacity;
+        lock.lock();
+        try {
+            remainingCapacity = maxSize - liveQueue.size();
+        } finally {
+            lock.unlock();
+        }
+        return remainingCapacity;
     }
 
     /**
-    * This method is analagous to <tt>size</tt> in the
-    * <tt>LinkedBlockingDeque</tt> class.
-    *
-    * @return the number of elements in the queue
-    */
+     * This method is analogous to <tt>size</tt> in the <tt>LinkedList</tt>
+     * class.
+     *
+     * @return the number of elements in the queue
+     */
     @Override
     public int size() {
-        return liveQueue.size();
+        int size;
+        lock.lock();
+        try {
+            size = liveQueue.size();
+        } finally {
+            lock.unlock();
+        }
+        return size;
     }
 
     /**
-    * Acquires a write lock from <tt>ReentrantReadWriteLock</tt>.
-    *
-    * Note that this implementation does not fulfill requirement (e) in the
-    * LockablePool javadocs for lock(); with this implementation, the thread
-    * holding the lock cannot perform a borrow while it's holding the lock.
-    */
+     * Acquires a "lock" on the underlying queue, preventing any would-be
+     * future borrowers from acquiring an element or any future pool lockers
+     * until the lock is freed.
+     *
+     * @throws InterruptedException if the calling thread is interrupted while
+     *                              waiting for the pool to be unlocked.
+     */
     @Override
     public void lock() throws InterruptedException {
-        lock.writeLock().lock();
+        lock.lock();
+        try {
+            long currentThreadId = getThreadId(Thread.currentThread());
+            while (currentThreadId != lockThreadId) {
+                if (lockThreadId == -1) {
+                    lockThreadId = currentThreadId;
+                } else {
+                    notLocked.await();
+                }
+            }
+            while (registeredElements.size() != liveQueue.size()) {
+                allRegisteredInQueue.await();
+            }
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
-    * Releases the write lock.
-    */
+     * Releases the write lock.
+     *
+     * @throws IllegalStateException if the calling thread does not currently
+     *                               hold the write lock.
+     */
     @Override
     public void unlock() throws InterruptedException {
-        lock.writeLock().unlock();
+        lock.lock();
+        try {
+            long currentThreadId = getThreadId(Thread.currentThread());
+            if (currentThreadId != lockThreadId) {
+                String threadIdForMessage;
+                if (lockThreadId == -1) {
+                    threadIdForMessage = "not held by any thread";
+                } else {
+                    threadIdForMessage = "held by thread id " + lockThreadId;
+                }
+                throw new IllegalStateException(
+                        "Unlock requested from thread not holding the lock.  " +
+                                "Requested from thread id " + currentThreadId +
+                                " but lock " + threadIdForMessage);
+            }
+            lockThreadId = -1;
+            // Need to use 'signalAll' here because there might be multiple
+            // waiters (e.g., multiple borrowers) queued up, waiting for the
+            // pool to be unlocked.
+            notLocked.signalAll();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -231,4 +359,40 @@ public final class JRubyPool<E> implements LockablePool<E> {
         return registeredElements;
     }
 
+    private void addFirst(E e) {
+        liveQueue.addFirst(e);
+        signalNotEmpty();
+    }
+
+    private void signalNotEmpty() {
+        // Could use 'signalAll' here instead of 'signal' but 'signal' is
+        // less expensive in that only one waiter will be woken up.  Can use
+        // signal here because the thread being awoken will be able to borrow
+        // a pool instance and any further waiters will be woken up by
+        // subsequent posts of this signal when instances are added/returned to
+        // the queue.
+        notEmpty.signal();
+        signalIfAllRegisteredInQueue();
+    }
+
+    private void signalIfAllRegisteredInQueue() {
+        // Could use 'signalAll' here instead of 'signal'.  Doesn't really
+        // matter though in that there will only be one waiter at most which
+        // is active at a time - a caller of lock() that has just acquired
+        // the lock but is waiting for all registered elements to be returned
+        // to the queue.
+        if (registeredElements.size() == liveQueue.size()) {
+            allRegisteredInQueue.signal();
+        }
+    }
+
+    /**
+     * Returns the thread id for a given thread.  For safety, we might want /
+     * need to replace this with the scary-looking method that the OpenJDK uses
+     * in <tt>ReentrantReadWriteLock</tt> - see
+     * http://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/1919c226b427#l1.124.
+     */
+     private static long getThreadId(Thread thread) {
+         return thread.getId();
+     }
 }

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -240,14 +240,18 @@ public final class JRubyPool<E> implements LockablePool<E> {
     }
 
     /**
-     * This method is analogous to <tt>clear</tt> in the
-     * <tt>LinkedList</tt> class.
+     * This method is analogous to <tt>clear</tt> in the <tt>LinkedList</tt>
+     * class.  This method clears all elements currently in the queue and
+     * also unregisters them from the set of registered elements.
      */
     @Override
     public void clear() {
         lock.lock();
         try {
-            liveQueue.clear();
+            int queueSize = liveQueue.size();
+            for (int i=0; i<queueSize; i++) {
+                registeredElements.remove(liveQueue.removeFirst());
+            }
         } finally {
             lock.unlock();
         }

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -1,5 +1,6 @@
 package com.puppetlabs.puppetserver.pool;
 
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -36,13 +37,13 @@ public final class JRubyPool<E> implements LockablePool<E> {
     // this class, the pool is backed by a non-synchronized JDK `LinkedList`.
 
     // Underlying queue which holds the elements that clients can borrow.
-    private final LinkedList<E> liveQueue;
+    private final Deque<E> liveQueue;
 
     // Lock which guards all accesses to the underlying queue and registered
     // element set.  Constructed as "nonfair" for performance, like the lock
     // that a `LinkedBlockingDeque` does.  Not clear that we need this
     // to be a "fair" lock.
-    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock(false);
 
     // Condition signaled when all elements that have been registered have been
     // returned to the queue.  Awaited when a lock has been requested but

--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -74,10 +74,18 @@ public final class JRubyPool<E> implements LockablePool<E> {
     // Thread which currently holds the write lock.  null indicates that
     // there is no current write lock holder.  Using the current Thread
     // object for tracking the lock owner is comparable to what the JDK's
-    // `ReentrantLock` class does:
+    // `ReentrantLock` class does via the `AbstractOwnableSynchronizer` class:
     //
     // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/ReentrantLock.java#l164
-    private Thread writeLockThread = null;
+    // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/AbstractOwnableSynchronizer.java#l64
+    //
+    // Unlike the `AbstractOwnableSynchronizer` class implementation, we marked
+    // this variable as `volatile` because we couldn't convince ourselves
+    // that it would be safe to update this variable from different threads and
+    // not be susceptible to per-thread / per-CPU caching causing the wrong
+    // value to be seen by a thread.  `volatile` seems safer and doesn't appear
+    // to impose any noticeable performance degradation.
+    private volatile Thread writeLockThread = null;
 
     /**
      * Create a JRubyPool

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -158,7 +158,7 @@ public interface LockablePool<E> {
     * @throws IllegalStateException if the calling thread does not currently
     *                               hold the exclusive lock
     */
-    void unlock() throws InterruptedException;
+    void unlock();
 
    /**
     * Returns a set of all of the elements that are currently registered with

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -6,98 +6,164 @@ import java.util.concurrent.TimeUnit;
 public interface LockablePool<E> {
 
    /**
-    * Introduce a new instance to the pool in a way that allows us to keep track
-    * of the list of all existing instances, even if some of them are
-    * borrowed.
+    * Introduce a new element to the pool.
+    *
+    * @param e the element to register
+    * @throws IllegalStateException if an attempt is made to register an
+    *                               element but the number of registered
+    *                               elements is already equal to the maximum
+    *                               capacity for the pool
     */
-    void register(E e) throws InterruptedException;
-
+    void register(E e) throws IllegalStateException;
 
     /**
-     * Unregister an instance from the pool, removing it from the list of
-     * existing instances.
+     * Unregister an element from the pool.  It is assumed that the
+     * caller of this method has previously called {@link #borrowItem()} to
+     * retrieve the item back from the pool.  This method does not
+     * implicitly remove the element from the list of elements available for
+     * {@link #borrowItem()} calls.  This method does remove the element
+     * from the set returned from subsequent calls to
+     * {@link #getRegisteredElements()}.
+     *
+     * @param e the element to remove from the list of registered elements
      */
-    void unregister(E e) throws InterruptedException;
+    void unregister(E e);
 
-   /**
-    * Borrow an instance. This and <tt>borrowItemWithTimeout</tt> are the
-    * only entry points for accessing instances.
-    */
+    /**
+     * Borrow an element from the pool.  This method will block until
+     * whichever of the following happens first:
+     *
+     * - the element can be returned
+     * - the caller's thread is interrupted
+     *
+     * On a successful return, subsequent calls to {@link #borrowItem()} and
+     * {@link #borrowItemWithTimeout(long, TimeUnit)} will not return the same
+     * element returned for the call to this method until/unless a subsequent
+     * call to {@link #releaseItem(Object)} is made to return the element back
+     * to the pool.
+     *
+     * @return the borrowed element
+     * @throws InterruptedException if the calling thread is interrupted
+     *                              while waiting for the pool to be
+     *                              unlocked or for an element to
+     *                              be available in the queue for borrowing
+     * @see #borrowItemWithTimeout(long, TimeUnit)
+     */
     E borrowItem() throws InterruptedException;
 
-   /**
-    * Borrow an instance, waiting up to the specified timeout if necessary
-    * for an instance to become available. Returns `null` if the wait time
-    * elapses before an instance is available.
-    *
-    * This and <tt>borrowItemWithTimeout</tt> are the only entry points for
-    * accessing instances.
-    */
-    E borrowItemWithTimeout(long timout, TimeUnit unit) throws InterruptedException;
+    /**
+     * Borrow an element from the pool.  This method will block until
+     * whichever of the following happens first:
+     *
+     * - the element can be returned
+     * - the maximum time specified by the <tt>timeout</tt> parameter has
+     *   elapsed
+     * - the caller's thread is interrupted
+     *
+     * On a successful return, subsequent calls to {@link #borrowItem()} and
+     * {@link #borrowItemWithTimeout(long, TimeUnit)} will not return the same
+     * element returned for the call to this method until/unless a subsequent
+     * call to {@link #releaseItem(Object)} is made to return the element
+     * back to the pool.
+     *
+     * @param timeout how long to wait before giving up, in units of unit
+     * @param unit    a <tt>TimeUnit</tt> determining how to interpret the
+     *                <tt>timeout</tt> parameter
+     * @return The borrowed element or <tt>null</tt> if the specified waiting
+     *         time elapses before an element is available
+     * @throws InterruptedException if the calling thread is interrupted
+     *                              while waiting for the pool to be
+     *                              unlocked or for an element to
+     *                              be available in the queue for borrowing
+     * @see #borrowItem()
+     */
+    E borrowItemWithTimeout(long timeout, TimeUnit unit)
+            throws InterruptedException;
 
    /**
     * Release an item back into the pool.
+    *
+    * @param e the element to return to the pool
     */
-    void releaseItem(E e) throws InterruptedException;
+    void releaseItem(E e);
 
    /**
-    * Release an item.  For a returnToPool value of 'true', return the item
-    * back to the pool.  For a value of 'false', discard the item.
+    * Release an item.
+    *
+    * @param e the element
+    * @param returnToPool if <tt>true</tt>, return the item back to the
+    *                     pool.  For a value of <tt>false</tt>, discard the
+    *                     item.
     */
-    void releaseItem(E e, boolean returnToPool) throws InterruptedException;
+    void releaseItem(E e, boolean returnToPool);
 
    /**
-    * Insert a poison pill to the pool. This is different from returning an
-    * instance to the pool because there are different locking semantics
-    * around inserting a pill.
+    * Insert a poison pill into the pool.
+    *
+    * @param e the pill element to add to the queue
     */
-    void insertPill(E e) throws InterruptedException;
+    void insertPill(E e);
 
     /**
-     * Clear the pool.
+     * Unregister all elements which are currently in the pool.  Elements
+     * in the pool at the time this method is called would no longer be
+     * returned in subsequent {@link #borrowItem()},
+     * {@link #borrowItemWithTimeout(long, TimeUnit)}, or
+     * {@link #getRegisteredElements()} calls.  Note that any elements that
+     * have been borrowed but not yet returned to the pool at the time this
+     * method is called will remain registered.
      */
     void clear();
 
     /**
-     * Returns the number of additional items that the pool can accept without
-     * blocking. Equal to the initial capacity of the pool minus the current
-     * <tt>size</tt> of the pool.
+     * Returns the number of elements that can be added into the pool.  Equal
+     * to the capacity of the pool minus the number of elements that have
+     * been registered with but not borrowed from the pool.
      */
     int remainingCapacity();
 
     /**
-     * Returns the number of elements in the pool.
+     * Returns the number of elements that have been registered with but not
+     * borrowed from the pool.
      */
     int size();
 
    /**
     * Lock the pool. This method should make the following guarantees:
     *
-    *  a) blocks until all registered instances are returned to the pool
+    *  a) blocks until all registered elements are returned to the pool
     *  b) once this method is called (even before it returns), any new threads
-    *     that attempt a <tt>borrow</tt> should block until <tt>unlock()</tt>
+    *     that attempt a <tt>borrow</tt> should block until {@link #unlock()}
     *     is called
     *  c) if there are other threads that were already blocking in a
     *     <tt>borrow</tt> before this method was called, they should continue
-    *     to block until <tt>unlock()</tt> is called
-    *  d) instances may be returned by other threads while this method is
-    *     being executied
+    *     to block until {@link #unlock()} is called
+    *  d) elements may be returned by other threads while this method is
+    *     being executed
     *  e) when the method returns, the caller holds an exclusive lock on the
     *     pool; the lock should be re-entrant in the sense that this thread
     *     should still be able to perform borrows while it's holding the lock
+    *
+    * @throws InterruptedException if the calling thread is interrupted while
+    *                              waiting for the pool to be unlocked
     */
     void lock() throws InterruptedException;
 
    /**
-    * Release the exclusive lock so that other threads may begin to perform
-    * borrow operations again.
+    * Release the exclusive pool lock so that other threads may begin to
+    * perform borrow operations again.  Note that this method must be called
+    * from the same thread from which {@link #lock} was called in order to
+    * obtain the exclusive pool lock.
+    *
+    * @throws IllegalStateException if the calling thread does not currently
+    *                               hold the exclusive lock
     */
     void unlock() throws InterruptedException;
 
    /**
-    * Returns a set of all of the known elements that have been registered with
-    * this pool, regardless of whether they are
-    * currently available in the pool or not.
+    * Returns a set of all of the elements that are currently registered with
+    * this pool.  The set includes both elements that are available to be
+    * borrowed and elements that have already been borrowed.
     */
     Set<E> getRegisteredElements();
 }

--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -15,7 +15,16 @@
 (defn jruby-service-test-config
   [pool-size]
   (jruby-testutils/jruby-puppet-tk-config
-    (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size})))
+    (jruby-testutils/jruby-puppet-config {:max-active-instances pool-size
+                                          :borrow-timeout 1})))
+
+(defn can-borrow-from-different-thread?
+  [jruby-service]
+  @(future
+    (if-let [instance (jruby-protocol/borrow-instance jruby-service :test)]
+      (do
+        (jruby-protocol/return-instance jruby-service instance :test)
+        true))))
 
 (deftest ^:integration with-lock-test
   (tk-bootstrap/with-app-with-config
@@ -23,16 +32,15 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
-    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock-from-app app)]
-
+    (jruby-testutils/wait-for-jrubies app)
+    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
       (testing "initial state of write lock is unlocked"
-        (is (not (.isWriteLocked lock))))
+        (is (can-borrow-from-different-thread? jruby-service))
       (testing "with-lock macro holds write lock while executing body"
         (jruby-service/with-lock jruby-service :with-lock-holds-lock-test
-          (is (.isWriteLocked lock))))
+          (is (not (can-borrow-from-different-thread? jruby-service)))))
       (testing "with-lock macro releases write lock after exectuing body"
-        (is (not (.isWriteLocked lock)))))))
+        (is (can-borrow-from-different-thread? jruby-service)))))))
 
 (deftest ^:integration with-lock-exception-test
   (tk-bootstrap/with-app-with-config
@@ -40,18 +48,19 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
-    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock-from-app app)]
+    (jruby-testutils/wait-for-jrubies app)
+    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
 
       (testing "initial state of write lock is unlocked"
-        (is (not (.isWriteLocked lock))))
+        (is (can-borrow-from-different-thread? jruby-service)))
 
       (testing "with-lock macro releases lock even if body throws exception"
         (is (thrown? IllegalStateException
                      (jruby-service/with-lock jruby-service :with-lock-exception-test
-                       (is (.isWriteLocked lock))
+                      (is (not (can-borrow-from-different-thread?
+                                jruby-service)))
                        (throw (IllegalStateException. "exception")))))
-        (is (not (.isWriteLocked lock)))))))
+        (is (can-borrow-from-different-thread? jruby-service))))))
 
 (deftest ^:integration with-lock-event-notification-test
   (testing "locking sends event notifications"
@@ -89,24 +98,35 @@
             (is (= [:instance-requested :instance-borrowed :instance-returned
                     :lock-requested :lock-acquired :lock-released] @events))))))))
 
-(deftest ^:integration borrow-and-return-affect-read-lock-test
-  (tk-bootstrap/with-app-with-config
-    app
-    [jruby-service/jruby-puppet-pooled-service
-     profiler/puppet-profiler-service]
-    (jruby-service-test-config 1)
-    (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
-          lock (jruby-testutils/get-lock-from-app app)]
-
-      (is (= 0 (.getReadLockCount lock)))
-      (is (not (.isWriteLocked lock)))
-
-      (let [instance (jruby-protocol/borrow-instance jruby-service :test-borrow-and-read-lock)]
-        (testing "borrow-instance acquires a read lock and does not affect write lock"
-          (is (= 1 (.getReadLockCount lock)))
-          (is (not (.isWriteLocked lock))))
-
-        (testing "return-instance releases a read lock and does not affect write lock"
-          (jruby-protocol/return-instance jruby-service instance :test-return-and-read-lock)
-          (is (= 0 (.getReadLockCount lock)))
-          (is (not (.isWriteLocked lock))))))))
+(deftest ^:integration with-lock-and-borrow-contention-test
+  (testing "contention for instances with borrows and locking handled properly"
+    (tk-bootstrap/with-app-with-config
+     app
+     [jruby-service/jruby-puppet-pooled-service
+      profiler/puppet-profiler-service]
+     (jruby-service-test-config 2)
+     (jruby-testutils/wait-for-jrubies app)
+     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
+       (let [instance (jruby-protocol/borrow-instance
+                       jruby-service
+                       :with-lock-and-borrow-contention-test)]
+         (let [lock-thread-started? (promise)
+               unlock-thread? (promise)
+               lock-thread (future (jruby-service/with-lock
+                                    jruby-service
+                                    :with-lock-and-borrow-contention-test
+                                    (deliver lock-thread-started? true)
+                                    @unlock-thread?))]
+           (testing "lock not granted yet when instance still borrowed"
+             (Thread/sleep 500)
+             (is (not (realized?
+                       lock-thread-started?))))
+           (jruby-protocol/return-instance
+            jruby-service instance :with-lock-and-borrow-contention-test)
+           @lock-thread-started?
+           (testing "cannot borrow from non-locking thread when locked"
+             (is (not (can-borrow-from-different-thread? jruby-service))))
+           (deliver unlock-thread? true)
+           @lock-thread
+           (testing "can borrow from non-locking thread after lock released"
+             (is (can-borrow-from-different-thread? jruby-service)))))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -32,6 +32,7 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
+    (jruby-testutils/wait-for-jrubies app)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
       (testing "initial state of write lock is unlocked"
         (is (can-borrow-from-different-thread? jruby-service))
@@ -47,6 +48,7 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
+    (jruby-testutils/wait-for-jrubies app)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
 
       (testing "initial state of write lock is unlocked"

--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -32,7 +32,6 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
-    (jruby-testutils/wait-for-jrubies app)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
       (testing "initial state of write lock is unlocked"
         (is (can-borrow-from-different-thread? jruby-service))
@@ -48,7 +47,6 @@
     [jruby-service/jruby-puppet-pooled-service
      profiler/puppet-profiler-service]
     (jruby-service-test-config 1)
-    (jruby-testutils/wait-for-jrubies app)
     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
 
       (testing "initial state of write lock is unlocked"
@@ -118,7 +116,6 @@
                                     (deliver lock-thread-started? true)
                                     @unlock-thread?))]
            (testing "lock not granted yet when instance still borrowed"
-             (Thread/sleep 500)
              (is (not (realized?
                        lock-thread-started?))))
            (jruby-protocol/return-instance

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -57,20 +57,6 @@
     {:headers     {"Accept" "pson"}
      :as          :text}))
 
-(defn service-context
-  [app service-id]
-  (-> (tk-app/app-context app)
-      deref
-      service-id))
-
-(defn wait-for-jrubies
-  [app]
-  (let [pool-context (-> (service-context app :JRubyPuppetService)
-                         :pool-context)]
-    (while (< (count (jruby-core/registered-instances pool-context))
-              num-jrubies)
-      (Thread/sleep 100))))
-
 (defn get-catalog
   "Make an HTTP request to get a catalog."
   []
@@ -163,7 +149,7 @@
                                              :environment-flush-integration-test))]
         ;; wait for all of the jrubies to be ready so that we can
         ;; validate cache state differences between them.
-        (wait-for-jrubies app)
+        (jruby-testutils/wait-for-jrubies app)
 
         (testing "flush called when no jrubies are borrowed"
           ;;; Now we grab a catalog from the first jruby instance.  This

--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -233,24 +233,6 @@
         @borrow-thread-1
         @borrow-thread-2))))
 
-(deftest pool-lock-reentrant-for-one-lock-test
-  (testing "another thread cannot lock the pool while it is already locked"
-    (let [pool (create-populated-pool 1)]
-      (.lock pool)
-      (is (true? true))
-      (let [lock-thread-started? (promise)
-            lock-thread-locked? (promise)
-            lock-thread (future (deliver lock-thread-started? true)
-                                (.lock pool)
-                                (deliver lock-thread-locked? true)
-                                (.unlock pool))]
-        @lock-thread-started?
-        (is (not (realized? lock-thread-locked?)))
-        (.unlock pool)
-        (is (true? true))
-        @lock-thread
-        (is (true? true))))))
-
 (deftest pool-lock-reentrant-for-many-locks-test
   (testing "multiple threads cannot lock the pool while it is already locked"
     (let [pool (create-populated-pool 1)]

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -161,12 +161,19 @@
         (testing "instance is removed from registered elements after flushing"
           (is (= 1 (count (jruby-core/registered-instances pool-context))))))
       (testing "Can lock pool after a flush via max requests"
-        (let [pool (jruby-internal/get-pool pool-context)
-              lock (jruby-testutils/get-lock-from-pool pool)]
+        (let [pool (jruby-internal/get-pool pool-context)]
           (.lock pool)
-          (is (.isWriteLocked lock))
+          (is (nil? @(future (jruby-core/borrow-from-pool-with-timeout
+                              pool-context
+                              1
+                              :test
+                              []))))
           (.unlock pool)
-          (is (not (.isWriteLocked lock)))))))
+          (is (not (nil? @(future (jruby-core/borrow-from-pool-with-timeout
+                                  pool-context
+                                  1
+                                  :test
+                                  [])))))))))
 
   (testing "JRuby instance is not flushed if max requests setting is set to 0"
     (let [pool-context  (create-pool-context 0)


### PR DESCRIPTION
This PR reworks the `JRubyPool` implementation to pull in all of the
concurrent constructs around a single `ReentrantLock`, the primary benefit
being to allow the holder of a write lock to be able to borrow instances
from the pool without running the risk of a deadlock due to competing
borrows that may be occurring from other threads.  The implementation
uses three condition variables to gate borrower and locker access to the
pool, similar to how `LinkedBlockingDeque` does for managing queue takers.

Where the underlying lock construct in the `JRubyPool` class would be a
`ReentrantLock` instead of a `ReentrantReadWriteLock`, this commit also
reworks a few of the unit tests to attempt borrows from non-locking
threads as an indication that the write lock is held, as opposed to
trying to interrogate the lock construct itself.

This PR also cleans up the Javadocs for the `LockablePool` interface and
`JRubyPool` class to be less redundant and cover only details that the
consumer of the two would need to know, pulling internal details about the
`JRubyPool` class into comments within that class.