### PR TITLE
(SERVER-880) Add static_file_content endpoint

### DIFF
--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -30,7 +30,8 @@
                                 config)
           jruby-service (tk-services/get-service this :JRubyPuppetService)
           master-route-handler (-> (master-core/root-routes handle-request
-                                                            jruby-service)
+                                                            jruby-service
+                                                            (constantly nil))
                                    ((partial comidi/context path))
                                    comidi/routes->handler)
           master-handler-info {:mount       (master-core/get-master-mount

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -81,7 +81,9 @@
    ring/wrap-params))
 
 (defn static-file-content-request-handler
-  "Build the main request handler for the /static_file_content endpoint"
+  "Returns a function which is the main request handler for the
+  /static_file_content endpoint, utilizing the provided implementation of
+  `get-code-content`"
   [get-code-content]
   (fn [req]
     (let [environment (get-in req [:params "environment"])

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -80,6 +80,17 @@
    jruby-request/wrap-with-error-handling
    ring/wrap-params))
 
+(defn static-file-content-request-handler
+  "Build the main request handler for the /static_file_content endpoint"
+  [get-code-content]
+  (fn [req]
+    (let [environment (get-in req [:params "environment"])
+          code-id (get-in req [:params "code-id"])
+          file-path (get-in req [:params :rest])
+          content-stream (get-code-content environment code-id file-path)]
+      {:status 200
+       :body content-stream})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
 
@@ -89,7 +100,7 @@
    endpoints are handled separately by the CA service."
   [request-handler jruby-service get-code-content-fn]
   (let [environment-class-handler (environment-class-handler jruby-service)
-        static-file-content-handler (request-core/static-file-content-request-handler get-code-content-fn)]
+        static-file-content-handler (static-file-content-request-handler get-code-content-fn)]
     (comidi/routes
      (comidi/GET ["/node/" [#".*" :rest]] request
                  (request-handler request))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -85,11 +85,15 @@
   [get-code-content]
   (fn [req]
     (let [environment (get-in req [:params "environment"])
-          code-id (get-in req [:params "code-id"])
-          file-path (get-in req [:params :rest])
-          content-stream (get-code-content environment code-id file-path)]
-      {:status 200
-       :body content-stream})))
+          code-id (get-in req [:params "code_id"])
+          file-path (get-in req [:params :rest])]
+      (if (or (nil? environment)
+              (nil? code-id)
+              (or (nil? file-path) (= "" file-path)))
+        {:status 400
+         :body "Error: A /static_file_content request requires an environment, a code-id, and a file-path"}
+        {:status 200
+         :body   (get-code-content environment code-id file-path)}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -16,7 +16,8 @@
    [:RequestHandlerService handle-request]
    [:CaService initialize-master-ssl! retrieve-ca-cert! retrieve-ca-crl!]
    [:JRubyPuppetService]
-   [:AuthorizationService wrap-with-authorization-check]]
+   [:AuthorizationService wrap-with-authorization-check]
+   [:VersionedCodeService get-code-content]]
   (init
    [this context]
    (core/validate-memory-requirements!)
@@ -45,7 +46,9 @@
            path (core/get-master-mount ::master-service route-config)
            ring-handler (when path
                           (core/get-wrapped-handler
-                            (-> (core/root-routes handle-request jruby-service)
+                            (-> (core/root-routes handle-request
+                                                  jruby-service
+                                                  get-code-content)
                                 ((partial comidi/context path))
                                 comidi/routes->handler)
                             wrap-with-authorization-check

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -285,3 +285,14 @@
   (-> (jruby-request-handler config current-code-id)
       (jruby-request/wrap-with-jruby-instance jruby-service)
       jruby-request/wrap-with-error-handling))
+
+(defn static-file-content-request-handler
+  "Build the main request handler for the /static_file_content endpoint"
+  [get-code-content]
+  (fn [req]
+    (let [environment (get-in req [:params "environment"])
+          code-id (get-in req [:params "code-id"])
+          file-path (get-in req [:params :rest])
+          content-stream (get-code-content environment code-id file-path)]
+      {:status 200
+       :body content-stream})))

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -285,14 +285,3 @@
   (-> (jruby-request-handler config current-code-id)
       (jruby-request/wrap-with-jruby-instance jruby-service)
       jruby-request/wrap-with-error-handling))
-
-(defn static-file-content-request-handler
-  "Build the main request handler for the /static_file_content endpoint"
-  [get-code-content]
-  (fn [req]
-    (let [environment (get-in req [:params "environment"])
-          code-id (get-in req [:params "code-id"])
-          file-path (get-in req [:params :rest])
-          content-stream (get-code-content environment code-id file-path)]
-      {:status 200
-       :body content-stream})))

--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
@@ -31,4 +31,4 @@
      (vc-core/execute-code-content-script!
        code-content-script environment code-id file-path)
      (throw (IllegalStateException.
-             "Cannot fetch code content without :code-content-command being set.")))))
+              "Cannot retrieve code content because the \"versioned-code.code-content-command\" setting is not present in configuration.")))))

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -119,4 +119,6 @@
         (let [response (http-client/get "https://localhost:8140/puppet/v3/static_file_content/foo/bar/?code_id=foobar&environment=test"
                                         (assoc testutils/ssl-request-options
                                           :as :stream))]
-          (is (= 500 (:status response))))))))
+          (is (= 500 (:status response)))
+          (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"
+                 (slurp (:body response)))))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -14,7 +14,7 @@
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]
-  (-> (root-routes request-handler jruby-service)
+  (-> (root-routes request-handler jruby-service (constantly nil))
       (comidi/routes->handler)
       (wrap-middleware puppet-version)))
 

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_service_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_service_test.clj
@@ -50,7 +50,7 @@
       (logging/with-test-logging
         (tk-testutils/with-app-with-config app [vcs/versioned-code-service] {}
           (let [vcs (tk-app/get-service app :VersionedCodeService)]
-            (is (thrown-with-msg? IllegalStateException #"without :code-content-command"
+            (is (thrown-with-msg? IllegalStateException #".*Cannot retrieve code content because the \"versioned-code.code-content-command\" setting is not present in configuration.*"
                                   (vc/get-code-content vcs "test" "foobar" "foo/bar/")))))))
     (testing "and there is a code-content-command"
       (logging/with-test-logging


### PR DESCRIPTION
Add a new /static_file_content web endpoint that exercises the
`get-code-content` service function from the VersionedCodeService.

This is based on top of https://github.com/puppetlabs/puppet-server/pull/885, which should be merged first. The relevant commit is 2bba3d2