### PR TITLE
Revert "(QENG-3181) Use beaker-hostgenerator instead of sqa-utils."

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ gem 'jira-ruby', :group => :development
 group :test do
   gem 'rspec'
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.14.0')
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
+  if ENV['GEM_SOURCE'] =~ /rubygems\.delivery\.puppetlabs\.net/
+    gem 'sqa-utils', '0.13.3'
+  end
   gem 'httparty'
   gem 'uuidtools'
 end

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -34,15 +34,14 @@ Copy/modify the local RHEL-7 host config at
 basic 2-node configuration.
 
 Please note, the most recent host configurations can be generated with the
-`beaker-hostgenerator` command available from the `beaker-hostgenerator` gem.
-Generating a new host configuration takes the form of `bundle exec
-beaker-hostgenerator redhat7-64ma`
+`genconfig` command available from the `sqa-utils` gem.  Generating a new host
+configuration takes the form of `bundle exec genconfig redhat7-64ma`
 
 The host expression is a bit strange and is parsed as per the documentation at
-`bundle exec beaker-hostgenerator --help`.  See also [the
-source][beaker-hostgenerator].
+`bundle exec genconfig --help`.  See also [the
+source][genconfig].
 
-[beaker-hostgenerator]: https://github.com/puppetlabs/beaker-hostgenerator
+[genconfig]: https://github.com/puppetlabs/sqa-utils-gem/blob/76d8dbc/lib/genconfig/cli.rb#L20-L47
 
 #### Define the PACKAGE_BUILD_VERSION and PUPPET_VERSION environment variables
 

--- a/acceptance/scripts/generic/testrun.sh
+++ b/acceptance/scripts/generic/testrun.sh
@@ -14,7 +14,7 @@ export BEAKER_HELPER="acceptance/lib/helper.rb"
 
 bundle install --path vendor/bundle
 
-bundle exec beaker-hostgenerator $GENCONFIG_LAYOUT > $BEAKER_CONFIG
+bundle exec genconfig2 $GENCONFIG_LAYOUT > $BEAKER_CONFIG
 
 bundle exec beaker \
   --config $BEAKER_CONFIG \


### PR DESCRIPTION
Reverts puppetlabs/puppet-server#836