### PR TITLE
(MAINT) Fix ezbake clojure version conflict

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
-(def tk-version "1.1.1")
+(def clojure-version "1.7.0")
+(def tk-version "1.1.3")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
 (def ps-version "2.2.2-master-SNAPSHOT")
@@ -13,7 +14,7 @@
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure ~clojure-version]
 
                  ;; begin version conflict resolution dependencies
                  [puppetlabs/typesafe-config "0.1.4"]
@@ -103,7 +104,13 @@
 
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
 
-             :ezbake {:dependencies ^:replace [[puppetlabs/puppetserver ~ps-version]
+             :ezbake {:dependencies ^:replace [;; we need to explicitly specify the clojure version
+                                               ;; here, because without it, lein brings in its own
+                                               ;; version, and older versions of lein (such as version
+                                               ;; 2.5.1 that is used on our jenkins servers at the time
+                                               ;; of this writing) depend on clojure 1.6.
+                                               [org.clojure/clojure ~clojure-version]
+                                               [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
                       :plugins [[puppetlabs/lein-ezbake "0.3.21"]]


### PR DESCRIPTION
This commit adds an explicit clojure version to our ezbake configuration.
Without this, leiningen may bring in its own version of clojure, which
can vary depending on which version of lein you are running.

Also, this commit updates us to the latest trapperkeeper for improved
logging testutils.