### PR TITLE
(SERVER-874) Add protocol for VersionedCodeService

### DIFF
--- a/src/clj/puppetlabs/services/protocols/versioned_code.clj
+++ b/src/clj/puppetlabs/services/protocols/versioned_code.clj
@@ -1,0 +1,8 @@
+(ns puppetlabs.services.protocols.versioned-code)
+
+(defprotocol VersionedCodeService
+  "A TK service for interacting with versioned puppet code."
+
+  (current-code-id
+   [this environment]
+   "Returns the current code id (representing the freshest code) for the given environment."))


### PR DESCRIPTION
This commit merely adds a protocol for VersionedCodeService but not an
implementation. The implementation will follow in SERVER-875.

This protocol is being exercised in https://github.com/puppetlabs/pe-puppet-server-extensions/pull/506