### PR TITLE
(SERVER-1115) Tolerate invalid-in-puppet-4 key in master webroute config

### DIFF
--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -53,10 +53,13 @@
        ;; if the webrouting config uses the old-style config where
        ;; there is a single key with a route-id, we need to deal with that
        ;; for backward compat.  We have a hard-coded assumption that this route-id
-       ;; must be `master-routes`.  We should be able to remove this hack as soon
-       ;; as we are able to get rid of the legacy routes.
+       ;; must be `master-routes`.  In Puppet Server 2.0, we also supported a
+       ;; key called `invalid-in-puppet-4` in the same route config, even though
+       ;; that key is no longer used for Puppet Server 2.1 and later.  We
+       ;; should be able to remove this hack as soon as we are able to get rid
+       ;; of the legacy routes.
        (if (and (map? route-config)
-                (= #{:master-routes} (ks/keyset route-config)))
+                (contains? route-config :master-routes))
          (add-ring-handler this ring-handler
                            {:route-id :master-routes})
          (add-ring-handler this ring-handler))))

--- a/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
+++ b/test/integration/puppetlabs/services/legacy_routes/legacy_routes_test.clj
@@ -40,7 +40,8 @@
     (bootstrap/with-puppetserver-running app
       {:web-router-service
        {:puppetlabs.services.master.master-service/master-service
-        {:master-routes "/puppet"}}}
+        {:master-routes "/puppet"
+         :invalid-in-puppet-4 "/"}}}
       (is (= 200 (:status (http-get "/puppet/v3/node/localhost?environment=production"))))))
 
   (testing "The new map-style multi-server route configuration map still works."


### PR DESCRIPTION
This commit re-adds the ability to tolerate the now obsolete
`invalid-in-puppet-4` key in the webroute config for the master-service.
The work for SERVER-1071 had removed this support, causing the server to
fail to start up if it still had this key in the config.