### PR TITLE
(SERVER-1097) Use timed waits for lockable-pool-test promises

### DIFF
--- a/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/puppetserver/lockable_pool_test.clj
@@ -3,6 +3,10 @@
   (:import (com.puppetlabs.puppetserver.pool JRubyPool)
            (java.util.concurrent TimeUnit ExecutionException)))
 
+(defn timed-deref
+  [ref]
+  (deref ref 10000 :timed-out))
+
 (defn create-empty-pool
   [size]
   (JRubyPool. size))
@@ -60,7 +64,8 @@
                               (.lock pool)
                               (deliver lock-acquired? true)
                               @unlock?
-                              (.unlock pool))]
+                              (.unlock pool)
+                              true)]
       @future-started?
       (testing "pool.lock() blocks until all instances are returned to the pool"
         (is (not (realized? lock-acquired?)))
@@ -73,11 +78,13 @@
           (is (not (realized? lock-acquired?)))
           (.releaseItem pool (nth instances 2)))
 
-        @lock-acquired?
+        (is (true? (timed-deref lock-acquired?))
+            "timed out waiting for the lock to be acquired")
         (is (not (realized? lock-thread)))
         (is (.isLocked pool))
         (deliver unlock? true)
-        @lock-thread
+        (is (true? (timed-deref lock-thread))
+            "timed out waiting for the lock thread to finish")
         (is (not (.isLocked pool))))
 
       (testing "borrows may be resumed after unlock()"
@@ -99,7 +106,8 @@
                               (.lock pool)
                               (deliver lock-acquired? true)
                               @unlock?
-                              (.unlock pool))]
+                              (.unlock pool)
+                              true)]
       @future-started?
       (testing "pool.lock() blocks until borrowed instances are unregistered"
         (is (not (realized? lock-thread)))
@@ -110,17 +118,20 @@
           (is (not (realized? lock-thread)))
           (.unregister pool (second instances)))
 
-        @lock-acquired?
+        (is (true? (timed-deref lock-acquired?))
+            "timed out waiting for the lock thread to be acquired"))
         (is (not (realized? lock-thread)))
         (is (.isLocked pool))
         (deliver unlock? true)
-        @lock-thread
-        (is (not (.isLocked pool)))))
+        (is (true? (timed-deref lock-thread))
+            "timed out waiting for the lock thread to finish"))
+        (is (not (.isLocked pool)))
 
     (let [future-started? (promise)
           last-instance (.borrowItem pool)
           lock-thread (future (deliver future-started? true)
-                              (.lock pool))]
+                              (.lock pool)
+                              true)]
       @future-started?
       (testing "pool.lock() blocks until last borrowed instance is unregistered"
         (is (not (realized? lock-thread)))
@@ -129,7 +140,8 @@
                       "is being executed")
           (.unregister pool last-instance))
 
-        @lock-thread
+        (is (true? (timed-deref lock-thread))
+            "timed out waiting for the lock thread to finish")
         (is (.isLocked pool))))))
 
 (deftest pool-lock-blocks-borrows-test
@@ -145,7 +157,8 @@
                                 (.lock pool)
                                 (deliver lock-acquired? true)
                                 @unlock?
-                                (.unlock pool))]
+                                (.unlock pool)
+                                true)]
         @lock-thread-started?
         (is (not (realized? lock-acquired?)))
         (let [borrow-after-lock-requested-thread-started? (promise)
@@ -154,12 +167,14 @@
               (future (deliver borrow-after-lock-requested-thread-started? true)
                       (let [instance (.borrowItem pool)]
                         (deliver borrow-after-lock-requested-instance-acquired? true)
-                        (.releaseItem pool instance)))]
+                        (.releaseItem pool instance))
+                      true)]
           @borrow-after-lock-requested-thread-started?
           (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
 
           (return-instances pool instances)
-          @lock-acquired?
+          (is (true? (timed-deref lock-acquired?))
+              "timed out waiting for the lock acquired thread to start")
           (is (.isLocked pool))
           (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
           (is (not (realized? lock-thread)))
@@ -167,20 +182,35 @@
           (let [borrow-after-lock-acquired-thread-started? (promise)
                 borrow-after-lock-acquired-instance-acquired? (promise)
                 borrow-after-lock-acquired-thread
-                (future (deliver borrow-after-lock-acquired-thread-started? (promise))
+                (future (deliver borrow-after-lock-acquired-thread-started?
+                                 true)
                         (let [instance (.borrowItem pool)]
                           (deliver borrow-after-lock-acquired-instance-acquired? true)
-                          (.releaseItem pool instance)))]
+                          (.releaseItem pool instance))
+                        true)]
             @borrow-after-lock-acquired-thread-started?
             (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
 
             (deliver unlock? true)
-            @lock-thread
-            @borrow-after-lock-requested-instance-acquired?
-            @borrow-after-lock-requested-thread
-            @borrow-after-lock-acquired-instance-acquired?
-            @borrow-after-lock-acquired-thread
-            (is (not (.isLocked pool)))))))))
+
+            (is (true? (timed-deref lock-thread))
+                "timed out waiting for the lock thread to finish")
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-instance-acquired?))
+                (str "timed out waiting for the borrow after lock requested "
+                     "to be completed"))
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-thread))
+                (str "timed out waiting for the borrow after lock requested "
+                     "thread to finish"))
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-instance-acquired?))
+                "timed out waiting for the borrow after lock acquired")
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-thread))
+                (str "timed out waiting for the borrow after lock acquired "
+                     "thread to finish")))))
+            (is (not (.isLocked pool))))))
 
 (deftest pool-lock-supersedes-existing-borrows-test
   (testing "if there are pending borrows when pool.lock() is called, they aren't fulfilled until after unlock()"
@@ -191,7 +221,8 @@
           blocked-borrow-thread (future (deliver blocked-borrow-thread-started? true)
                                         (let [instance (.borrowItem pool)]
                                           (deliver blocked-borrow-thread-borrowed? true)
-                                          (.releaseItem pool instance)))
+                                          (.releaseItem pool instance))
+                                        true)
           lock-thread-started? (promise)
           lock-acquired? (promise)
           unlock? (promise)
