### PR TITLE
(SERVER-1091) Add .isLocked() method for JRubyPool

### DIFF
--- a/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/JRubyPool.java
@@ -307,6 +307,19 @@ public final class JRubyPool<E> implements LockablePool<E> {
     }
 
     @Override
+    public boolean isLocked() {
+        boolean locked;
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            locked = isPoolLockHeld();
+        } finally {
+            lock.unlock();
+        }
+        return locked;
+    }
+
+    @Override
     public void unlock() {
         final ReentrantLock lock = this.queueLock;
         lock.lock();

--- a/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/puppetserver/pool/LockablePool.java
@@ -149,6 +149,15 @@ public interface LockablePool<E> {
     */
     void lock() throws InterruptedException;
 
+    /**
+     * Returns whether or not the pool is currently locked.  Note that the
+     * value returned may no longer be accurate by the time it is consumed by
+     * the caller since activity on the pool, e.g., locks taken or released,
+     * is not implicitly held off until the caller has a chance to consume
+     * the value returned from a call to this method.
+     */
+    boolean isLocked();
+
    /**
     * Release the exclusive pool lock so that other threads may begin to
     * perform borrow operations again.  Note that this method must be called


### PR DESCRIPTION
This commit adds an .isLocked() method to the JRubyPool, mostly for ease
of use in upstream tests for detecting whether or not the pool is
locked.