### PR TITLE
(SERVER-1069) bundle logback json encoder

### DIFF
--- a/documentation/config_logging_advanced.md
+++ b/documentation/config_logging_advanced.md
@@ -1,0 +1,130 @@
+---
+layout: default
+title: "Puppet Server: Advanced Logging Configuration"
+canonical: "/puppetserver/latest/config_logging_advanced.html"
+---
+
+Puppet Server uses the very flexible, very powerful [Logback](http://logback.qos.ch/) library under the hood to handle all of our logging needs.
+
+Among the many interesting and useful capabilities of logback is the ability to configure it to log messages in a JSON format, which makes it easy to send them over to other logging backends such as logstash.
+
+## Configuring Puppet Server for use with Logstash
+
+There are a few steps necessary to get your Puppet Server logging set up for use with logstash.  The first step is to modify your logging configuration so that Puppet Server is logging in a JSON format.  After that, you'll need to configure an external tool to monitor these JSON files and send the data to logstash (or another remote logging system).
+
+### Configuring Puppet Server to log to JSON
+
+There are a handful of considerations you may want to take into account before configuring Puppet Server to log to JSON:
+
+* Do you want to configure Puppet Server to *only* log to JSON?  In lieu of the normal text file logging?  Or do you want to add JSON logging *in addition to* your normal text logging?
+* Do you want to set up JSON logging only for the normal Puppet Server logs (i.e. `puppetserver.log`), or also for the HTTP access logs (i.e. `puppetserver-access.log`)?
+* What kind of log rotation strategy do you want to use for the new JSON log files?
+
+In this section we'll show some examples of setting up your configuration for logging both the normal logs and the HTTP access logs in JSON, *in addition to* leaving the normal text-based log files in place.  We'll also configure logback to do log rotation on these new JSON files.  Hopefully you can modify these examples to suit your own needs, based on your answers to the three questions above.
+
+**NOTE**: Puppet Server's packaging sets up `logrotate` management of the main `puppetserver.log` file automatically, which is why you don't see any of the `logback` support for log rotation configured in our default `logback.xml` file.  However, the Puppet Server packaging does *not* include any `logrotate` integration for these new JSON log files that we'll be setting up, so that is why we will show examples of how to use `logback` to do that.  If you were so inclined, you could omit those portions of these configuration examples, and configure `logrotate` to manage the log rotation for your new JSON files.
+
+#### Adding a JSON version of the "normal" Puppet Server logs
+
+To configure Puppet Server to log its "normal" logs to a second log file, in JSON format, simply add a section like this to your `logback.xml` file:
+
+``` xml
+<appender name="LOGSTASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetserver/puppetserver.log.json</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver.log.json.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>5</maxHistory>
+        </rollingPolicy>
+
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <fieldNames>
+                <timestamp>timegenerated</timestamp>
+                <message>logmsg</message>
+            </fieldNames>
+        </encoder>
+    </appender>
+```
+
+Note that the above configuration includes the `RollingFileAppender`, to rotate the log files and ensure they don't fill up your disk.  Also, note that the `fieldNames` section above is optional, and in this case is restricting the number of fields that will be included in the JSON to two fields per log entry.  There are additional fields available, and if you omitted the `fieldNames` section you would end up with several additional fields per log entry by default.  For more info see the [Logstash Logback Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#loggingevent-fields).
+
+The above XML snippet will create an appender that will log to the specified JSON file when active.  In order to activate the appender, you also need to add an `appender-ref`, e.g. in the `<root>` section of your `logback.xml`:
+
+``` xml
+<root level="info">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="LOGSTASH"/>
+</root>
+```
+
+You could also comment out or remove the other `appender-ref`s, if you decided you *only* wanted to log the JSON format.
+
+#### Adding a JSON version of the Puppet Server HTTP Acces logs
+
+To add JSON logging for Puppet Server's HTTP requests, modify the `request-logging.xml` file.  Here's an example of adding a logback appender there:
+
+``` xml
+   <appender name="LOGSTASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/puppetlabs/puppetserver/puppetserver-access.log.json</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/puppetlabs/puppetserver/puppetserver-access.log.json.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+      <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
+          <providers>
+              <version/>
+              <pattern>
+                  <pattern>
+                    {
+                      "timegenerated":"%date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}",
+                      "clientip":"%remoteIP",
+                      "auth":"%user",
+                      "verb":"%requestMethod",
+                      "requestprotocol":"%protocol",
+                      "rawrequest":"%requestURL",
+                      "response":"#asLong{%statusCode}",
+                      "bytes":"#asLong{%bytesSent}",
+                      "total_service_time":"#asLong{%elapsedTime}",
+                      "request":"http://%header{Host}%requestURI",
+                      "referrer":"%header{Referer}",
+                      "agent":"%header{User-agent}",
+
+                      "request.host":"%header{Host}",
+                      "request.accept":"%header{Accept}",
+                      "request.accept-encoding":"%header{Accept-Encoding}",
+                      "request.connection":"%header{Connection}",
+
+                      "puppet.client-verify":"%header{X-Client-Verify}",
+                      "puppet.client-dn":"%header{X-Client-DN}",
+                      "puppet.client-cert":"%header{X-Client-Cert}",
+
+                      "response.content-type":"%responseHeader{Content-Type}",
+                      "response.content-length":"%responseHeader{Content-Length}",
+                      "response.server":"%responseHeader{Server}",
+                      "response.connection":"%responseHeader{Connection}"
+                    }
+                  </pattern>
+              </pattern>
+            </providers>
+        </encoder>
+    </appender>
+```
+
+For more information on options available for the `pattern` section, see the [Logback Logstash Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#accessevent-fields).
+
+You also need to deal with the `appender-ref`s in this config file as well, e.g. by adding something like this inside the `configuration` section of the file:
+
+``` xml
+<appender-ref ref="LOGSTASH"/>
+```
+
+### Sending the JSON data to Logstash
+
+If you've followed the steps above, you now have Puppet Server configured to log to files on disk in a JSON format.  Puppet Server does not have any built-in capabilities for streaming this JSON data to an external system such as Logstash, but there are many third-party tools available that can be configured to do this.  Here are a few for you to consider:
+
+* [Filebeat](https://www.elastic.co/products/beats/filebeat) is Elastic's latest tool for shipping log data to logstash.
+* [Logstash Forwarder](https://github.com/elastic/logstash-forwarder) is an earlier tool that Elastic provided that has some of the same capabilities.
+
+

--- a/documentation/config_logging_advanced.md
+++ b/documentation/config_logging_advanced.md
@@ -4,7 +4,7 @@ title: "Puppet Server: Advanced Logging Configuration"
 canonical: "/puppetserver/latest/config_logging_advanced.html"
 ---
 
-Puppet Server uses the very flexible, very powerful [Logback](http://logback.qos.ch/) library under the hood to handle all of our logging needs.
+Puppet Server uses the very flexible, very powerful [Logback](http://logback.qos.ch/) library under the hood to handle all of our logging needs.  Logback can be configured via the `logback.xml` file, which is located at `/etc/puppetlabs/puppetserver/logback.xml` by default.
 
 Among the many interesting and useful capabilities of logback is the ability to configure it to log messages in a JSON format, which makes it easy to send them over to other logging backends such as logstash.
 
@@ -16,20 +16,20 @@ There are a few steps necessary to get your Puppet Server logging set up for use
 
 There are a handful of considerations you may want to take into account before configuring Puppet Server to log to JSON:
 
-* Do you want to configure Puppet Server to *only* log to JSON?  In lieu of the normal text file logging?  Or do you want to add JSON logging *in addition to* your normal text logging?
-* Do you want to set up JSON logging only for the normal Puppet Server logs (i.e. `puppetserver.log`), or also for the HTTP access logs (i.e. `puppetserver-access.log`)?
+* Do you want to configure Puppet Server to *only* log to JSON?  In lieu of the default plain-text logging?  Or do you want to add JSON logging *in addition to* the default plain-text logging?
+* Do you want to set up JSON logging only for the main Puppet Server logs (i.e. `puppetserver.log`), or also for the HTTP access logs (i.e. `puppetserver-access.log`)?
 * What kind of log rotation strategy do you want to use for the new JSON log files?
 
-In this section we'll show some examples of setting up your configuration for logging both the normal logs and the HTTP access logs in JSON, *in addition to* leaving the normal text-based log files in place.  We'll also configure logback to do log rotation on these new JSON files.  Hopefully you can modify these examples to suit your own needs, based on your answers to the three questions above.
+In this section we'll show some examples of setting up your configuration for logging both the main logs and the HTTP access logs in JSON, *in addition to* leaving the main text-based log files in place.  We'll also configure logback to do log rotation on these new JSON files.  Hopefully you can modify these examples to suit your own needs, based on your answers to the three questions above.
 
 **NOTE**: Puppet Server's packaging sets up `logrotate` management of the main `puppetserver.log` file automatically, which is why you don't see any of the `logback` support for log rotation configured in our default `logback.xml` file.  However, the Puppet Server packaging does *not* include any `logrotate` integration for these new JSON log files that we'll be setting up, so that is why we will show examples of how to use `logback` to do that.  If you were so inclined, you could omit those portions of these configuration examples, and configure `logrotate` to manage the log rotation for your new JSON files.
 
-#### Adding a JSON version of the "normal" Puppet Server logs
+#### Adding a JSON version of the main Puppet Server logs
 
-To configure Puppet Server to log its "normal" logs to a second log file, in JSON format, simply add a section like this to your `logback.xml` file:
+To configure Puppet Server to log its main logs to a second log file, in JSON format, simply add a section like this to your `logback.xml` file (it should be added at the same level in the XML as your existing appender/appenders, but the order of the appenders does not matter):
 
 ``` xml
-<appender name="LOGSTASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+<appender name="JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetserver/puppetserver.log.json</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -46,14 +46,14 @@ To configure Puppet Server to log its "normal" logs to a second log file, in JSO
     </appender>
 ```
 
-Note that the above configuration includes the `RollingFileAppender`, to rotate the log files and ensure they don't fill up your disk.  Also, note that the `fieldNames` section above is optional, and in this case is restricting the number of fields that will be included in the JSON to two fields per log entry.  There are additional fields available, and if you omitted the `fieldNames` section you would end up with several additional fields per log entry by default.  For more info see the [Logstash Logback Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#loggingevent-fields).
+Logback writes logs using components called [appenders](http://logback.qos.ch/manual/appenders.html).  Note that the above configuration includes the `RollingFileAppender`, to rotate the log files and ensure they don't fill up your disk.  Also, note that the `fieldNames` section above is optional, and in this case is restricting the number of fields that will be included in the JSON to two fields per log entry.  There are additional fields available, and if you omitted the `fieldNames` section you would end up with several additional fields per log entry by default.  For more info see the [Logstash Logback Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#loggingevent-fields).
 
 The above XML snippet will create an appender that will log to the specified JSON file when active.  In order to activate the appender, you also need to add an `appender-ref`, e.g. in the `<root>` section of your `logback.xml`:
 
 ``` xml
 <root level="info">
         <appender-ref ref="FILE"/>
-        <appender-ref ref="LOGSTASH"/>
+        <appender-ref ref="JSON"/>
 </root>
 ```
 
@@ -64,7 +64,7 @@ You could also comment out or remove the other `appender-ref`s, if you decided y
 To add JSON logging for Puppet Server's HTTP requests, modify the `request-logging.xml` file.  Here's an example of adding a logback appender there:
 
 ``` xml
-   <appender name="LOGSTASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+   <appender name="JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/puppetlabs/puppetserver/puppetserver-access.log.json</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -117,7 +117,7 @@ For more information on options available for the `pattern` section, see the [Lo
 You also need to deal with the `appender-ref`s in this config file as well, e.g. by adding something like this inside the `configuration` section of the file:
 
 ``` xml
-<appender-ref ref="LOGSTASH"/>
+<appender-ref ref="JSON"/>
 ```
 
 ### Sending the JSON data to Logstash

--- a/documentation/config_logging_advanced.md
+++ b/documentation/config_logging_advanced.md
@@ -59,7 +59,7 @@ The above XML snippet will create an appender that will log to the specified JSO
 
 You could also comment out or remove the other `appender-ref`s, if you decided you *only* wanted to log the JSON format.
 
-#### Adding a JSON version of the Puppet Server HTTP Acces logs
+#### Adding a JSON version of the Puppet Server HTTP Access logs
 
 To add JSON logging for Puppet Server's HTTP requests, modify the `request-logging.xml` file.  Here's an example of adding a logback appender there:
 

--- a/documentation/config_logging_advanced.md
+++ b/documentation/config_logging_advanced.md
@@ -37,16 +37,11 @@ To configure Puppet Server to log its main logs to a second log file, in JSON fo
             <maxHistory>5</maxHistory>
         </rollingPolicy>
 
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <timestamp>timegenerated</timestamp>
-                <message>logmsg</message>
-            </fieldNames>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 ```
 
-Logback writes logs using components called [appenders](http://logback.qos.ch/manual/appenders.html).  Note that the above configuration includes the `RollingFileAppender`, to rotate the log files and ensure they don't fill up your disk.  Also, note that the `fieldNames` section above is optional, and in this case is restricting the number of fields that will be included in the JSON to two fields per log entry.  There are additional fields available, and if you omitted the `fieldNames` section you would end up with several additional fields per log entry by default.  For more info see the [Logstash Logback Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#loggingevent-fields).
+Logback writes logs using components called [appenders](http://logback.qos.ch/manual/appenders.html).  Note that the above configuration includes the `RollingFileAppender`, to rotate the log files and ensure they don't fill up your disk.  Also, note that there are a lot of configuration options available for the `LogstashEncoder` above, including the ability to modify the list of fields that you wish to include, or give them different field names.  For more info see the [Logstash Logback Encoder Docs](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#loggingevent-fields).
 
 The above XML snippet will create an appender that will log to the specified JSON file when active.  In order to activate the appender, you also need to add an `appender-ref`, e.g. in the `<root>` section of your `logback.xml`:
 
@@ -78,7 +73,7 @@ To add JSON logging for Puppet Server's HTTP requests, modify the `request-loggi
               <pattern>
                   <pattern>
                     {
-                      "timegenerated":"%date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}",
+                      "@timestamp":"%date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}",
                       "clientip":"%remoteIP",
                       "auth":"%user",
                       "verb":"%requestMethod",
@@ -122,9 +117,8 @@ You also need to deal with the `appender-ref`s in this config file as well, e.g.
 
 ### Sending the JSON data to Logstash
 
-If you've followed the steps above, you now have Puppet Server configured to log to files on disk in a JSON format.  Puppet Server does not have any built-in capabilities for streaming this JSON data to an external system such as Logstash, but there are many third-party tools available that can be configured to do this.  Here are a few for you to consider:
+If you've followed the steps above, you now have Puppet Server configured to log to files on disk in a JSON format.  The next step is to configure your system to send the logs to logstash (or another external logging system).  There are several different ways to approach this; here are a few for you to consider:
 
+* Configure logback to send the data to logstash directly, from within Puppet Server.  Checkout the logstash-logback-encoder docs on how to send the logs via [TCP](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#tcp) or [UDP](https://github.com/logstash/logstash-logback-encoder/blob/master/README.md#udp).  Note that TCP comes with the risk of bottlenecking Puppet Server if your logstash system is backed up, and UDP comes with the risk of silently dropping log messages.
 * [Filebeat](https://www.elastic.co/products/beats/filebeat) is Elastic's latest tool for shipping log data to logstash.
 * [Logstash Forwarder](https://github.com/elastic/logstash-forwarder) is an earlier tool that Elastic provided that has some of the same capabilities.
-
-

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -35,6 +35,8 @@ The default Logback configuration file is at `/etc/puppetserver/logback.xml` or 
 
 Puppet Server relies on `logrotate` to manage the log file, and installs a configuration file at `/etc/logrotate.d/puppetserver` or `/etc/logrotate.d/pe-puppetserver`.
 
+For some tips on advanced logging configuration, including information about configuring your system to send log data to logstash, see the [Advanced Logging Configuration](./config_logging_advanced.html) documentation.
+
 ### HTTP Traffic
 
 Puppet Server logs HTTP traffic in a format similar to Apache, and to a separate file than the main log file. By default, this is located at `/var/log/puppetlabs/puppetserver/puppetserver-access.log` (open source releases) and `/var/log/pe-puppetserver/puppetserver-access.log` (Puppet Enterprise).

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -35,7 +35,7 @@ The default Logback configuration file is at `/etc/puppetserver/logback.xml` or 
 
 Puppet Server relies on `logrotate` to manage the log file, and installs a configuration file at `/etc/logrotate.d/puppetserver` or `/etc/logrotate.d/pe-puppetserver`.
 
-For some tips on advanced logging configuration, including information about configuring your system to send log data to logstash, see the [Advanced Logging Configuration](./config_logging_advanced.html) documentation.
+For some tips on advanced logging configuration, including information about configuring your system to write logs in a JSON format suitable for sending to logstash or other external logging systems, see the [Advanced Logging Configuration](./config_logging_advanced.html) documentation.
 
 ### HTTP Traffic
 

--- a/project.clj
+++ b/project.clj
@@ -19,6 +19,7 @@
                  ;; begin version conflict resolution dependencies
                  [puppetlabs/typesafe-config "0.1.4"]
                  [org.clojure/tools.macro "0.1.5"]
+                 [com.fasterxml.jackson.core/jackson-core "2.5.4"]
                  ;; end version conflict resolution dependencies
 
                  [cheshire "5.3.1"]
@@ -43,6 +44,13 @@
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
                  [org.jruby/jruby-stdlib "1.7.20.1"]
+
+                 ;; we do not currently use this dependency directly, but
+                 ;; we have documentation that shows how users can use it to
+                 ;; send their logs to logstash, so we include it in the jar.
+                 ;; we may use it directly in the future
+                 [net.logstash.logback/logstash-logback-encoder "4.5.1"]
+
 
                  [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/trapperkeeper-authorization "0.5.0"]


### PR DESCRIPTION
This PR adds a dependency on the logback logstash JSON encoder library, so that we will bundle it with our uberjar.  This allows users to opt-in to configuring their Puppet Server logs to write output in a JSON format that can be imported into logstash.

The PR also includes documentation with examples of how to configure Puppet Server's logging accordingly.

We were almost certainly going to end up with a dependency on this library in the future anyway, because it is a dependency of the structured logging library that PuppetDB is now using.