### PR TITLE
(SERVER-1117) Update class-info tests per PUP-5713 changes

### DIFF
--- a/src/ruby/puppet-server-lib/puppet/server/master.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/master.rb
@@ -97,7 +97,7 @@ class Puppet::Server::Master
     # and so would not be subject to any potentially stale settings data being
     # used to enumerate manifests.
     environment = @env_loader.list.find do |env_from_loader|
-      env_from_loader.name == env
+      env_from_loader.name.to_s == env
     end
     unless environment.nil?
       environments = Hash[env, self.class.getManifests(environment)]

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -51,7 +51,8 @@
                 "type" "Integer"}
                {"name" (str class "_c"),
                 "type" "String",
-                "default_literal" "c default value"}]})
+                "default_literal" "c default value"
+                "default_source" "'c default value'"}]})
 
 (defn expected-manifests-info
   [manifests]


### PR DESCRIPTION
This commit contains two changes:

1) Update the class-info tests to expect a 'default_source' parameter to
   be present in the return from a call to the
   `ClassInformationService.classes_per_environment` method per expected
   changes made in PUP-5713.

2) Update the code in .getClassInfoForEnvironment from "master.rb" to
   ensure that the value of a candidate Puppet::Node::Environment's
   "name" is coerced to a String before comparing to the supplied String
   type environment argument.  Previously, the "name" was not coerced
   and so was being compared as a Symbol rather than a String, leading
   the comparison to always fail and for the target environment to not
   be found.