### PR TITLE
(SERVER-537) Cleanup jruby pools during shutdown

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,8 @@
                                    [ring-basic-authentication "1.0.5"]
                                    [ring-mock "0.1.5"]
                                    [spyscope "0.1.4" :exclusions [clj-time]]
-                                   [grimradical/clj-semver "0.3.0" :exclusions [org.clojure/clojure]]]
+                                   [grimradical/clj-semver "0.3.0" :exclusions [org.clojure/clojure]]
+                                   [beckon "0.1.1"]]
                    :injections    [(require 'spyscope.core)]
                    ; SERVER-332, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts      ["-Djava.security.properties=./dev-resources/java.security"]}

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_agents.clj
@@ -6,7 +6,7 @@
             [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas])
   (:import (clojure.lang IFn)
            (com.puppetlabs.puppetserver PuppetProfiler)
-           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill JRubyPuppetInstance)))
+           (puppetlabs.services.jruby.jruby_puppet_schemas PoisonPill RetryPoisonPill JRubyPuppetInstance ShutdownPoisonPill)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -95,6 +95,8 @@
         old-pool (:pool old-pool-state)
         count    (:size old-pool-state)]
     (log/info "Replacing old JRuby pool with new instance.")
+    (when (= reason :shutdown)
+      (.insertPill new-pool (ShutdownPoisonPill. new-pool)))
     (reset! pool-state new-pool-state)
     (log/info "Swapped JRuby pools, beginning cleanup of old pool.")
     (doseq [i (range count)]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -103,7 +103,7 @@
    :instance instance})
 
 (schema/defn create-returned-event :- jruby-schemas/JRubyReturnedEvent
-  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrPill
    reason :- jruby-schemas/JRubyEventReason]
   {:type :instance-returned
    :reason reason
@@ -147,7 +147,7 @@
 
 (schema/defn instance-returned :- jruby-schemas/JRubyReturnedEvent
   [event-callbacks :- [IFn]
-   instance :- jruby-schemas/JRubyPuppetInstanceOrRetry
+   instance :- jruby-schemas/JRubyPuppetInstanceOrPill
    reason :- jruby-schemas/JRubyEventReason]
   (notify-event-listeners event-callbacks (create-returned-event instance reason)))
 
@@ -260,7 +260,7 @@
         puppet-env/mark-all-environments-expired!)))
 
 (schema/defn ^:always-validate
-  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrPill
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
   [pool-context :- jruby-schemas/PoolContext
@@ -294,7 +294,7 @@
 (schema/defn ^:always-validate
   return-to-pool
   "Return a borrowed pool instance to its free pool."
-  [instance :- jruby-schemas/JRubyPuppetInstanceOrRetry
+  [instance :- jruby-schemas/JRubyPuppetInstanceOrPill
    reason :- schema/Any
    event-callbacks :- [IFn]]
   (instance-returned event-callbacks instance reason)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_internal.clj
@@ -174,6 +174,15 @@
    :size size})
 
 (schema/defn ^:always-validate
+  cleanup-pool-instance!
+  "Cleans up and cleanly terminates a JRubyPuppet instance and removes it from the pool."
+  [{:keys [scripting-container jruby-puppet pool] :as instance} :- JRubyPuppetInstance]
+  (.unregister pool instance)
+  (.terminate jruby-puppet)
+  (.terminate scripting-container)
+  (log/infof "Cleaned up old JRuby instance with id %s." (:id instance)))
+
+(schema/defn ^:always-validate
   create-pool-instance! :- JRubyPuppetInstance
   "Creates a new JRubyPuppet instance and adds it to the pool."
   [pool     :- jruby-schemas/pool-queue-type
@@ -189,6 +198,7 @@
     (when-not ruby-load-path
       (throw (Exception.
                "JRuby service missing config value 'ruby-load-path'")))
+    (log/infof "Creating JRuby instance with id %s." id)
     (let [scripting-container   (create-scripting-container
                                  ruby-load-path
                                  gem-home

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -303,6 +303,3 @@
     event-type-lock-requested? JRubyLockRequestedEvent
     event-type-lock-acquired? JRubyLockAcquiredEvent
     event-type-lock-released? JRubyLockReleasedEvent))
-
-(def FlushReason
-  (schema/enum :shutdown :flush-requested))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -290,3 +290,6 @@
     event-type-lock-requested? JRubyLockRequestedEvent
     event-type-lock-acquired? JRubyLockAcquiredEvent
     event-type-lock-released? JRubyLockReleasedEvent))
+
+(def FlushReason
+  (schema/enum :shutdown :flush-requested))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -46,7 +46,7 @@
    [this context]
    (let [{:keys [pool-context]} (tk-services/service-context this)
          flush-complete? (promise)]
-     (jruby-agents/send-flush-pool! pool-context :shutdown flush-complete?)
+     (jruby-agents/send-flush-pool-for-shutdown! pool-context flush-complete?)
      @flush-complete?)
    context)
 
@@ -80,7 +80,7 @@
     [this]
     (let [service-context (tk-services/service-context this)
           {:keys [pool-context]} service-context]
-      (jruby-agents/send-flush-pool! pool-context)))
+      (jruby-agents/send-flush-and-repopulate-pool! pool-context)))
 
   (register-event-handler
     [this callback-fn]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -45,9 +45,11 @@
   (stop
    [this context]
    (let [{:keys [pool-context]} (tk-services/service-context this)
-         flush-complete? (promise)]
-     (jruby-agents/send-flush-pool-for-shutdown! pool-context flush-complete?)
-     @flush-complete?)
+         on-complete (promise)]
+     (log/debug "Beginning flush of JRuby pools for shutdown")
+     (jruby-agents/send-flush-pool-for-shutdown! pool-context on-complete)
+     @on-complete
+     (log/debug "Finished flush of JRuby pools for shutdown"))
    context)
 
   (borrow-instance

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -108,6 +108,11 @@
                         "misconfigured or trying to serve too many agent nodes. "
                         "Check Puppet Server settings: "
                         "jruby-puppet.max-active-instances.")}))
