### PR TITLE
(SERVER-1103) Fix borrow-after-borrow lock tests

### DIFF
--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -77,6 +77,7 @@
          profiler/puppet-profiler-service
          event-service]
         (jruby-service-test-config 1)
+        (jruby-testutils/wait-for-jrubies app)
         (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
 
           (testing "locking events trigger event notifications"

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -47,16 +47,16 @@
                    (fn [& _] (throw (Exception. "42")))]
        (let [got-expected-exception (atom false)]
          (logging/with-test-logging
-          (bootstrap/with-app-with-config
-           app
-           default-services
-           (jruby-service-test-config 1)
-           (try
-             (tk/run-app app)
-             (catch Exception e
-               (let [cause (stacktrace/root-cause e)]
-                 (is (= (.getMessage cause) "42"))
-                 (reset! got-expected-exception true))))))
+          (try
+            (bootstrap/with-app-with-config
+             app
+             default-services
+             (jruby-service-test-config 1)
+             (tk/run-app app))
+            (catch Exception e
+              (let [cause (stacktrace/root-cause e)]
+                (is (= (.getMessage cause) "42"))
+                (reset! got-expected-exception true)))))
          (is (true? @got-expected-exception)
              "Did not get expected exception."))))))
 


### PR DESCRIPTION
This commit includes fixes for timing-related issues in the
`pool-can-borrow-after-borrow-interrupted-during-lock` and
`pool-can-borrow-after-borrow-timed-out-during-lock` tests.  In both
cases, there previously was a race condition where a borrow on a
separate thread could succeed before a lock() call was made, causing the
lock() call to block indefinitely because the pool was indefinitely not
full.  The production code was behaving properly but the tests were
designed with the expectation that the lock would occur before the
any borrows were attempted.  Both tests were changed to wait to perform
the borrow until the lock is taken.