### PR TITLE
(SERVER-876) Compute code_id when holding a JRuby

### DIFF
--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -27,7 +27,7 @@
           master-route-config (master-core/get-master-route-config
                                 master-ns
                                 config)
-          master-route-handler (-> (master-core/root-routes handle-request (constantly nil))
+          master-route-handler (-> (master-core/root-routes handle-request)
                                    ((partial comidi/context path))
                                    comidi/routes->handler)
           master-handler-info {:mount       (master-core/get-master-mount

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -20,42 +20,39 @@
   "Creates the routes to handle the master's '/v3' routes, which
    includes '/environments' and the non-CA indirected routes. The CA-related
    endpoints are handled separately by the CA service."
-  [request-handler-fn
-   get-code-id-fn]
-  (let [request-handler (comp request-handler-fn request-core/wrap-params-for-jruby)
-        request-handler-with-code-id (request-core/wrap-with-code-id request-handler-fn get-code-id-fn)]
-    (comidi/routes
-     (comidi/GET ["/node/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_content/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_metadata/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
-                  (request-handler request))
+  [request-handler]
+  (comidi/routes
+   (comidi/GET ["/node/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_content/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_metadata/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
+                (request-handler request))
 
-     (comidi/GET ["/catalog/" [#".*" :rest]] request
-                 (request-handler-with-code-id request))
-     (comidi/POST ["/catalog/" [#".*" :rest]] request
-                 (request-handler-with-code-id request))
-     (comidi/PUT ["/report/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/resource_type/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/resource_types/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/environment/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET "/environments" request
-                 (request-handler request))
-     (comidi/GET ["/status/" [#".*" :rest]] request
-                 (request-handler request)))))
+   (comidi/GET ["/catalog/" [#".*" :rest]] request
+               (request-handler (assoc request :assoc-code-id true)))
+   (comidi/POST ["/catalog/" [#".*" :rest]] request
+                (request-handler (assoc request :assoc-code-id true)))
+   (comidi/PUT ["/report/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/resource_type/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/resource_types/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/environment/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET "/environments" request
+               (request-handler request))
+   (comidi/GET ["/status/" [#".*" :rest]] request
+               (request-handler request))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions
@@ -106,11 +103,10 @@
 
 (defn root-routes
   "Creates all of the web routes for the master."
-  [request-handler
-   get-code-id-fn]
+  [request-handler]
   (comidi/routes
     (comidi/context "/v3"
-                    (v3-routes request-handler get-code-id-fn))
+                    (v3-routes request-handler))
     (comidi/not-found "Not Found")))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -38,9 +38,9 @@
                 (request-handler request))
 
    (comidi/GET ["/catalog/" [#".*" :rest]] request
-               (request-handler (assoc request :assoc-code-id true)))
+               (request-handler (assoc request :include-code-id? true)))
    (comidi/POST ["/catalog/" [#".*" :rest]] request
-                (request-handler (assoc request :assoc-code-id true)))
+                (request-handler (assoc request :include-code-id? true)))
    (comidi/PUT ["/report/" [#".*" :rest]] request
                (request-handler request))
    (comidi/GET ["/resource_type/" [#".*" :rest]] request

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -16,8 +16,7 @@
    [:RequestHandlerService handle-request]
    [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl!]
    [:JRubyPuppetService]
-   [:AuthorizationService wrap-with-authorization-check]
-   [:VersionedCodeService current-code-id]]
+   [:AuthorizationService wrap-with-authorization-check]]
   (init
    [this context]
    (core/validate-memory-requirements!)
@@ -45,7 +44,7 @@
            path (core/get-master-mount ::master-service route-config)
            ring-handler (when path
                           (core/get-wrapped-handler
-                            (-> (core/root-routes handle-request current-code-id)
+                            (-> (core/root-routes handle-request)
                                 ((partial comidi/context path))
                                 comidi/routes->handler)
                             wrap-with-authorization-check

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -320,8 +320,11 @@
       (get-in [:params "environment"])))
 
 (defn with-code-id
+  "Wraps the given request with the current-code-id, if it contains a
+  :include-code-id? key with a truthy value.  current-code-id is passed the
+  environment from the request from it is invoked."
   [current-code-id request]
-  (if (:assoc-code-id request)
+  (if (:include-code-id? request)
     (let [env (get-environment-from-request request)]
       (when-not env
         (throw (IllegalStateException. "Environment is required in a catalog request.")))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -313,39 +313,40 @@
       
       (f (assoc request :jruby-instance jruby-instance)))))
 
-(defn jruby-request-handler
-  "Build a request handler fn that processes a request using a JRubyPuppet instance"
-  [config]
-  (fn [request]
-    (->> request
-      (as-jruby-request config)
-      clojure.walk/stringify-keys
-      make-request-mutable
-      (.handleRequest (:jruby-instance request))
-      response->map)))
-
 (defn get-environment-from-request
   "Gets the environment from a request."
   [req]
   (-> req
       (get-in [:params "environment"])))
 
-(defn wrap-with-code-id
-  "Specialized middleware for catalogs. Adds code_id to the request before passing
-  it on to the specified handler."
-  [handler get-code-id-fn]
-  (fn [req]
-    (let [wrapped-request (wrap-params-for-jruby req)
-          env (get-environment-from-request wrapped-request)]
-      (when-not env (throw (IllegalStateException. "Environment is required in a catalog request.")))
-      (handler (assoc-in wrapped-request [:params "code_id"] (get-code-id-fn env))))))
+(defn with-code-id
+  [current-code-id request]
+  (let [env (get-environment-from-request request)]
+    (when-not env
+      (throw (IllegalStateException. "Environment is required in a catalog request.")))
+    (if (:assoc-code-id request)
+      (assoc-in request [:params "code_id"] (current-code-id env))
+      request)))
+
+(defn jruby-request-handler
+  "Build a request handler fn that processes a request using a JRubyPuppet instance"
+  [config current-code-id]
+  (fn [request]
+    (->> request
+         wrap-params-for-jruby
+         (as-jruby-request config)
+         clojure.walk/stringify-keys
+         (with-code-id current-code-id)
+         make-request-mutable
+         (.handleRequest (:jruby-instance request))
+         response->map)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
 (defn build-request-handler
   "Build the main request handler fn for JRuby requests."
-  [jruby-service config]
-  (-> (jruby-request-handler config)
-    (wrap-with-jruby-instance jruby-service)
-    wrap-with-error-handling))
+  [jruby-service config current-code-id]
+  (-> (jruby-request-handler config current-code-id)
+      (wrap-with-jruby-instance jruby-service)
+      wrap-with-error-handling))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -321,12 +321,12 @@
 
 (defn with-code-id
   [current-code-id request]
-  (let [env (get-environment-from-request request)]
-    (when-not env
-      (throw (IllegalStateException. "Environment is required in a catalog request.")))
-    (if (:assoc-code-id request)
-      (assoc-in request [:params "code_id"] (current-code-id env))
-      request)))
+  (if (:assoc-code-id request)
+    (let [env (get-environment-from-request request)]
+      (when-not env
+        (throw (IllegalStateException. "Environment is required in a catalog request.")))
+      (assoc-in request [:params "code_id"] (current-code-id env)))
+    request))
 
 (defn jruby-request-handler
   "Build a request handler fn that processes a request using a JRubyPuppet instance"

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -334,9 +334,9 @@
   (fn [request]
     (->> request
          wrap-params-for-jruby
+         (with-code-id current-code-id)
          (as-jruby-request config)
          clojure.walk/stringify-keys
-         (with-code-id current-code-id)
          make-request-mutable
          (.handleRequest (:jruby-instance request))
          response->map)))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -7,7 +7,8 @@
 
 (tk/defservice request-handler-service
   handler/RequestHandlerService
-  [[:PuppetServerConfigService get-config]]
+  [[:PuppetServerConfigService get-config]
+   [:VersionedCodeService current-code-id]]
   (init [this context]
     (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
           config (get-config)]
@@ -28,7 +29,8 @@
                      (request-handler-core/build-request-handler
                       jruby-service
                       (request-handler-core/config->request-handler-settings
-                       config)))))
+                       config)
+                      current-code-id))))
   (handle-request
     [this request]
     (let [handler (:request-handler (tk-services/service-context this))]

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -19,6 +19,7 @@
             [puppetlabs.trapperkeeper.internal :as tk-internal]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.services.request-handler.request-handler-service :as handler-service]
+            [puppetlabs.services.versioned-code-service.versioned-code-service :as vcs]
             [puppetlabs.services.config.puppet-server-config-service :as ps-config]
             [puppetlabs.services.protocols.request-handler :as handler]
             [puppetlabs.services.request-handler.request-handler-core :as handler-core]
@@ -325,7 +326,8 @@
     (ks-testutils/with-no-jvm-shutdown-hooks
      (let [services [jruby/jruby-puppet-pooled-service profiler/puppet-profiler-service
                      handler-service/request-handler-service ps-config/puppet-server-config-service
-                     jetty9/jetty9-service]
+                     jetty9/jetty9-service
+                     vcs/versioned-code-service]
            config (-> (jruby-testutils/jruby-puppet-tk-config
                        (jruby-testutils/jruby-puppet-config {:max-active-instances 2}))
                       (assoc-in [:webserver :port] 8081))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -54,17 +54,19 @@
                 "is not overwritten, and simply passed through unmodified.")
     (let [handler     (fn ([req] {:request req}))
           app         (build-ring-handler handler "1.2.3")
-          resp        (app {:request-method :put
-                            :content-type   "application/octet-stream"
-                            :uri            "/v3/file_bucket_file/bar"})]
+          resp        (app (-> {:request-method :put
+                                :content-type "application/octet-stream"
+                                :uri "/v3/file_bucket_file/bar"}
+                               (mock/body "foo")))]
       (is (= "application/octet-stream"
              (get-in resp [:request :content-type])))
 
       (testing "Even if the client sends something insane, "
                "just pass it through and let the puppet code handle it."
-        (let [resp (app {:request-method :put
-                         :content-type   "something-crazy/for-content-type"
-                         :uri            "/v3/file_bucket_file/bar"})]
+        (let [resp (app (-> {:request-method :put
+                          :content-type "something-crazy/for-content-type"
+                          :uri "/v3/file_bucket_file/bar"}
+                            (mock/body "foo")))]
           (is (= "something-crazy/for-content-type"
                  (get-in resp [:request :content-type]))))))))
 

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -90,7 +90,7 @@
               path paths]
         (let [resp (request method (str "/v3/" path "/bar?environment=environment1234"))]
           (is (nil? (get-in resp [:request :params "code_id"])))
-          (is (nil? (get-in resp [:request :assoc-code-id]))))))))
+          (is (nil? (get-in resp [:request :include-code-id?]))))))))
 
 (defn assert-failure-msg
   "Assert the message thrown by validate-memory-requirements! matches re"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -24,11 +24,12 @@
         app         (build-ring-handler handler "1.2.3")
         request     (partial app-request app)]
     (is (= 200 (:status (request "/v3/environments"))))
+    (is (= 200 (:status (request "/v3/catalog/bar?environment=environment1234"))))
+    (is (= 200 (:status (request :post "/v3/catalog/bar?environment=environment1234"))))
     (is (= 404 (:status (request "/foo"))))
     (is (= 404 (:status (request "/foo/bar"))))
     (doseq [[method paths]
-            {:get ["catalog"
-                   "node"
+            {:get ["node"
                    "environment"
                    "file_content"
                    "file_metadatas"
@@ -37,7 +38,6 @@
                    "resource_type"
                    "resource_types"
                    "status"]
-             :post ["catalog"]
              :put ["file_bucket_file"
                    "report"]
              :head ["file_bucket_file"]}
@@ -72,8 +72,7 @@
   (testing "code_id is calculated and added to the catalog request."
     (let [handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" (constantly "foo-is-my-codeid"))
-          resp (app {:request-method :get
-                     :uri "/v3/catalog/bar"})]
+          resp (app-request app "/v3/catalog/bar?environment=environment1234")]
       (is (= "foo-is-my-codeid" (get-in resp [:request :params "code_id"])))))
   (testing "code_id is not added to non-catalog requests"
     (let [handler (fn ([req] {:request req}))
@@ -93,7 +92,7 @@
                      "report"]
                :head ["file_bucket_file"]}
               path paths]
-        (let [resp (request method (str "/v3/" path "/bar"))]
+        (let [resp (request method (str "/v3/" path "/bar?environment=environment1234"))]
           (is (nil? (get-in resp [:request :params "code_id"]))))))))
 
 (defn assert-failure-msg

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -3,17 +3,16 @@
             [puppetlabs.services.master.master-core :refer :all]
             [ring.mock.request :as mock]
             [schema.test :as schema-test]
-            [puppetlabs.comidi :as comidi]))
+            [puppetlabs.comidi :as comidi]
+            [puppetlabs.services.request-handler.request-handler-core :as request-handler-core]))
 
 (use-fixtures :once schema-test/validate-schemas)
 
 (defn build-ring-handler
-  ([request-handler puppet-version]
-   (build-ring-handler request-handler puppet-version (constantly nil)))
-  ([request-handler puppet-version code-id-fn]
-   (-> (root-routes request-handler code-id-fn)
-       (comidi/routes->handler)
-       (wrap-middleware puppet-version))))
+  [request-handler puppet-version]
+  (-> (root-routes request-handler)
+      (comidi/routes->handler)
+      (wrap-middleware puppet-version)))
 
 (defn app-request
   ([app path] (app-request app :get path))
@@ -71,14 +70,9 @@
                  (get-in resp [:request :content-type]))))))))
 
 (deftest code-id-injection-test
-  (testing "code_id is calculated and added to the catalog request."
-    (let [handler (fn ([req] {:request req}))
-          app (build-ring-handler handler "1.2.3" (constantly "foo-is-my-codeid"))
-          resp (app-request app "/v3/catalog/bar?environment=environment1234")]
-      (is (= "foo-is-my-codeid" (get-in resp [:request :params "code_id"])))))
   (testing "code_id is not added to non-catalog requests"
     (let [handler (fn ([req] {:request req}))
-          app (build-ring-handler handler "1.2.3" (constantly "foo-is-my-codeid"))
+          app (build-ring-handler handler "1.2.3")
           request (partial app-request app)]
       (doseq [[method paths]
               {:get ["node"
@@ -95,7 +89,8 @@
                :head ["file_bucket_file"]}
               path paths]
         (let [resp (request method (str "/v3/" path "/bar?environment=environment1234"))]
-          (is (nil? (get-in resp [:request :params "code_id"]))))))))
+          (is (nil? (get-in resp [:request :params "code_id"])))
+          (is (nil? (get-in resp [:request :assoc-code-id]))))))))
 
 (defn assert-failure-msg
   "Assert the message thrown by validate-memory-requirements! matches re"

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -276,14 +276,14 @@
     (logutils/with-test-logging
       (testing "slingshot bad requests translated to ring response"
         (let [bad-message "it's real bad"
-              request-handler (core/build-request-handler dummy-service {})]
+              request-handler (core/build-request-handler dummy-service {} (constantly nil))]
           (with-redefs [core/as-jruby-request (fn [_ _]
                                                 (core/throw-bad-request!
                                                   bad-message))]
             (let [response (request-handler {:body (StringReader. "blah")})]
               (is (= 400 (:status response)) "Unexpected response status")
               (is (= bad-message (:body response)) "Unexpected response body")))
-          (let [request-handler (core/build-request-handler dummy-service-with-timeout {})
+          (let [request-handler (core/build-request-handler dummy-service-with-timeout {} (constantly nil))
                 response (request-handler {:body (StringReader. "")})]
             (is (= 503 (:status response)) "Unexpected response status")
             (is (.startsWith


### PR DESCRIPTION
This commit refactors the code which computes the code_id to only do so
while holding a JRuby instance.  This ensures that other code which may
result in the code_id changing (such as File Sync) and which requires
use of the JRubyPool's lock cannot be run in between the time when the
code_id is computed and when the catalog is compiled.