@@ -199,7 +230,8 @@
                               (.lock pool)
                               (deliver lock-acquired? true)
                               @unlock?
-                              (.unlock pool))]
+                              (.unlock pool)
+                              true)]
       @blocked-borrow-thread-started?
       @lock-thread-started?
       (is (not (realized? blocked-borrow-thread-borrowed?)))
@@ -208,14 +240,17 @@
       (return-instances pool instances)
       (is (not (realized? blocked-borrow-thread-borrowed?)))
       (is (not (realized? lock-thread)))
-      @lock-acquired?
+      (is (true? (timed-deref lock-acquired?))
+          "timed out waiting for the lock to be acquired")
       (is (.isLocked pool))
 
       (deliver unlock? true)
-      @lock-thread
-      @blocked-borrow-thread-borrowed?
-      @blocked-borrow-thread
-
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (true? (timed-deref blocked-borrow-thread-borrowed?))
+          "timed out waiting for the borrow to complete")
+      (is (true? (timed-deref blocked-borrow-thread))
+          "timed out waiting for the borrow thread to complete")
       (is (not (.isLocked pool))))))
 
 (deftest pool-lock-reentrant-for-borrow-from-locking-thread
@@ -244,11 +279,13 @@
             borrow-thread-1 (future (deliver borrow-thread-started-1? true)
                                     (let [instance (.borrowItem pool)]
                                       (deliver borrow-thread-borrowed-1? true)
-                                      (.releaseItem pool instance)))
+                                      (.releaseItem pool instance))
+                                    true)
             borrow-thread-2 (future (deliver borrow-thread-started-2? true)
                                     (let [instance (.borrowItem pool)]
                                       (deliver borrow-thread-borrowed-2? true)
-                                      (.releaseItem pool instance)))]
+                                      (.releaseItem pool instance))
+                                    true)]
         @borrow-thread-started-1?
         @borrow-thread-started-2?
         (is (not (realized? borrow-thread-borrowed-1?)))
@@ -260,9 +297,11 @@
 
         (is (true? true))
         (.unlock pool)
-        @borrow-thread-1
-        @borrow-thread-2
-        (is (not (.isLocked pool)))))))
+        (is (true? (timed-deref borrow-thread-1))
+            "timed out waiting for first borrow thread to finish")
+        (is (true? (timed-deref borrow-thread-2))
+            "timed out waiting for second borrow thread to finish"))
+        (is (not (.isLocked pool))))))
 
 (deftest pool-lock-reentrant-for-many-locks-test
   (testing "multiple threads cannot lock the pool while it is already locked"
@@ -277,21 +316,23 @@
             lock-thread-1 (future (deliver lock-thread-started-1? true)
                                   (.lock pool)
                                   (deliver lock-thread-locked-1? true)
-                                  (.unlock pool))
+                                  (.unlock pool)
+                                  true)
             lock-thread-2 (future (deliver lock-thread-started-2? true)
                                   (.lock pool)
                                   (deliver lock-thread-locked-2? true)
-                                  (.unlock pool))]
+                                  (.unlock pool)
+                                  true)]
         @lock-thread-started-1?
         @lock-thread-started-2?
         (is (not (realized? lock-thread-locked-1?)))
         (is (not (realized? lock-thread-locked-2?)))
         (.unlock pool)