+     (if (jruby-schemas/shutdown-poison-pill? pool-instance#)
+       (sling/throw+
+        {:type    ::service-unavailable
+         :message (str "Attempted to borrow a JRuby instance from the pool "
+                       "during a shutdown. Please try again.")}))
      (if (jruby-schemas/retry-poison-pill? pool-instance#)
        (do
          (jruby/return-instance ~jruby-service pool-instance# ~reason)

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -42,6 +42,11 @@
             (assoc :pool-context pool-context)
             (assoc :borrow-timeout (:borrow-timeout config))
             (assoc :event-callbacks (atom []))))))
+  (stop
+   [this context]
+   (let [{:keys [pool-context]} (tk-services/service-context this)]
+     (jruby-agents/send-flush-pool! pool-context :shutdown))
+   context)
 
   (borrow-instance
     [this reason]

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -266,6 +266,13 @@
     (= (:type x)
        :puppetlabs.services.request-handler.request-handler-core/bad-request)))
 
+(defn service-unavailable?
+  [x]
+  "Determine if the supplied slingshot message is for a 'service unavailable'"
+  (when (map? x)
+    (= (:type x)
+       :puppetlabs.services.jruby.jruby-puppet-service/service-unavailable)))
+
 (defn jruby-timeout?
   "Determine if the supplied slingshot message is for a JRuby borrow timeout."
   [x]
@@ -290,6 +297,8 @@
       (catch bad-request? e
         (output-error request e 400))
       (catch jruby-timeout? e
+        (output-error request e 503))
+      (catch service-unavailable? e
         (output-error request e 503)))))
 
 (defn wrap-with-jruby-instance

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -296,7 +296,7 @@
 (defprotocol BonusService
   (bonus-service-fn [this]))
 
-(deftest ^:integration test-hup-comes-back
+#_(deftest ^:integration test-hup-comes-back
   (testing "After a HUP signal puppetserver can still handle requests"
     (let [call-seq (atom [])
           lc-fn (fn [context action] (swap! call-seq conj action) context)

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -17,7 +17,6 @@
             [puppetlabs.http.client.sync :as http-client]
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.internal :as tk-internal]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -5,6 +5,7 @@
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
+            [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
@@ -14,7 +15,15 @@
             [puppetlabs.services.puppet-admin.puppet-admin-service :as puppet-admin]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
             [puppetlabs.http.client.sync :as http-client]
-            [me.raynes.fs :as fs]))
+            [me.raynes.fs :as fs]
+            [puppetlabs.trapperkeeper.internal :as tk-internal]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.services.request-handler.request-handler-service :as handler-service]
+            [puppetlabs.services.config.puppet-server-config-service :as ps-config]
+            [puppetlabs.services.protocols.request-handler :as handler]
+            [puppetlabs.services.request-handler.request-handler-core :as handler-core]
+            [puppetlabs.ssl-utils.core :as ssl-utils]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/jruby_pool_int_test")
@@ -283,3 +292,83 @@
 
             ;; we should have three instances with the constant and one without.
             (is (true? (check-jrubies-for-constant-counts pool-context 3 1)))))))))
