### PR TITLE
(SERVER-1094) log message about stdin jdk8 bug

### DIFF
--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -67,22 +67,15 @@
     opts :- ExecutionOptions]
    (let [{:keys [args env in]} (merge default-execution-options opts)]
      (validate-command! command)
-     (try
-       (let [process (ShellUtils/executeCommand
-                      command
-                      (into-array String args)
-                      (if env
-                        (ks/mapkeys name env))
-                      in)]
-         {:exit-code (.getExitCode process)
-          :stderr (.getError process)
-          :stdout (.getOutputAsStream process)})
-       (catch IOException e
-         (throw (IllegalStateException.
-                 (format "Exception while executing '%s': %s"
-                         command
-                         (.getMessage e))
-                 e)))))))
+     (let [process (ShellUtils/executeCommand
+                    command
+                    (into-array String args)
+                    (if env
+                      (ks/mapkeys name env))
+                    in)]
+       {:exit-code (.getExitCode process)
+        :stderr (.getError process)
+        :stdout (.getOutputAsStream process)}))))
 
 (schema/defn ^:always-validate
   execute-command :- ExecutionResult

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -1,8 +1,9 @@
 (ns puppetlabs.puppetserver.shell-utils-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.shell-utils :as sh-utils]
+            [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [me.raynes.fs :as fs])
-  (:import (java.io ByteArrayInputStream)))
+  (:import (java.io ByteArrayInputStream IOException)))
 
 (def test-resources
   (fs/absolute-path

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -1,9 +1,8 @@
 (ns puppetlabs.puppetserver.shell-utils-test
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.shell-utils :as sh-utils]
-            [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [me.raynes.fs :as fs])
-  (:import (java.io ByteArrayInputStream IOException)))
+  (:import (java.io ByteArrayInputStream)))
 
 (def test-resources
   (fs/absolute-path


### PR DESCRIPTION
This commit adds some extra error handling and logging around an edge case that we hit with JDK8 and commons-exec, where passing data on STDIN to a process that doesn't consume it can cause commons-exec to throw a not-very-helpful exception.  For more info see SERVER-1094 and linked tickets.