### PR TITLE
(MAINT) Rename `clojure-version` to avoid shadowing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def clojure-version "1.7.0")
+(def clj-version "1.7.0")
 (def tk-version "1.1.3")
 (def tk-jetty-version "1.3.1")
 (def ks-version "1.1.0")
@@ -14,7 +14,7 @@
 (defproject puppetlabs/puppetserver ps-version
   :description "Puppet Server"
 
-  :dependencies [[org.clojure/clojure ~clojure-version]
+  :dependencies [[org.clojure/clojure ~clj-version]
 
                  ;; begin version conflict resolution dependencies
                  [puppetlabs/typesafe-config "0.1.4"]
@@ -109,7 +109,7 @@
                                                ;; version, and older versions of lein (such as version
                                                ;; 2.5.1 that is used on our jenkins servers at the time
                                                ;; of this writing) depend on clojure 1.6.
-                                               [org.clojure/clojure ~clojure-version]
+                                               [org.clojure/clojure ~clj-version]
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]


### PR DESCRIPTION
In a recent PR, we introduced a var called `clojure-version` in
the project.clj, to coordinate our references to our clojure
dependency version.  It turns out that the name `clojure-version`
is already in use in `clojure.core`, so this var results in a
warning that we are shadowing the upstream var.

This commit changes the var name to `clj-version`, so that we
will no longer be shadowing the built-in name.