### PR TITLE
(SERVER-876) Only call wrap-params-for-jruby once

### DIFF
--- a/dev/user_repl.clj
+++ b/dev/user_repl.clj
@@ -12,6 +12,7 @@
             [puppetlabs.services.puppet-admin.puppet-admin-service :refer [puppet-admin-service]]
             [puppetlabs.services.legacy-routes.legacy-routes-service :refer [legacy-routes-service]]
             [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
+            [puppetlabs.services.versioned-code-service.versioned-code-service :refer [versioned-code-service]]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.app :as tka]
             [clojure.tools.namespace.repl :refer (refresh)]
@@ -56,7 +57,8 @@
                certificate-authority-service
                puppet-admin-service
                legacy-routes-service
-               authorization-service]
+               authorization-service
+               versioned-code-service]
               ((resolve 'user/puppet-server-conf)))))
   (alter-var-root #'system tka/init)
   (tka/check-for-errors! system))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -20,9 +20,10 @@
   "Creates the routes to handle the master's '/v3' routes, which
    includes '/environments' and the non-CA indirected routes. The CA-related
    endpoints are handled separately by the CA service."
-  [request-handler
+  [request-handler-fn
    get-code-id-fn]
-  (let [request-handler-with-code-id (request-core/wrap-with-code-id request-handler get-code-id-fn)]
+  (let [request-handler (comp request-handler-fn request-core/wrap-params-for-jruby)
+        request-handler-with-code-id (request-core/wrap-with-code-id request-handler-fn get-code-id-fn)]
     (comidi/routes
      (comidi/GET ["/node/" [#".*" :rest]] request
                  (request-handler request))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -337,7 +337,7 @@
   (fn [req]
     (let [wrapped-request (wrap-params-for-jruby req)
           env (get-environment-from-request wrapped-request)]
-      (when-not env (throw (IllegalStateException.) "Environment is required in a catalog request."))
+      (when-not env (throw (IllegalStateException. "Environment is required in a catalog request.")))
       (handler (assoc-in wrapped-request [:params "code_id"] (get-code-id-fn env))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -318,7 +318,6 @@
   [config]
   (fn [request]
     (->> request
-      wrap-params-for-jruby
       (as-jruby-request config)
       clojure.walk/stringify-keys
       make-request-mutable
@@ -326,11 +325,9 @@
       response->map)))
 
 (defn get-environment-from-request
-  "Gets the environment from a request, after the params map has been populated
-  via wrap-params-for-jruby."
+  "Gets the environment from a request."
   [req]
   (-> req
-      wrap-params-for-jruby
       (get-in [:params "environment"])))
 
 (defn wrap-with-code-id
@@ -338,8 +335,10 @@
   it on to the specified handler."
   [handler get-code-id-fn]
   (fn [req]
-    (let [req (assoc-in req [:params "code_id"] (get-code-id-fn (get-environment-from-request req)))]
-      (handler req))))
+    (let [wrapped-request (wrap-params-for-jruby req)
+          env (get-environment-from-request wrapped-request)]
+      (when-not env (throw (IllegalStateException.) "Environment is required in a catalog request."))
+      (handler (assoc-in wrapped-request [:params "code_id"] (get-code-id-fn env))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
@@ -21,8 +21,6 @@
 
   (current-code-id
    [this environment]
-   "Returns the current code id (representing the freshest code) for the given environment.
-   In the case of a non-zero return from the code-id-command, returns nil."
    (if-let [code-id-script (get-in-config [:versioned-code :code-id-command])]
      (let [error-msg #(log/errorf (str "Calculating code id generated an error. "
                                        "Command executed: '%s', error generated: '%s'")

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -3,7 +3,7 @@
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.puppet-environments-int-test :refer
-             [write-site-pp-file get-catalog catalog-contains?]]
+             [write-site-pp-file get-catalog catalog-contains? post-catalog]]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [me.raynes.fs :as fs]))
 
@@ -50,6 +50,17 @@
           :versioned-code
           {:code-id-command (script-path "echo")}}
      (let [catalog (get-catalog)]
+       (is (= "production" (get catalog "code_id"))))))
+  (testing "code id is added to the request body for catalog requests"
+    ; As we have set code-id-command to echo, the code id will
+    ; be the result of running `echo $environment`, which will
+    ; be production here.
+    (bootstrap/with-puppetserver-running
+     app {:jruby-puppet
+          {:max-active-instances num-jrubies}
+          :versioned-code
+          {:code-id-command (script-path "echo")}}
+     (let [catalog (post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
   (testing "code id is added to the request body for catalog requests"
     ; As we have set code-id-command to warn, the code id will

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -7,7 +7,6 @@
             [cheshire.core :as json]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
 
 (def test-resources-dir
@@ -58,7 +57,7 @@
      :as          :text}))
 
 (defn get-catalog
-  "Make an HTTP request to get a catalog."
+  "Make an HTTP get request for a catalog."
   []
   (-> (http-client/get
         "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"

--- a/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/puppet_environments_int_test.clj
@@ -66,6 +66,17 @@
       :body
       json/parse-string))
 
+(defn post-catalog
+  "Make an HTTP post request for a catalog."
+  []
+  (-> (http-client/post
+       "https://localhost:8140/puppet/v3/catalog/localhost"
+       (assoc-in (assoc catalog-request-options
+                   :body "environment=production")
+                 [:headers "Content-Type"] "application/x-www-form-urlencoded"))
+      :body
+      json/parse-string))
+
 (defn get-catalog-and-borrow-jruby
   "Gets a catalog, and then borrows a JRuby instance from a pool to ensure that
   a subsequent catalog request will be directed to a different JRuby.  Returns a

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -54,17 +54,19 @@
                 "is not overwritten, and simply passed through unmodified.")
     (let [handler     (fn ([req] {:request req}))
           app         (build-ring-handler handler "1.2.3")
-          resp        (app {:request-method :put
-                            :content-type   "application/octet-stream"
-                            :uri            "/v3/file_bucket_file/bar"})]
+          resp        (app (-> {:request-method :put
+                                :content-type "application/octet-stream"
+                                :uri "/v3/file_bucket_file/bar"}
+                               (mock/body "foo")))]
       (is (= "application/octet-stream"
              (get-in resp [:request :content-type])))
 
       (testing "Even if the client sends something insane, "
                "just pass it through and let the puppet code handle it."
-        (let [resp (app {:request-method :put
-                         :content-type   "something-crazy/for-content-type"
-                         :uri            "/v3/file_bucket_file/bar"})]
+        (let [resp (app (-> {:request-method :put
+                          :content-type "something-crazy/for-content-type"
+                          :uri "/v3/file_bucket_file/bar"}
+                            (mock/body "foo")))]
           (is (= "something-crazy/for-content-type"
                  (get-in resp [:request :content-type]))))))))
 

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -25,7 +25,10 @@
         request     (partial app-request app)]
     (is (= 200 (:status (request "/v3/environments"))))
     (is (= 200 (:status (request "/v3/catalog/bar?environment=environment1234"))))
-    (is (= 200 (:status (request :post "/v3/catalog/bar?environment=environment1234"))))
+    (is (= 200 (:status (app (-> {:request-method :post
+                                  :uri "/v3/catalog/bar"
+                                  :content-type "application/x-www-form-urlencoded"}
+                                 (mock/body "environment=environment1234"))))))
     (is (= 404 (:status (request "/foo"))))
     (is (= 404 (:status (request "/foo/bar"))))
     (doseq [[method paths]

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -24,11 +24,12 @@
         app         (build-ring-handler handler "1.2.3")
         request     (partial app-request app)]
     (is (= 200 (:status (request "/v3/environments"))))
+    (is (= 200 (:status (request "/v3/catalog/bar?environment=environment1234"))))
+    (is (= 200 (:status (request :post "/v3/catalog/bar?environment=environment1234"))))
     (is (= 404 (:status (request "/foo"))))
     (is (= 404 (:status (request "/foo/bar"))))
     (doseq [[method paths]
-            {:get ["catalog"
-                   "node"
+            {:get ["node"
                    "environment"
                    "file_content"
                    "file_metadatas"
@@ -37,7 +38,6 @@
                    "resource_type"
                    "resource_types"
                    "status"]
-             :post ["catalog"]
              :put ["file_bucket_file"
                    "report"]
              :head ["file_bucket_file"]}
@@ -72,8 +72,7 @@
   (testing "code_id is calculated and added to the catalog request."
     (let [handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" (constantly "foo-is-my-codeid"))
-          resp (app {:request-method :get
-                     :uri "/v3/catalog/bar"})]
+          resp (app-request app "/v3/catalog/bar?environment=environment1234")]
       (is (= "foo-is-my-codeid" (get-in resp [:request :params "code_id"])))))
   (testing "code_id is not added to non-catalog requests"
     (let [handler (fn ([req] {:request req}))
@@ -93,7 +92,7 @@
                      "report"]
                :head ["file_bucket_file"]}
               path paths]
-        (let [resp (request method (str "/v3/" path "/bar"))]
+        (let [resp (request method (str "/v3/" path "/bar?environment=environment1234"))]
           (is (nil? (get-in resp [:request :params "code_id"]))))))))
 
 (defn assert-failure-msg


### PR DESCRIPTION
In a previous commit, wrap-params-for-jruby was called twice for catalog
requests. This meant that the body of the request would be consumed by
the first call (via body-for-jruby), and then the body would be gone for
the second call. This commit avoids that problem by refactoring
root-routes and the wrap-with-code-id to call wrap-params-for-jruby only
once in all routes. It also adds a test for the failing case where
catalog POST requests had no body.