-        (is (true? true))
-        @lock-thread-1
-        (is (true? true))
-        @lock-thread-2
-        (is (not (.isLocked pool)))))))
+        (is (true? (timed-deref lock-thread-1))
+            "timed out waiting for first lock thread to finish")
+        (is (true? (timed-deref lock-thread-2))
+            "timed out waiting for second lock thread to finish"))
+        (is (not (.isLocked pool))))))
 
 (deftest pool-lock-not-held-after-thread-interrupt
   (let [pool (create-populated-pool 1)
@@ -304,9 +345,10 @@
     (testing (str "write locker's thread can be interrupted while waiting for "
                   "instances to be returned")
       (.interrupt @lock-thread-obj)
-      (is (thrown? ExecutionException @lock-thread))
-      (is (not (realized? lock-thread-locked?)))
-      (is (not (.isLocked pool))))
+      (is (thrown? ExecutionException (timed-deref lock-thread)))
+      (is (not (realized? lock-thread-locked?))))
+      (is (not (.isLocked pool)))
+
     (.releaseItem pool item)
     (testing "new write lock can be taken after prior write lock interrupted"
       (.lock pool)
@@ -323,12 +365,14 @@
           lock-thread (future (.lock pool)
                               (deliver lock-started? true)
                               @unlock?
-                              (.unlock pool))]
+                              (.unlock pool)
+                              true)]
       @lock-started?
       (is (.isLocked pool))
       (is (thrown? IllegalStateException (.unlock pool)))
       (deliver unlock? true)
-      @lock-thread
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for lock thread to finish")
       (is (not (.isLocked pool))))))
 
 (deftest pool-release-item-test
@@ -343,14 +387,19 @@
       (is (not (.isLocked pool)))
       (.lock pool)
       (is (.isLocked pool))
-      (is (nil? @(future (.borrowItemWithTimeout pool
-                                                 1
-                                                 TimeUnit/MICROSECONDS))))
+      (is (nil? (timed-deref
+                  (future (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout in lock to finish")
       (.unlock pool)
-      (is (not (nil? @(future (.borrowItemWithTimeout pool
+      (is (not (nil? (timed-deref
+                      (future (.borrowItemWithTimeout pool
                                                       1
                                                       TimeUnit/MICROSECONDS)))))
+          "timed out waiting for borrow with timeout after unlock to finish")
       (is (not (.isLocked pool)))))
+       
   (testing (str "releaseItem call with value 'true' returns item to "
                 "pool and allows pool to still be lockable")
     (let [pool (create-populated-pool 2)
@@ -361,13 +410,17 @@
       (is (not (.isLocked pool)))
       (.lock pool)
       (is (.isLocked pool))
-      (is (nil? @(future (.borrowItemWithTimeout pool
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
                                                  1
                                                  TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout in lock to finish")
       (.unlock pool)
-      (is (not (nil? @(future (.borrowItemWithTimeout pool
+      (is (not (nil? (timed-deref
+                      (future (.borrowItemWithTimeout pool
                                                       1
                                                       TimeUnit/MICROSECONDS)))))
+          "timed out waiting for borrow with timeout after unlock to finish")
       (is (not (.isLocked pool))))))
 
 (deftest pool-borrow-blocks-borrow-when-pool-empty
@@ -379,24 +432,30 @@
           borrow-thread (future (deliver borrow-thread-started? true)
                                 (let [instance (.borrowItem pool)]
                                   (deliver borrow-thread-borrowed? true)
-                                  (.releaseItem pool instance)))]
+                                  (.releaseItem pool instance))
+                                true)]
       @borrow-thread-started?
       (is (not (realized? borrow-thread-borrowed?)))
       (.releaseItem pool item)
-      @borrow-thread
-      (is (true? true)))))
+      (is (true? (timed-deref borrow-thread))
+          "timed out waiting for borrow thread to finish"))))
 
 (deftest pool-timed-borrows-test
   (testing "pool borrows with timeout"
     (let [pool (create-populated-pool 1)
           item (.borrowItem pool)]
       (testing "borrow times out and returns nil when pool is empty"
-        (is (nil? (.borrowItemWithTimeout pool 1 TimeUnit/MICROSECONDS))))
+        (is (nil? (timed-deref
+                   (future (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/MICROSECONDS))))))
       (.releaseItem pool item)
       (testing "borrow succeeds when pool is non-empty"
-        (is (identical? item (.borrowItemWithTimeout pool
-                                                     1
-                                                     TimeUnit/MICROSECONDS)))))))
+        (is (identical? item (timed-deref
+                              (future (.borrowItemWithTimeout
+                                       pool
+                                       1
+                                       TimeUnit/MICROSECONDS)))))))))
 
 (deftest pool-can-do-blocking-borrow-after-borrow-timed-out
   (testing "can do blocking borrow from pool after previous borrow timed out"
@@ -408,12 +467,13 @@
             borrow-thread (future (deliver borrow-thread-started? true)
                                   (let [instance (.borrowItem pool)]
                                     (deliver borrow-thread-borrowed? true)
-                                    (.releaseItem pool instance)))]
+                                    (.releaseItem pool instance))
+                                  true)]
         @borrow-thread-started?
         (is (not (realized? borrow-thread-borrowed?)))
         (.releaseItem pool item)
-        @borrow-thread
-        (is (true? true))))))
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")))))
 
 (deftest pool-can-do-blocking-borrow-after-borrow-timed-out-during-lock
   (testing (str "can do a blocking borrow from pool after previous borrow "
@@ -421,19 +481,24 @@
     (let [pool (create-populated-pool 1)]
       (.lock pool)
       (is (.isLocked pool))
-      (is (nil? @(future (.borrowItemWithTimeout pool
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
                                                  1
                                                  TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout to finish")
+
       (let [borrow-thread-started? (promise)
             borrow-thread-borrowed? (promise)
             borrow-thread (future (deliver borrow-thread-started? true)
                                   (let [instance (.borrowItem pool)]
                                     (deliver borrow-thread-borrowed? true)
-                                    (.releaseItem pool instance)))]
+                                    (.releaseItem pool instance))
+                                  true)]
         @borrow-thread-started?
         (is (not (realized? borrow-thread-borrowed?)))
         (.unlock pool)
-        @borrow-thread
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")
         (is (not (.isLocked pool)))))))
 
 (deftest pool-can-borrow-after-borrow-interrupted-during-lock
@@ -460,25 +525,28 @@
                        (.lock pool)
                        (deliver lock-thread-locked? true)
                        @unlock?
-                       (.unlock pool))]
+                       (.unlock pool)
+                       true)]
       @lock-thread-started?
       (.releaseItem pool borrow-1)
