### PR TITLE
(MAINT) Upgrade ezbake to remove utopic target

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -102,7 +102,7 @@
              :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.16"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.21"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
The version of lein-ezbake we were on was a few releases behind and
would fail to build packages when doing a `lein with-profile ezbake
ezbake build` since utopic was removed from somewhere.

This commit just brings us up to a newer version that will no longer
attempt to build packages for utopic.