### PR TITLE
(SERVER-876) Add versioned-code-service to ezbake bootstrap.cfg

### DIFF
--- a/ezbake/config/bootstrap.cfg
+++ b/ezbake/config/bootstrap.cfg
@@ -8,6 +8,7 @@ puppetlabs.services.master.master-service/master-service
 puppetlabs.services.puppet-admin.puppet-admin-service/puppet-admin-service
 puppetlabs.services.legacy-routes.legacy-routes-service/legacy-routes-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
+puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code-service
 
 # To enable the CA service, leave the following line uncommented
 puppetlabs.services.ca.certificate-authority-service/certificate-authority-service


### PR DESCRIPTION
The previous work neglected to add the versioned-code-service to
ezbake's bootstrap.cfg, which has the unfortunate consequence of
preventing puppet-server from starting up. This commit addresses that
oversight.