### PR TITLE
(maint) Create puppetlabs.testutils namespace

### DIFF
--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -1,11 +1,9 @@
 (ns puppetlabs.general-puppet.general-puppet-int-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.puppet-environments-int-test :refer
-             [write-site-pp-file get-catalog catalog-contains? post-catalog]]
-            [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [me.raynes.fs :as fs]))
+            [me.raynes.fs :as fs]
+            [puppetlabs.testutils :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as logging]))
 
 (def test-resources-dir
   (fs/absolute-path "./dev-resources/puppetlabs/general_puppet/general_puppet_int_test"))
@@ -15,7 +13,7 @@
   (str test-resources-dir "/" script-name))
 
 (use-fixtures :once
-              (jruby-testutils/with-puppet-conf
+              (testutils/with-puppet-conf
                (fs/file test-resources-dir "puppet.conf")))
 
 (def num-jrubies 1)
@@ -26,15 +24,15 @@
     ; This function calls into Puppet::Util::Execution.execute(), which calls into
     ; our shell-utils code via Puppet::Util::ExecutionStub which we call in
     ; Puppet::Server::Execution.
-    (write-site-pp-file
+    (testutils/write-site-pp-file
      (format "$a = generate('%s', 'this command echoes a thing'); notify {$a:}"
              (script-path "echo")))
     (bootstrap/with-puppetserver-running
      app {:jruby-puppet
           {:max-active-instances num-jrubies}}
      (testing "calling generate successfully executes shell command"
-       (let [catalog (get-catalog)]
-         (is (catalog-contains? catalog "Notify" "this command echoes a thing\n")))))))
+       (let [catalog (testutils/get-catalog)]
+         (is (testutils/catalog-contains? catalog "Notify" "this command echoes a thing\n")))))))
 
 (deftest ^:integration code-id-request-test
   (testing "code id is added to the request body for catalog requests"
@@ -46,7 +44,7 @@
           {:max-active-instances num-jrubies}
           :versioned-code
           {:code-id-command (script-path "echo")}}
-     (let [catalog (get-catalog)]
+     (let [catalog (testutils/get-catalog)]
        (is (= "production" (get catalog "code_id"))))))
   (testing "code id is added to the request body for catalog requests"
     ; As we have set code-id-command to echo, the code id will
@@ -57,7 +55,7 @@
           {:max-active-instances num-jrubies}
           :versioned-code
           {:code-id-command (script-path "echo")}}
