### PR TITLE
(MAINT) Bump project.clj version to 2.2.2-stable-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
-(def ps-version "2.2.2-SNAPSHOT")
+(def ps-version "2.2.2-stable-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
This commit adds "stable" into the puppet-server version, to
disambiguate builds done from the "stable" branch from corresponding
ones done from the "master" branch.