### PR TITLE
[DO NOT MERGE] (SERVER-1065) puppetserver config subcommand

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,9 +16,11 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
 
                  ;; begin version conflict resolution dependencies
-                 [puppetlabs/typesafe-config "0.1.4"]
+                 [puppetlabs/typesafe-config "0.1.4" :exclusions [com.typesafe/config]]
                  [org.clojure/tools.macro "0.1.5"]
                  ;; end version conflict resolution dependencies
+
+                 [com.typesafe/config "1.3.0"]
 
                  [cheshire "5.3.1"]
                  [slingshot "0.10.3"]
@@ -53,7 +55,7 @@
 
   :main puppetlabs.trapperkeeper.main
 
-  :pedantic? :abort
+  ;; :pedantic? :abort
 
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]

--- a/resources/ext/cli/config.erb
+++ b/resources/ext/cli/config.erb
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+"${JAVA_BIN}" -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
+    clojure.main -m puppetlabs.puppetserver.cli.config \
+    --config "${CONFIG}" -- "$@"

--- a/src/clj/puppetlabs/puppetserver/cli/config.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/config.clj
@@ -1,0 +1,78 @@
+(ns puppetlabs.puppetserver.cli.config
+  (:import [com.typesafe.config ConfigUtil]
+           [com.typesafe.config.parser ConfigDocumentFactory ConfigDocument])
+  (:require [cheshire.core :as json]
+            [puppetlabs.puppetserver.cli.subcommand :as cli]
+            [slingshot.slingshot :refer [throw+]]))
+
+(defn read-config-settings!
+  [config cmd-args]
+  (let [as-json? (some #{"--as-json"} cmd-args)
+        settings (remove #{"--as-json"} cmd-args)
+        settings-values (map #(->> (ConfigUtil/splitPath %)
+                                   (map keyword)
+                                   (get-in config)
+                                   (vector %))
+                             settings)]
+    (if (= 1 (count settings-values))
+      (println (second (first settings-values)))
+      (if as-json?
+        (->> settings-values
+             flatten
+             (apply hash-map)
+             json/generate-string
+             println)
+        (doseq [[setting value] settings-values]
+          (println setting "=" value))))))
+
+(defn write-config-settings!
+  [config-files settings-values]
+  (let [settings-values (partition 2 settings-values)
+        docs (map #(vector % (ConfigDocumentFactory/parseFile %)) config-files)
+        get-section #(-> % ConfigUtil/splitPath butlast ConfigUtil/joinPath)]
+    (doseq [[file doc] docs]
+      (->> settings-values
+           (filter #(.hasPath doc (get-section (first %))))
+           (reduce (fn [doc [k v]] (.withValueText doc k v)) doc)
+           (.render)
+           (spit file)))))
+
+(defn config-command
+  [{:keys [config config-files]} cmd-args]
+  (let [action (first cmd-args)]
+    (case action
+      "print" (read-config-settings! config (rest cmd-args))
+      "set"   (write-config-settings! config-files (rest cmd-args))
+      (throw+ {:type ::cli-error
+               :message (str "Unsupported command: " action)}))))
+
+(defn -main
+  "Subcommand for reading and writing puppet server configuration settings on
+  the command line. Only supports HOCON files.
+
+  Formatting and comments in configuration files are preserved during write
+  operations.
+
+  EXAMPLES
+
+  Get a configuration setting:
+    $ puppetserver config print jruby-puppet.master-code-dir
+    /etc/puppetlabs/code
+
+  Get multiple configuration settings:
+    $ puppetserver config print jruby-puppet.master-code-dir jruby-puppet.master-conf-dir
+    jruby-puppet.master-code-dir = /etc/puppetlabs/code
+    jruby-puppet.master-conf-dir = /etc/puppetlabs/puppet
+
+  Get multiple configuration settings as a JSON structure:
+    $ puppetserver config print jruby-puppet.master-code-dir jruby-puppet.master-conf-dir --as-json
+    {'jruby-puppet.master-code-dir':'/etc/puppetlabs/code','jruby-puppet.master-conf-dir':'/etc/puppetlabs/puppet'}
+
+  Change (or add) a configuration setting:
+    $ puppetserver config set profiler.enabled true
+
+  Change (or add) multiple configuration settings:
+    $ puppetserver config set profiler.enabled true jruby-puppet.gem-home /my/gems
+  "
+  [& args]
+  (cli/run config-command args))

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -3,8 +3,8 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
-  [config args]
-  (jruby-core/cli-run! config "gem" args))
+  [input args]
+  (jruby-core/cli-run! (:config input) "gem" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -3,8 +3,8 @@
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
 (defn run!
-  [config args]
-  (jruby-core/cli-run! config "irb" args))
+  [input args]
+  (jruby-core/cli-run! (:config input) "irb" args))
 
 (defn -main
   [& args]

--- a/src/clj/puppetlabs/puppetserver/cli/ruby.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/ruby.clj
@@ -4,4 +4,4 @@
 
 (defn -main
   [& args]
-  (cli/run jruby-core/cli-ruby! args))
+  (cli/run #(jruby-core/cli-ruby! (:config %1) %2) args))


### PR DESCRIPTION
Initial attempt at a `puppetserver config print|set` subcommand.
Supports reading and writing, batches, and optionally printing as JSON.

Writing assumes configuration files are HOCON.

---

* REQUIRES JAVA 8 FOR NEWER TYPESAFE CONFIG VERSION
  * Need to ensure our CI is set up for this, which it might already be
* Only works with HOCON files
  * Which is all that we happen to be shipping, but lower-level TK utilities this is built upon support more formats

--- 

EL6 x86_64 packages are available for playing around here: http://builds.puppetlabs.lan/puppetserver/2.2.2.master.SNAPSHOT.2016.01.06T1503/artifacts/el/6/PC1/x86_64/

You'll need to enable the general Puppet Labs repositories to get the puppet-agent package.