### PR TITLE
(SERVER-1071) Make legacy routes tolerant of multi-server config

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -134,8 +134,16 @@
   [master-ns :- schema/Keyword
    config-route]
   (cond
-    (and (map? config-route) (contains? config-route :master-routes))
-    (:master-routes config-route)
+    ;; if the route config is a map, we need to determine whether it's the
+    ;; new-style multi-server config (where there will be a `:route` key and a
+    ;; `:server`, key), or the old style where there is a single key that is
+    ;; assumed to be our hard-coded route id (`:master-routes`).
+    ;; It should be possible to delete this hack (perhaps this entire function)
+    ;; when we remove support for legacy routes.
+    (and (map? config-route) (or (contains? config-route :route)
+                                 (contains? config-route :master-routes)))
+    (or (:route config-route)
+        (:master-routes config-route))
 
     (string? config-route)
     config-route

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -55,6 +55,15 @@
        ~config
        ~@body)))
 
+(defmacro with-puppetserver-running-with-config
+  [app config & body]
+  `(let [services# (tk-bootstrap/parse-bootstrap-config! ~dev-bootstrap-file)]
+     (tk-testutils/with-app-with-config
+      ~app
+      services#
+      ~config
+      ~@body)))
+
 (defmacro with-puppetserver-running
   [app config-overrides & body]
   (let [config (load-dev-config-with-overrides config-overrides)]

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -17,6 +17,7 @@
             [puppetlabs.services.puppet-admin.puppet-admin-service :as admin]
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled-ca]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]))
 
 (def test-resources-dir
@@ -43,8 +44,36 @@
 (deftest ^:integration old-master-route-config
   (testing "The old map-style route configuration map still works."
     (bootstrap/with-puppetserver-running app
-      {:web-router-service {::master-service/master-service {:master-routes "/puppet"}}}
+      {:web-router-service
+       {:puppetlabs.services.master.master-service/master-service
+        {:master-routes "/puppet"}}}
       (is (= 200 (:status (http-get "/puppet/v3/node/localhost?environment=production"))))))
+
+  (testing "The new map-style multi-server route configuration map still works."
+    ;; For a multi-server config, we need to remove the existing webserver
+    ;; config from the sample config.  Since `with-puppetserver-running` just does
+    ;; a deep merge, there's no clean way to do this, so we just load the
+    ;; config ourselves to give us more control to modify it.
+    (let [default-config (bootstrap/load-dev-config-with-overrides {})
+          webserver-config (:webserver default-config)]
+      ;; use `-with-config` variant, so that we can pass in the entire config map
+      (bootstrap/with-puppetserver-running-with-config
+       app
+       (-> default-config
+           ;; remove the 'root' webserver config, which wouldn't exist in a
+           ;; multi-server config
+           (dissoc :webserver)
+           ;; add the webserver config back in with an id of `:puppet-server`
+           (assoc :webserver {:puppet-server
+                              (assoc webserver-config
+                                :default-server true)})
+           (ks/deep-merge
+            {:web-router-service
+             ;; set the master service to use the map-based multi-server-style config
+             {:puppetlabs.services.master.master-service/master-service
+              {:route "/puppet"
+               :server "puppet-server"}}}))
+       (is (= 200 (:status (http-get "/puppet/v3/node/localhost?environment=production")))))))
 
   (testing "An exception is thrown if an improper master service route is found."
     (logutils/with-test-logging


### PR DESCRIPTION
Prior to this commit, the legacy routes services made some
hard-coded assumptions about the master's route configuration that
made it incompatible with the recommended webrouting configuration
style for multi-webserver configurations.  This commit adds a few
more checks to detect that case, and make the services compatible
with the multi-server configuration style.  This is necessary in
order for us to be able to run PE Puppet Server in-process with
other PE web apps.