+
+(defprotocol BonusService
+  (bonus-service-fn [this]))
+
+(deftest ^:integration test-hup-comes-back
+  (testing "After a HUP signal puppetserver can still handle requests"
+    (let [call-seq (atom [])
+          lc-fn (fn [context action] (swap! call-seq conj action) context)
+          bonus-service (tk-services/service BonusService
+                          [[:MasterService]]
+                          (init [this context] (lc-fn context :init-bonus-service))
+                          (start [this context] (lc-fn context :start-bonus-service))
+                          (stop [this context] (lc-fn context :stop-bonus-service))
+                          (bonus-service-fn [this] (lc-fn nil :bonus-service-fn)))]
+      (bootstrap/with-puppetserver-running-with-services
+       app
+       (conj (tk-bootstrap/parse-bootstrap-config! bootstrap/dev-bootstrap-file) bonus-service)
+       {:jruby-puppet {:max-active-instances 1}}
+       (tk-internal/register-sighup-handler [app])
+       (beckon/raise! "HUP")
+       (let [start (System/currentTimeMillis)]
+         (while (and (not= (count @call-seq) 5)
+                     (< (- (System/currentTimeMillis) start) 90000))
+           (Thread/yield)))
+       (is (= @call-seq [:init-bonus-service :start-bonus-service :stop-bonus-service :init-bonus-service :start-bonus-service]))
+       (let [get-results (http-client/get "https://localhost:8140/puppet/v3/environments"
+                                          bootstrap/request-options)]
+         (is (= 200 (:status get-results))))))))
+
+(deftest ^:integration test-503-when-app-shuts-down
+  (testing "During a shutdown the agent requests result in a 503 response"
+    (let [services [jruby/jruby-puppet-pooled-service profiler/puppet-profiler-service
+                    handler-service/request-handler-service ps-config/puppet-server-config-service
+                    jetty9/jetty9-service]
+          config (-> (jruby-testutils/jruby-puppet-tk-config
+                      (jruby-testutils/jruby-puppet-config {:max-active-instances 2}))
+                     (assoc-in [:webserver :port] 8081))
+          app (tk/boot-services-with-config services config)
+          cert (ssl-utils/pem->cert
+                (str test-resources-dir "/localhost-cert.pem"))
+          jruby-service (tk-app/get-service app :JRubyPuppetService)
+          jruby-instance (jruby-protocol/borrow-instance jruby-service :i-want-this-instance)
+          handler-service (tk-app/get-service app :RequestHandlerService)
+          request { :uri "/puppet/v3/environments", :params {}, :headers {},
+                   :request-method :GET, :body "", :ssl-client-cert cert, :content-type ""}
+          ping-environment #(->> request (handler-core/wrap-params-for-jruby) (handler/handle-request handler-service))
+          stop-complete? (future (tk-app/stop app))]
+        (let [start (System/currentTimeMillis)]
+          (while (and
+                  (< (- (System/currentTimeMillis) start) 10000)
+                  (not= 503 (:status (ping-environment))))
+            (Thread/yield))
+          (is (= 503 (:status (ping-environment))))
+          (jruby-protocol/return-instance jruby-service jruby-instance :i-want-this-instance)
+          @stop-complete?
+          (is (= 503 (:status (ping-environment))))))))
+
+(deftest ^:integration test-503-when-jruby-is-first-to-shutdown
+  (testing "During a shutdown requests result in 503 http responses"
+    (bootstrap/with-puppetserver-running
+     app
+     {:jruby-puppet {:max-active-instances 2}}
+     (let [jruby-service (tk-app/get-service app :JRubyPuppetService)
+           context (tk-services/service-context jruby-service)
+           jruby-instance (jruby-protocol/borrow-instance jruby-service :i-want-this-instance)
+           stop-complete? (future (tk-services/stop jruby-service context))
+           ping-environment #(http-client/get "https://localhost:8140/puppet/v3/environments"
+                                              bootstrap/request-options)]
+       (let [start (System/currentTimeMillis)]
+         (while (and
+                 (< (- (System/currentTimeMillis) start) 10000)
+                 (not= 503 (:status (ping-environment))))
+           (Thread/yield)))
+       (is (= 503 (:status (ping-environment))))
+       (jruby-protocol/return-instance jruby-service jruby-instance :i-want-this-instance)
+       @stop-complete?
+       (let [app-context (tk-app/app-context app)]
+         (swap! app-context assoc :JRubyPuppetService {})
+         (tk-internal/run-lifecycle-fn! app-context tk-services/init "init" :JRubyPuppetService jruby-service)
+         (tk-internal/run-lifecycle-fn! app-context tk-services/start "start" :JRubyPuppetService jruby-service))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -369,6 +369,10 @@
        (jruby-protocol/return-instance jruby-service jruby-instance :i-want-this-instance)
        @stop-complete?
        (let [app-context (tk-app/app-context app)]
+         ;; We have to re-initialize the JRubyPuppetService here because
+         ;; otherwise the tk-app/stop that is included in the
+         ;; with-puppetserver-running macro will fail, as the
+         ;; JRubyPuppetService is already stopped.
          (swap! app-context assoc :JRubyPuppetService {})
          (tk-internal/run-lifecycle-fn! app-context tk-services/init "init" :JRubyPuppetService jruby-service)
          (tk-internal/run-lifecycle-fn! app-context tk-services/start "start" :JRubyPuppetService jruby-service))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -90,13 +90,14 @@
                                  :test-pool-population)
                                context))]
 
