### PR TITLE
(MAINT) Bump project.clj version to 2.2.2-master-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.2.0-master-SNAPSHOT")
+(def ps-version "2.2.2-master-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit bumps the Puppet Server version in the project.clj up to
2.2.2-master-SNAPSHOT given that we've released 2.2.1 already.