### PR TITLE
(SERVER-876) Add test for current-code-id function

### DIFF
--- a/dev-resources/puppetlabs/services/request_handler/request_handler_core_test/puppet.conf
+++ b/dev-resources/puppetlabs/services/request_handler/request_handler_core_test/puppet.conf
@@ -1,0 +1,2 @@
+[main]
+certname = localhost

--- a/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_service.clj
@@ -8,7 +8,8 @@
 (tk/defservice request-handler-service
   handler/RequestHandlerService
   [[:PuppetServerConfigService get-config]
-   [:VersionedCodeService current-code-id]]
+   [:VersionedCodeService current-code-id]
+   [:JRubyPuppetService]]
   (init [this context]
     (let [jruby-service (tk-services/get-service this :JRubyPuppetService)
           config (get-config)]

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -6,6 +6,12 @@
   (:import (java.io File)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def PuppetConfFiles
+  {schema/Str (schema/pred (some-fn string? #(instance? File %)))})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Default settings
 
 (def conf-dir
@@ -37,6 +43,35 @@
    ssl-request-options
    {:headers     {"Accept" "pson"}
     :as          :text}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Internal functions
+
+(schema/defn ^:always-validate get-with-puppet-conf-target-paths :- PuppetConfFiles
+  "Helper function that joins the filename onto the dest-dir for each file in
+  puppet-conf-files."
+  [puppet-conf-files :- PuppetConfFiles
+   dest-dir :- schema/Str]
+  (reduce
+   (fn [acc filename]
+     (assoc acc filename (fs/file dest-dir filename)))
+   {}
+   (keys puppet-conf-files)))
+
+(schema/defn ^:always-validate copy-with-puppet-conf-files-into-place!
+  "Copies each file in puppet-conf-files into the corresponding destination in
+  target-paths."
+  [puppet-conf-files :- PuppetConfFiles
+   target-paths :- PuppetConfFiles]
+  (doseq [filename (keys puppet-conf-files)]
+    (fs/copy+ (get puppet-conf-files filename)
+              (get target-paths filename))))
+
+(schema/defn ^:always-validate cleanup-with-puppet-conf-files!
+  "Deletes all of the files in the target-paths map."
+  [target-paths :- PuppetConfFiles]
+  (doseq [target-path (vals target-paths)]
+    (fs/delete target-path)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities
@@ -101,7 +136,31 @@
   [catalogs resource-type resource-title]
   (count (filter #(catalog-contains? % resource-type resource-title) catalogs)))
 
-(schema/defn ^:always-validate with-puppet-conf-files
+(defmacro with-puppet-conf-files
+  "A macro that can be used to wrap a single test with the setup and teardown
+  of with-puppet-conf.
+
+  Accepts a map with the following characteristics:
+
+  * keys are simple filenames (no paths) that will be created in puppet's $confdir
+  * values are paths to a test-specific file that should be copied to puppet's confdir,
+    a la `$confdir/<key>`.
+
+  For each entry in the map, copies the files into $confdir, runs the test function,
+  and then deletes all of the files from $confdir.
+
+  Optionally accepts a second argument `dest-dir`, which specifies the location
+  of Puppet's $confdir.  If this argument is not provided, defaults to
+  `jruby-testutils/conf-dir`."
+  [puppet-conf-files dest-dir & body]
+  `(let [target-paths# (get-with-puppet-conf-target-paths ~puppet-conf-files ~dest-dir)]
+     (copy-with-puppet-conf-files-into-place! ~puppet-conf-files target-paths#)
+     (try
+       ~@body
+       (finally
+         (cleanup-with-puppet-conf-files! target-paths#)))))
+
+(schema/defn ^:always-validate with-puppet-conf-fixture
   "Test fixture; Accepts a map with the following characteristics:
 
   * keys are simple filenames (no paths) that will be created in puppet's $confdir
@@ -113,26 +172,13 @@
 
   Optionally accepts a second argument `dest-dir`, which specifies the location
   of Puppet's $confdir.  If this argument is not provided, defaults to
-  `testutils/conf-dir`."
+  `jruby-testutils/conf-dir`."
   ([puppet-conf-files]
-   (with-puppet-conf-files puppet-conf-files conf-dir))
-  ([puppet-conf-files :- {schema/Str (schema/pred (some-fn string? #(instance? File %)))}
+   (with-puppet-conf-fixture puppet-conf-files conf-dir))
+  ([puppet-conf-files :- PuppetConfFiles
     dest-dir :- schema/Str]
-
-   (let [target-paths (reduce
-                       (fn [acc filename]
-                         (assoc acc filename (fs/file dest-dir filename)))
-                       {}
-                       (keys puppet-conf-files))]
-     (fn [f]
-       (doseq [filename (keys puppet-conf-files)]
-         (fs/copy+ (get puppet-conf-files filename)
-                   (get target-paths filename)))
-       (try
-         (f)
-         (finally
-           (doseq [target-path (vals target-paths)]
-             (fs/delete target-path))))))))
+   (fn [f]
+     (with-puppet-conf-files puppet-conf-files dest-dir (f)))))
 
 (defn with-puppet-conf
   "This function returns a test fixture that will copy a specified puppet.conf
@@ -142,4 +188,4 @@
   ([puppet-conf-file]
    (with-puppet-conf puppet-conf-file conf-dir))
   ([puppet-conf-file dest-dir]
-   (with-puppet-conf-files {"puppet.conf" puppet-conf-file} dest-dir)))
+   (with-puppet-conf-fixture {"puppet.conf" puppet-conf-file} dest-dir)))

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -146,8 +146,9 @@
   * values are paths to a test-specific file that should be copied to puppet's confdir,
     a la `$confdir/<key>`.
 
-  For each entry in the map, copies the files into $confdir, runs the test function,
-  and then deletes all of the files from $confdir.
+  For each entry in the map, copies the files into $confdir.
+  Then it runs the body.
+  Then after running the body it deletes all of the files from $confdir.
 
   Optionally accepts a second argument `dest-dir`, which specifies the location
   of Puppet's $confdir.  If this argument is not provided, defaults to

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.services.request-handler.request-handler-core-test
   (:import (java.io StringReader ByteArrayInputStream))
   (:require [clojure.test :refer :all]
+            [me.raynes.fs :as fs]
             [slingshot.test :refer :all]
             [ring.util.codec :as ring-codec]
             [puppetlabs.services.request-handler.request-handler-core :as core]
@@ -8,7 +9,23 @@
             [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.puppetserver.certificate-authority :as cert-authority]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [puppetlabs.trapperkeeper.app :as tk-app]
+            [puppetlabs.trapperkeeper.services :refer [defservice service] :as svcs]
+            [puppetlabs.services.jruby.puppet-environments-int-test :as jruby-int-test]
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby-service]
+            [puppetlabs.puppetserver.bootstrap-testutils :as jruby-bootstrap]
+            [puppetlabs.services.protocols.versioned-code :as vc]
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as profiler]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
+            [puppetlabs.services.request-handler.request-handler-service :as handler-service]
+            [puppetlabs.services.config.puppet-server-config-service :as ps-config]
+            [puppetlabs.services.master.master-service :as master-service]
+            [puppetlabs.services.ca.certificate-authority-service :as ca-service]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service :as routing-service]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-service :as authorization-service]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
+            [puppetlabs.puppetserver.testutils :as testutils]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Test Data
@@ -259,6 +276,47 @@
                     (-> (str test-resources-dir "/master-with-all-cas.pem")
                         slurp
                         ring-codec/url-encode))))))
+
+(deftest ^:integration test-jruby-pool-not-full-during-code-id-generation
+   (testing "A jruby instance is held while code id is generated"
+     ; Okay, some prose to describe the test at hand.
+     ; Here we are validating that the code id command is run by the same jruby
+     ; instance that will be handling the current request. To do this we stand
+     ; up most of the stack, and replace the current-code-id function with a
+     ; variety that we can control entry into and exit from. This allows us
+     ; to make a request, and then while the request is in progress, make some
+     ; assertions about the pool state, and then finish the request.
+     (testutils/with-puppet-conf-files
+      {"puppet.conf" (fs/file test-resources-dir "puppet.conf")}
+      jruby-bootstrap/master-conf-dir
+      (let [first-promise (promise)
+            second-promise (promise)
+            custom-vcs (service vc/VersionedCodeService
+                         []
+                         (current-code-id [_ _]
+                                          (deliver first-promise true)
+                                          (deref second-promise 5000 false)))
+            services [master-service/master-service
+                      jruby-service/jruby-puppet-pooled-service
+                      profiler/puppet-profiler-service
+                      handler-service/request-handler-service
+                      ps-config/puppet-server-config-service
+                      jetty9/jetty9-service
+                      ca-service/certificate-authority-service
+                      authorization-service/authorization-service
+                      routing-service/webrouting-service
+                      custom-vcs]]
+        (jruby-bootstrap/with-puppetserver-running-with-services
+         app services {:jruby-puppet {:max-active-instances 1}}
+         (jruby-testutils/wait-for-jrubies app)
+         (let [jruby-service (tk-app/get-service app :JRubyPuppetService)]
+           (future (testutils/get-catalog))
+           (is (deref first-promise 5000 false))
+           ; Because we are blocking inside current-code-id, which happens to be
+           ; used during a jruby request, we can assert that there will be no
+           ; jruby instances left in the pool.
+           (is (zero? (jruby-protocol/free-instance-count jruby-service)))
+           (deliver second-promise true)))))))
 
 (deftest request-handler-test
   (let [dummy-service (reify jruby-protocol/JRubyPuppetService

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -1,13 +1,13 @@
 (ns puppetlabs.services.request-handler.request-handler-core-test
   (:import (java.io StringReader ByteArrayInputStream))
-  (:require [puppetlabs.services.request-handler.request-handler-core :as core]
+  (:require [clojure.test :refer :all]
+            [slingshot.test :refer :all]
+            [ring.util.codec :as ring-codec]
+            [puppetlabs.services.request-handler.request-handler-core :as core]
             [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.ssl-utils.simple :as ssl-simple]
             [puppetlabs.puppetserver.certificate-authority :as cert-authority]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [clojure.test :refer :all]
-            [ring.util.codec :as ring-codec]
-            [slingshot.test :refer :all]
             [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -8,7 +8,7 @@
             [clojure.test :refer :all]
             [ring.util.codec :as ring-codec]
             [slingshot.test :refer :all]
-            [puppetlabs.services.protocols.jruby-puppet :as jruby]))
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Test Data
@@ -261,13 +261,13 @@
                         ring-codec/url-encode))))))
 
 (deftest request-handler-test
-  (let [dummy-service (reify jruby/JRubyPuppetService
+  (let [dummy-service (reify jruby-protocol/JRubyPuppetService
                         (borrow-instance [_ _] {})
                         (return-instance [_ _ _])
                         (free-instance-count [_])
                         (mark-all-environments-expired! [_])
                         (flush-jruby-pool! [_]))
-        dummy-service-with-timeout (reify jruby/JRubyPuppetService
+        dummy-service-with-timeout (reify jruby-protocol/JRubyPuppetService
                                      (borrow-instance [_ _] nil)
                                      (return-instance [_ _ _])
                                      (free-instance-count [_])


### PR DESCRIPTION
A previous commit moved where the current-code-id function was called
during request handling into the jruby request handler. In order to
ensure that current-code-id is always calculated with the same jruby
that is handling the request, this commit adds a test that makes a
request and inspects the state of the jruby pool while code id is being
calculated during the request.