-      @lock-thread-locked?
-      (is (.isLocked pool))
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
+      (is (true? (.isLocked pool)))
       ;; Interrupt the second borrow thread so that it will stop waiting for the
       ;; pool to be not empty and not locked.
       (.interrupt borrow-thread-obj-2)
-      (is (thrown? ExecutionException @borrow-thread-2)
+      (is (thrown? ExecutionException (timed-deref borrow-thread-2))
           "second borrow could not be interrupted")
       (is (not (realized? borrow-thread-3)))
       (deliver unlock? true)
-      @lock-thread
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
       (is (not (.isLocked pool)))
       ;; If the third borrow doesn't block indefinitely, we've confirmed that
       ;; the interruption of the second borrow while the write lock was
       ;; held did not adversely affect the ability of the third borrow call
       ;; to return.
-      (is (identical? borrow-1 @borrow-thread-3)
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
           (str "did not get back the same instance from the third borrow"
                "attempt as was returned from the first borrow attempt")))))
 
@@ -510,17 +578,20 @@
                        (.lock pool)
                        (deliver lock-thread-locked? true)
                        @unlock?
-                       (.unlock pool))]
+                       (.unlock pool)
+                       true)]
       @lock-thread-started?
       (.releaseItem pool borrow-1)
-      @lock-thread-locked?
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
       (is (.isLocked pool))
-      (is (nil? @borrow-thread-2)
+      (is (nil? (timed-deref borrow-thread-2))
           "second borrow attempt did not time out")
       (deliver unlock? true)
-      @lock-thread
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
       (is (not (.isLocked pool)))
-      (is (identical? borrow-1 @borrow-thread-3)
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
           (str "did not get back the same instance from the third borrow"
                "attempt as was returned from the first borrow attempt")))))
 


### PR DESCRIPTION
This commit modifies logic in the `lockable-pool-test` tests to use a
timed wait with assertions for all promises other than just ones related
to thread start synchronization.  Hopefully, this would help better
pinpoint any test failures when they occur, as opposed to just having a
test potentially hang and be aborted by a test runner without any better
information to help diagnose the problem.