-     (let [catalog (post-catalog)]
+     (let [catalog (testutils/post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
   (testing "code id is added to the request body for catalog requests"
     ; As we have set code-id-command to warn, the code id will
@@ -69,7 +67,7 @@
            {:max-active-instances num-jrubies}
            :versioned-code
            {:code-id-command (script-path "warn_echo_and_error")}}
-      (let [catalog (get-catalog)]
+      (let [catalog (testutils/get-catalog)]
         (is (nil? (get catalog "code_id")))
         (is (logged? #"Non-zero exit code returned while calculating code id." :error))
         (is (logged? #"Executed an external process which logged to STDERR: production" :warn)))))))

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [me.raynes.fs :as fs]
-            [puppetlabs.testutils :as testutils]
+            [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]))
 
 (def test-resources-dir

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -9,6 +9,7 @@
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.test :as schema-test]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.testutils :as testutils :refer [http-get]]
             [me.raynes.fs :as fs]
             [ring.util.codec :as ring-codec])
   (:import (java.io StringWriter)))
@@ -19,12 +20,7 @@
 (use-fixtures
   :once
   schema-test/validate-schemas
-  (jruby-testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
-
-(defn http-get [path]
-  (http-client/get
-    (str "https://localhost:8140/" path)
-    bootstrap/request-options))
+  (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 (deftest ^:integration legacy-auth-conf-used-when-legacy-auth-conf-true
   (testing "Authorization is done per legacy auth.conf when :use-legacy-auth-conf true"

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -9,7 +9,7 @@
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [schema.test :as schema-test]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.testutils :as testutils :refer [http-get]]
+            [puppetlabs.puppetserver.testutils :as testutils :refer [http-get]]
             [me.raynes.fs :as fs]
             [ring.util.codec :as ring-codec])
   (:import (java.io StringWriter)))

--- a/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/bootstrap_testutils.clj
@@ -29,10 +29,6 @@
 (def master-log-dir
   "./target/master-var/log")
 
-(defn pem-file
-  [& args]
-  (str (apply fs/file master-conf-dir "ssl" args)))
-
 (defn load-dev-config-with-overrides
   [overrides]
   (let [tmp-conf (ks/temp-file "puppet-server" ".conf")]
@@ -73,23 +69,3 @@
          services#
          ~config
          ~@body))))
-
-(defn pem-file
-  [& args]
-  (str (apply fs/file master-conf-dir "ssl" args)))
-
-(def ca-cert
-  (pem-file "certs" "ca.pem"))
-
-(def localhost-cert
-  (pem-file "certs" "localhost.pem"))
-
-(def localhost-key
-  (pem-file "private_keys" "localhost.pem"))
-
-(def request-options
-  {:ssl-cert    localhost-cert
-   :ssl-key     localhost-key
-   :ssl-ca-cert ca-cert
-   :headers     {"Accept" "pson"}
-   :as          :text})

--- a/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
@@ -3,7 +3,6 @@
     [clojure.test :refer :all]
     [puppetlabs.trapperkeeper.testutils.logging :refer :all]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-    [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
     [puppetlabs.puppetserver.testutils :as testutils]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.certificate-authority :as ca]

--- a/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
@@ -4,7 +4,7 @@
     [puppetlabs.trapperkeeper.testutils.logging :refer :all]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
     [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-    [puppetlabs.testutils :as testutils]
+    [puppetlabs.puppetserver.testutils :as testutils]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.certificate-authority :as ca]
     [puppetlabs.services.request-handler.request-handler-core :as request-handler]))

--- a/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
+++ b/test/integration/puppetlabs/puppetserver/error_handling_int_test.clj
@@ -4,12 +4,13 @@
     [puppetlabs.trapperkeeper.testutils.logging :refer :all]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
     [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+    [puppetlabs.testutils :as testutils]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.certificate-authority :as ca]
     [puppetlabs.services.request-handler.request-handler-core :as request-handler]))
 
 (use-fixtures :once
-              (jruby-testutils/with-puppet-conf
+              (testutils/with-puppet-conf
                 "./dev-resources/puppetlabs/puppetserver/error_handling_int_test/puppet.conf"))
 
 ;; Used in the test below.
@@ -38,9 +39,7 @@
           ;; between the ring handler and the JRuby layer, and called on every
           ;; request) to simply ignore any arguments and just throw an Exception.
           (with-redefs [request-handler/as-jruby-request just-throw-it]
-            (let [response (http-client/get
-                             "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
-                             bootstrap/request-options)]
+            (let [response (testutils/http-get "puppet/v3/catalog/localhost?environment=production")]
               (is (= 500 (:status response)))
               (is (= "Internal Server Error: java.lang.Exception: barf"
                      (:body response)))
@@ -49,9 +48,7 @@
         (testing "the CA API - in particular, one of the endpoints implemented via liberator"
           ;; Yes, this is weird - see comment above.
           (with-redefs [ca/get-certificate-status throw-npe]
-            (let [response (http-client/get
-                             "https://localhost:8140/puppet-ca/v1/certificate_status/localhost"
-                             bootstrap/request-options)]
+            (let [response (testutils/http-get "puppet-ca/v1/certificate_status/localhost")]
               (is (= 500 (:status response)))
               (is (= "Internal Server Error: java.lang.NullPointerException"
                      (:body response)))

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -2,7 +2,6 @@
   (:require [me.raynes.fs :as fs]
             [schema.core :as schema]
             [cheshire.core :as json]
-            [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.http.client.sync :as http-client])
   (:import (java.io File)))
 

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -1,4 +1,4 @@
-(ns puppetlabs.testutils
+(ns puppetlabs.puppetserver.testutils
   (:require [me.raynes.fs :as fs]
             [schema.core :as schema]
             [cheshire.core :as json]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -4,7 +4,7 @@
     [puppetlabs.kitchensink.core :as ks]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-    [puppetlabs.testutils :as testutils :refer
+    [puppetlabs.puppetserver.testutils :as testutils :refer
      [ca-cert localhost-cert localhost-key ssl-request-options http-get]]
     [puppetlabs.trapperkeeper.testutils.logging :as logutils]
     [schema.test :as schema-test]

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -4,7 +4,8 @@
     [puppetlabs.kitchensink.core :as ks]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-    [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+    [puppetlabs.testutils :as testutils :refer
+     [ca-cert localhost-cert localhost-key ssl-request-options http-get]]
     [puppetlabs.trapperkeeper.testutils.logging :as logutils]
     [schema.test :as schema-test]
     [me.raynes.fs :as fs]))
@@ -14,34 +15,15 @@
 
 (use-fixtures :once
               schema-test/validate-schemas
-              (jruby-testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
+              (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
-
-(def ca-cert
-  (bootstrap/pem-file "certs" "ca.pem"))
-
-(def localhost-cert
-  (bootstrap/pem-file "certs" "localhost.pem"))
-
-(def localhost-key
-  (bootstrap/pem-file "private_keys" "localhost.pem"))
-
-(def ssl-request-options
-  {:ssl-cert    localhost-cert
-   :ssl-key     localhost-key
-   :ssl-ca-cert ca-cert})
 
 (def ca-mount-points
   ["puppet-ca/v1/" ; puppet 4 style
    "production/" ; pre-puppet 4 style
    ])
-
-(defn http-get [path]
-  (http-client/get
-    (str "https://localhost:8140/" path)
-    bootstrap/request-options))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests

--- a/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
+++ b/test/integration/puppetlabs/services/certificate_authority/certificate_authority_int_test.clj
@@ -2,7 +2,6 @@
   (:require
     [clojure.test :refer :all]
     [puppetlabs.kitchensink.core :as ks]
-    [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
     [puppetlabs.puppetserver.testutils :as testutils :refer
      [ca-cert localhost-cert localhost-key ssl-request-options http-get]]

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -5,7 +5,6 @@
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-services]
-            [puppetlabs.trapperkeeper.bootstrap :as tk-bootstrap]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
@@ -24,31 +23,19 @@
             [puppetlabs.services.protocols.request-handler :as handler]
             [puppetlabs.services.request-handler.request-handler-core :as handler-core]
             [puppetlabs.ssl-utils.core :as ssl-utils]
-            [puppetlabs.kitchensink.testutils :as ks-testutils]))
+            [puppetlabs.kitchensink.testutils :as ks-testutils]
+            [puppetlabs.testutils :as testutils :refer
+             [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/jruby_pool_int_test")
 
 (use-fixtures :once
               schema-test/validate-schemas
-              (jruby-testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
+              (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
-
-(def ca-cert
-  (bootstrap/pem-file "certs" "ca.pem"))
-
-(def localhost-cert
-  (bootstrap/pem-file "certs" "localhost.pem"))
-
-(def localhost-key
-  (bootstrap/pem-file "private_keys" "localhost.pem"))
-
-(def ssl-request-options
-  {:ssl-cert    localhost-cert
-   :ssl-key     localhost-key
-   :ssl-ca-cert ca-cert})
 
 (def script-to-check-if-constant-is-defined
   "! $instance_id.nil?")
@@ -318,7 +305,7 @@
            (Thread/yield)))
        (is (= @call-seq [:init-bonus-service :start-bonus-service :stop-bonus-service :init-bonus-service :start-bonus-service]))
        (let [get-results (http-client/get "https://localhost:8140/puppet/v3/environments"
-                                          bootstrap/request-options)]
+                                          bootstrap/catalog-request-options)]
          (is (= 200 (:status get-results))))))))
 
 (deftest ^:integration test-503-when-app-shuts-down
@@ -360,8 +347,7 @@
            context (tk-services/service-context jruby-service)
            jruby-instance (jruby-protocol/borrow-instance jruby-service :i-want-this-instance)
            stop-complete? (future (tk-services/stop jruby-service context))
-           ping-environment #(http-client/get "https://localhost:8140/puppet/v3/environments"
-                                              bootstrap/request-options)]
+           ping-environment #(testutils/http-get "puppet/v3/environments")]
        (let [start (System/currentTimeMillis)]
          (while (and
                  (< (- (System/currentTimeMillis) start) 10000)

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -24,7 +24,7 @@
             [puppetlabs.services.request-handler.request-handler-core :as handler-core]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.kitchensink.testutils :as ks-testutils]
-            [puppetlabs.testutils :as testutils :refer
+            [puppetlabs.puppetserver.testutils :as testutils :refer
              [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -3,7 +3,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.testutils :as testutils :refer [ssl-request-options catalog-request-options get-catalog]]
+            [puppetlabs.puppetserver.testutils :as testutils :refer [ssl-request-options catalog-request-options get-catalog]]
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.kitchensink.core :as ks]

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -3,7 +3,8 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.puppetserver.testutils :as testutils :refer [ssl-request-options catalog-request-options get-catalog]]
+            [puppetlabs.puppetserver.testutils :as testutils :refer
+             [ssl-request-options catalog-request-options get-catalog]]
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.kitchensink.core :as ks]

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -8,34 +8,18 @@
             [clojure.test :refer :all]
             [me.raynes.fs :as fs]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-            [puppetlabs.http.client.sync :as http-client]))
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.testutils :as testutils :refer
+             [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/jruby/request_handler_test")
 
 (use-fixtures :once
               schema-test/validate-schemas
-              (jruby-testutils/with-puppet-conf (fs/file test-resources-dir
+              (testutils/with-puppet-conf (fs/file test-resources-dir
                                                          "puppet.conf")))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Utilities
-
-(def ca-cert
-  (bootstrap/pem-file "certs" "ca.pem"))
-
-(def localhost-cert
-  (bootstrap/pem-file "certs" "localhost.pem"))
-
-(def localhost-key
-  (bootstrap/pem-file "private_keys" "localhost.pem"))
-
-(def ssl-request-options
-  {:ssl-cert    localhost-cert
-   :ssl-key     localhost-key
-   :ssl-ca-cert ca-cert})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Tests

--- a/test/integration/puppetlabs/services/jruby/request_handler_test.clj
+++ b/test/integration/puppetlabs/services/jruby/request_handler_test.clj
@@ -10,7 +10,7 @@
             [schema.test :as schema-test]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.http.client.sync :as http-client]
-            [puppetlabs.testutils :as testutils :refer
+            [puppetlabs.puppetserver.testutils :as testutils :refer
              [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -1,10 +1,8 @@
 (ns puppetlabs.services.legacy-routes.legacy-routes-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-            [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.services.master.master-service :as master-service]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [me.raynes.fs :as fs]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.services.request-handler.request-handler-service :as handler]
@@ -18,7 +16,8 @@
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled-ca]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]))
+            [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]
+            [puppetlabs.testutils :as testutils :refer [http-get]]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test")
@@ -26,12 +25,7 @@
 (use-fixtures
   :once
   schema-test/validate-schemas
-  (jruby-testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
-
-(defn http-get [path]
-  (http-client/get
-    (str "https://localhost:8140" path)
-    bootstrap/request-options))
+  (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 (deftest ^:integration legacy-routes
   (testing "The legacy web routing service properly handles old routes."

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -17,7 +17,7 @@
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]
-            [puppetlabs.testutils :as testutils :refer [http-get]]))
+            [puppetlabs.puppetserver.testutils :as testutils :refer [http-get]]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/legacy_routes/legacy_routes_test")

--- a/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
+++ b/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
@@ -4,7 +4,6 @@
     [puppetlabs.kitchensink.core :as ks]
     [puppetlabs.http.client.sync :as http-client]
     [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
-    [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
     [puppetlabs.trapperkeeper.testutils.logging :as logutils]
     [schema.test :as schema-test]
     [me.raynes.fs :as fs]

--- a/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
+++ b/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
@@ -8,7 +8,7 @@
     [puppetlabs.trapperkeeper.testutils.logging :as logutils]
     [schema.test :as schema-test]
     [me.raynes.fs :as fs]
-    [puppetlabs.testutils :as testutils :refer
+    [puppetlabs.puppetserver.testutils :as testutils :refer
      [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir

--- a/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
+++ b/test/integration/puppetlabs/services/puppet_admin/puppet_admin_int_test.clj
@@ -7,31 +7,19 @@
     [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
     [puppetlabs.trapperkeeper.testutils.logging :as logutils]
     [schema.test :as schema-test]
-    [me.raynes.fs :as fs]))
+    [me.raynes.fs :as fs]
+    [puppetlabs.testutils :as testutils :refer
+     [ca-cert localhost-cert localhost-key ssl-request-options]]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/puppet_admin/puppet_admin_int_test")
 
 (use-fixtures :once
   schema-test/validate-schemas
-  (jruby-testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
+  (testutils/with-puppet-conf (fs/file test-resources-dir "puppet.conf")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
-
-(def ca-cert
-  (bootstrap/pem-file "certs" "ca.pem"))
-
-(def localhost-cert
-  (bootstrap/pem-file "certs" "localhost.pem"))
-
-(def localhost-key
-  (bootstrap/pem-file "private_keys" "localhost.pem"))
-
-(def ssl-request-options
-  {:ssl-cert    localhost-cert
-   :ssl-key     localhost-key
-   :ssl-ca-cert ca-cert})
 
 (def endpoints
   ["/environment-cache" "/jruby-pool"])

--- a/test/integration/puppetlabs/testutils.clj
+++ b/test/integration/puppetlabs/testutils.clj
@@ -103,37 +103,37 @@
   (count (filter #(catalog-contains? % resource-type resource-title) catalogs)))
 
 (schema/defn ^:always-validate with-puppet-conf-files
-             "Test fixture; Accepts a map with the following characteristics:
+  "Test fixture; Accepts a map with the following characteristics:
 
-             * keys are simple filenames (no paths) that will be created in puppet's $confdir
-             * values are paths to a test-specific file that should be copied to puppet's confdir,
-               a la `$confdir/<key>`.
+  * keys are simple filenames (no paths) that will be created in puppet's $confdir
+  * values are paths to a test-specific file that should be copied to puppet's confdir,
+    a la `$confdir/<key>`.
 
-             For each entry in the map, copies the files into $confdir, runs the test function,
-             and then deletes all of the files from $confdir.
+  For each entry in the map, copies the files into $confdir, runs the test function,
+  and then deletes all of the files from $confdir.
 
-             Optionally accepts a second argument `dest-dir`, which specifies the location
-             of Puppet's $confdir.  If this argument is not provided, defaults to
-             `testutils/conf-dir`."
-             ([puppet-conf-files]
-              (with-puppet-conf-files puppet-conf-files conf-dir))
-             ([puppet-conf-files :- {schema/Str (schema/pred (some-fn string? #(instance? File %)))}
-               dest-dir :- schema/Str]
+  Optionally accepts a second argument `dest-dir`, which specifies the location
+  of Puppet's $confdir.  If this argument is not provided, defaults to
+  `testutils/conf-dir`."
+  ([puppet-conf-files]
+   (with-puppet-conf-files puppet-conf-files conf-dir))
+  ([puppet-conf-files :- {schema/Str (schema/pred (some-fn string? #(instance? File %)))}
+    dest-dir :- schema/Str]
 
-              (let [target-paths (reduce
-                                  (fn [acc filename]
-                                    (assoc acc filename (fs/file dest-dir filename)))
-                                  {}
-                                  (keys puppet-conf-files))]
-                (fn [f]
-                  (doseq [filename (keys puppet-conf-files)]
-                    (fs/copy+ (get puppet-conf-files filename)
-                              (get target-paths filename)))
-                  (try
-                    (f)
-                    (finally
-                      (doseq [target-path (vals target-paths)]
-                        (fs/delete target-path))))))))
+   (let [target-paths (reduce
+                       (fn [acc filename]
+                         (assoc acc filename (fs/file dest-dir filename)))
+                       {}
+                       (keys puppet-conf-files))]
+     (fn [f]
+       (doseq [filename (keys puppet-conf-files)]
+         (fs/copy+ (get puppet-conf-files filename)
+                   (get target-paths filename)))
+       (try
+         (f)
+         (finally
+           (doseq [target-path (vals target-paths)]
+             (fs/delete target-path))))))))
 
 (defn with-puppet-conf
   "This function returns a test fixture that will copy a specified puppet.conf

--- a/test/integration/puppetlabs/testutils.clj
+++ b/test/integration/puppetlabs/testutils.clj
@@ -1,0 +1,146 @@
+(ns puppetlabs.testutils
+  (:require [me.raynes.fs :as fs]
+            [schema.core :as schema]
+            [cheshire.core :as json]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.http.client.sync :as http-client])
+  (:import (java.io File)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Default settings
+
+(def conf-dir
+  "./target/master-conf")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Certificates and keys
+
+(defn pem-file
+  [& args]
+  (str (apply fs/file conf-dir "ssl" args)))
+
+(def ca-cert
+  (pem-file "certs" "ca.pem"))
+
+(def localhost-cert
+  (pem-file "certs" "localhost.pem"))
+
+(def localhost-key
+  (pem-file "private_keys" "localhost.pem"))
+
+(def ssl-request-options
+  {:ssl-cert    localhost-cert
+   :ssl-key     localhost-key
+   :ssl-ca-cert ca-cert})
+
+(def catalog-request-options
+  (merge
+   ssl-request-options
+   {:headers     {"Accept" "pson"}
+    :as          :text}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Utilities
+
+(defn http-get
+  [path]
+  (http-client/get
+   (str "https://localhost:8140/" path) catalog-request-options))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Interacting with puppet code and catalogs
+
+(defn write-foo-pp-file
+  [foo-pp-contents]
+  (let [foo-pp-file (fs/file conf-dir
+                             "environments"
+                             "production"
+                             "modules"
+                             "foo"
+                             "manifests"
+                             "init.pp")]
+    (fs/mkdirs (fs/parent foo-pp-file))
+    (spit foo-pp-file foo-pp-contents)))
+
+(defn get-catalog
+  "Make an HTTP get request for a catalog."
+  []
+  (-> (http-client/get
+       "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
+       catalog-request-options)
+      :body
+      json/parse-string))
+
+(defn post-catalog
+  "Make an HTTP post request for a catalog."
+  []
+  (-> (http-client/post
+       "https://localhost:8140/puppet/v3/catalog/localhost"
+       (assoc-in (assoc catalog-request-options
+                   :body "environment=production")
+                 [:headers "Content-Type"] "application/x-www-form-urlencoded"))
+      :body
+      json/parse-string))
+
+(defn write-site-pp-file
+  [site-pp-contents]
+  (let [site-pp-file (fs/file conf-dir "environments" "production" "manifests" "site.pp")]
+    (fs/mkdirs (fs/parent site-pp-file))
+    (spit site-pp-file site-pp-contents)))
+
+(defn resource-matches?
+  [resource-type resource-title resource]
+  (and (= resource-type (resource "type"))
+       (= resource-title (resource "title"))))
+
+(defn catalog-contains?
+  [catalog resource-type resource-title]
+  (let [resources (get catalog "resources")]
+    (some (partial resource-matches? resource-type resource-title) resources)))
+
+(defn num-catalogs-containing
+  [catalogs resource-type resource-title]
+  (count (filter #(catalog-contains? % resource-type resource-title) catalogs)))
+
+(schema/defn ^:always-validate with-puppet-conf-files
+             "Test fixture; Accepts a map with the following characteristics:
+
+             * keys are simple filenames (no paths) that will be created in puppet's $confdir
+             * values are paths to a test-specific file that should be copied to puppet's confdir,
+               a la `$confdir/<key>`.
+
+             For each entry in the map, copies the files into $confdir, runs the test function,
+             and then deletes all of the files from $confdir.
+
+             Optionally accepts a second argument `dest-dir`, which specifies the location
+             of Puppet's $confdir.  If this argument is not provided, defaults to
+             `testutils/conf-dir`."
+             ([puppet-conf-files]
+              (with-puppet-conf-files puppet-conf-files conf-dir))
+             ([puppet-conf-files :- {schema/Str (schema/pred (some-fn string? #(instance? File %)))}
+               dest-dir :- schema/Str]
+
+              (let [target-paths (reduce
+                                  (fn [acc filename]
+                                    (assoc acc filename (fs/file dest-dir filename)))
+                                  {}
+                                  (keys puppet-conf-files))]
+                (fn [f]
+                  (doseq [filename (keys puppet-conf-files)]
+                    (fs/copy+ (get puppet-conf-files filename)
+                              (get target-paths filename)))
+                  (try
+                    (f)
+                    (finally
+                      (doseq [target-path (vals target-paths)]
+                        (fs/delete target-path))))))))
+
+(defn with-puppet-conf
+  "This function returns a test fixture that will copy a specified puppet.conf
+  file into the provided location for testing, and then delete it after the
+  tests have completed. If no destination dir is provided then the puppet.conf
+  file is copied to the default location of './target/master-conf'."
+  ([puppet-conf-file]
+   (with-puppet-conf puppet-conf-file conf-dir))
+  ([puppet-conf-file dest-dir]
+   (with-puppet-conf-files {"puppet.conf" puppet-conf-file} dest-dir)))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -3,7 +3,7 @@
             [me.raynes.fs :as fs]
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.testutils :as testutils]
+            [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_disabled_test.clj
@@ -3,6 +3,7 @@
             [me.raynes.fs :as fs]
             [puppetlabs.services.ca.certificate-authority-disabled-service :as disabled]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.testutils :as testutils]
             [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
             [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
             [puppetlabs.trapperkeeper.app :as tk-app]
@@ -16,7 +17,7 @@
 
 (use-fixtures
   :once
-  (jruby-testutils/with-puppet-conf
+  (testutils/with-puppet-conf
     "./dev-resources/puppetlabs/services/ca/certificate_authority_disabled_test/puppet.conf"
     puppet-conf-dir))
 

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :refer :all]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.testutils :as testutils]
+            [puppetlabs.puppetserver.testutils :as testutils]
             [schema.core :as schema]))
 
 (use-fixtures :once

--- a/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
+++ b/test/unit/puppetlabs/services/config/puppet_server_config_core_test.clj
@@ -2,10 +2,11 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.config.puppet-server-config-core :refer :all]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.testutils :as testutils]
             [schema.core :as schema]))
 
 (use-fixtures :once
-              (jruby-testutils/with-puppet-conf
+              (testutils/with-puppet-conf
                 "./dev-resources/puppetlabs/services/config/puppet_server_config_core_test/puppet.conf"))
 
 (deftest test-puppet-config-values

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -3,7 +3,7 @@
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
-            [puppetlabs.testutils :as testutils]))
+            [puppetlabs.puppetserver.testutils :as testutils]))
 
 (use-fixtures :once
               (testutils/with-puppet-conf

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -2,10 +2,11 @@
   (:require [clojure.test :refer :all]
             [me.raynes.fs :as fs]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]))
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.testutils :as testutils]))
 
 (use-fixtures :once
-              (jruby-testutils/with-puppet-conf
+              (testutils/with-puppet-conf
                 "./dev-resources/puppetlabs/services/jruby/jruby_interpreter_test/puppet.conf"))
 
 (deftest create-jruby-instance-test


### PR DESCRIPTION
Several tests reuse or redefine several functions that help in
interacting with puppet catalogs, so this commit collects them in a
generic namespace for reuse. Tests that depended on the old functions
are updated to use the new ones.