### PR TITLE
(SERVER-876) Update test for VersionedCodeService protocol change

### DIFF
--- a/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
+++ b/test/unit/puppetlabs/services/request_handler/request_handler_core_test.clj
@@ -295,7 +295,9 @@
                          []
                          (current-code-id [_ _]
                                           (deliver first-promise true)
-                                          (deref second-promise 5000 false)))
+                                          (deref second-promise 5000 false))
+                         (get-code-content [_ _ _ _]
+                                               nil))
             services [master-service/master-service
                       jruby-service/jruby-puppet-pooled-service
                       profiler/puppet-profiler-service


### PR DESCRIPTION
The VCS protocol recently was updated to include the get-code-content
function, so this commit updates a request_handler_core test that
implemented a custom VCS service to include that function in its
definition.