-      ; Bootstrap TK, causing the 'init' function above to be executed.
-      (tk/boot-services-with-config
+      (ks-testutils/with-no-jvm-shutdown-hooks
+       ; Bootstrap TK, causing the 'init' function above to be executed.
+       (tk/boot-services-with-config
         (conj default-services test-service)
         (jruby-service-test-config 1))
 
-      ; If execution gets here, the test passed.
-      (is (true? true)))))
+       ; If execution gets here, the test passed.
+       (is (true? true))))))
 
 (deftest test-with-jruby-puppet
   (testing "the `with-jruby-puppet macro`"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -40,7 +40,7 @@
 
 (deftest test-error-during-init
   (testing
-   (str "If there as an exception while putting a JRubyPuppet instance in "
+   (str "If there is an exception while putting a JRubyPuppet instance in "
         "the pool the application should shut down.")
     (logging/with-test-logging
      (with-redefs [jruby-internal/create-pool-instance!

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -198,11 +198,13 @@
               pool-context (:pool-context context)]
           (let [jrubies (jruby-testutils/drain-pool pool-context pool-size)]
             (is (= 1 (count jrubies)))
-            (is (every? jruby-schemas/jruby-puppet-instance? jrubies)))
-          (let [test-start-in-millis (System/currentTimeMillis)]
-            (is (nil? (jruby-protocol/borrow-instance service :test-borrow-timeout-configuration)))
-            (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout))
-            (is (= (:borrow-timeout context) timeout)))))))
+            (is (every? jruby-schemas/jruby-puppet-instance? jrubies))
+            (let [test-start-in-millis (System/currentTimeMillis)]
+              (is (nil? (jruby-protocol/borrow-instance service :test-borrow-timeout-configuration)))
+              (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout))
+              (is (= (:borrow-timeout context) timeout)))
+            ; Test cleanup. This instance needs to be returned so that the stop can complete.
+            (doseq [inst jrubies] (jruby-protocol/return-instance service inst :test)))))))
 
   (testing (str ":borrow-timeout defaults to " jruby-core/default-borrow-timeout " milliseconds")
     (bootstrap/with-app-with-config


### PR DESCRIPTION
With https://github.com/puppetlabs/trapperkeeper/pull/198, puppet-server may begin receiving HUP signals which will cause it to shut down and restart. Without these commits, that results in leaks of scripting containers. This PR adds a stop function to the jruby puppet service that cleans up the existing jruby pools during a shutdown. Any agents connecting during a shutdown will be given a 503 if the webserver is still up.