### PR TITLE
(PE-13485) Implement a consistent request logging format

### DIFF
--- a/resources/ext/config/request-logging.xml
+++ b/resources/ext/config/request-logging.xml
@@ -2,7 +2,7 @@
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>/var/log/puppetlabs/puppetserver/puppetserver-access.log</file>
     <encoder>
-        <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+        <pattern>%h %l %u [%t] "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D</pattern>
     </encoder>
   </appender>
   <appender-ref ref="FILE" />


### PR DESCRIPTION
Prior to this commit puppetserver used a different request
logging format than puppetdb and console-services.

After this commit the request logging will be of the suggested
formatting for all trapper-keeper projects.