### PR TITLE
(SERVER-887) Implement get-code-content

### DIFF
--- a/src/clj/puppetlabs/services/protocols/versioned_code.clj
+++ b/src/clj/puppetlabs/services/protocols/versioned_code.clj
@@ -5,4 +5,7 @@
 
   (current-code-id
    [this environment]
-   "Returns the current code id (representing the freshest code) for the given environment."))
+   "Returns the current code id (representing the freshest code) for the given environment.")
+  (get-code-content
+   [this environment code-id file-path]
+   "Returns the content of file-path in the given environment at the revision represented by code-id."))

--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
@@ -15,10 +15,20 @@
    [this context]
    (if (nil? (get-in-config [:versioned-code :code-id-command]))
      (log/info "No code-id-command set for versioned-code-service. Code-id will be nil."))
+   (if (nil? (get-in-config [:versioned-code :code-content-command]))
+     (log/info "No code-content-command set for versioned-code-service. Attempting to fetch code content will fail."))
    context)
 
   (current-code-id
    [this environment]
    (if-let [code-id-script (get-in-config [:versioned-code :code-id-command])]
      (vc-core/execute-code-id-script! code-id-script environment)
-     nil)))
+     nil))
+
+  (get-code-content
+   [this environment code-id file-path]
+   (if-let [code-content-script (get-in-config [:versioned-code :code-content-command])]
+     (vc-core/execute-code-content-script!
+       code-content-script environment code-id file-path)
+     (throw (IllegalStateException.
+             "Cannot fetch code content without :code-content-command being set.")))))

--- a/src/java/com/puppetlabs/puppetserver/ExecutionResult.java
+++ b/src/java/com/puppetlabs/puppetserver/ExecutionResult.java
@@ -1,11 +1,15 @@
 package com.puppetlabs.puppetserver;
 
+import java.io.InputStream;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+
 public class ExecutionResult {
-    private final String output;
+    private final InputStream output;
     private final String error;
     private final int exitCode;
 
-    public ExecutionResult(String output, String error, int exitCode) {
+    public ExecutionResult(InputStream output, String error, int exitCode) {
         this.output = output;
         this.error = error;
         this.exitCode = exitCode;
@@ -15,7 +19,11 @@ public class ExecutionResult {
         return exitCode;
     }
 
-    public String getOutput() {
+    public String getOutput() throws IOException {
+        return IOUtils.toString(output, "UTF-8");
+    }
+
+    public InputStream getOutputAsStream() {
         return output;
     }
 

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -69,5 +69,5 @@
            {:code-id-command (script-path "warn_echo_and_error")}}
       (let [catalog (testutils/get-catalog)]
         (is (nil? (get catalog "code_id")))
-        (is (logged? #"Non-zero exit code returned while calculating code id." :error))
+        (is (logged? #"Non-zero exit code returned while running" :error))
         (is (logged? #"Executed an external process which logged to STDERR: production" :warn)))))))

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -3,7 +3,8 @@
     [clojure.test :refer :all]
     [puppetlabs.services.versioned-code-service.versioned-code-core :as vc-core]
     [puppetlabs.trapperkeeper.testutils.logging :as logging]
-    [me.raynes.fs :as fs]))
+    [me.raynes.fs :as fs])
+  (:import (org.apache.commons.io IOUtils)))
 
 (def test-resources
   (fs/absolute-path
@@ -20,14 +21,40 @@
   (testing "stderr is logged if generated"
     (logging/with-test-logging
      (is (= "" (vc-core/execute-code-id-script! (script-path "warn") "foo")))
-     (is (logged? (format "Error output generated while calculating code id. Command executed: '%s', stderr: '%s'" (script-path "warn") "foo\n")))))
+     (is (logged? (format "Error output generated while running '%s'. stderr: '%s'" (script-path "warn") "foo\n")))))
 
   (testing "exit-code, stdout and stderr are all logged for non-zero exit"
     (logging/with-test-logging
      (is (nil? (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
-     (is (logged? (format "Non-zero exit code returned while calculating code id. Command executed: '%s', exit-code '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
+     (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
 
   (testing "nil is returned and error logged for exception during execute-command"
     (logging/with-test-logging
      (is (nil? (vc-core/execute-code-id-script! "false" "foo")))
-     (is (logged? "Calculating code id generated an error. Command executed: 'false', error generated: 'An absolute path is required, but 'false' is not an absolute path'")))))
+     (is (logged? "Running script generated an error. Command executed: 'false', error generated: 'An absolute path is required, but 'false' is not an absolute path'")))))
+
+(deftest test-code-content-execution
+  (testing "when executing external code content command"
+    (let [environment "test"
+          code-id "bourgeoisie123"
+          file-path "foo/bar/baz"]
+      (testing "and code-id is nil we see a schema error"
+        (is (thrown-with-msg? Exception #"code-id.*nil"
+                              (vc-core/execute-code-content-script! (script-path "echo") environment nil file-path))))
+      (testing "and we failed to run the command we see the expected exception"
+        (is (thrown-with-msg? IllegalStateException #"generated an error.*false"
+                              (vc-core/execute-code-content-script! "false" environment code-id file-path))))
+      (testing "and the command returned nonzero"
+        (logging/with-test-logging
+          (is (thrown-with-msg? IllegalStateException #"Non-zero.*warn_echo_and_error"
+                                (vc-core/execute-code-content-script! (script-path "warn_echo_and_error")
+                                                                      environment code-id file-path)))))
+      (testing "and the command succeeded"
+        (testing "with stderr"
+          (logging/with-test-logging
+            (let [result (vc-core/execute-code-content-script! (script-path "warn") environment code-id file-path)]
+              (is (= "" (IOUtils/toString result "UTF-8")))
+              (is (logged? (format "Error output generated while running '%s'. stderr: '%s'" (script-path "warn") (format "%s %s %s\n" environment code-id file-path)))))))
+        (testing "witout stderr"
+          (let [result (vc-core/execute-code-content-script! (script-path "echo") environment code-id file-path)]
+            (is (= (format "%s %s %s\n" environment code-id file-path) (IOUtils/toString result "UTF-8")))))))))


### PR DESCRIPTION
This implements the open source half of get-code-content. This work is very similar to the current-code-id work with the important caveat that it switches ShellUtils's ExecutionResult to using a ByteArrayInputStream internally for stdout instead of a string.

There is some minor refactoring of the current-code-id stuff to have it share error message code with get-code-content.