### PR TITLE
(MAINT) remove not-found handler for master service

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -176,8 +176,7 @@
   [request-handler jruby-service]
   (comidi/routes
     (comidi/context "/v3"
-                    (v3-routes request-handler jruby-service))
-    (comidi/not-found "Not Found")))
+                    (v3-routes request-handler jruby-service))))
 
 (schema/defn ^:always-validate
   wrap-middleware :- IFn

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -32,8 +32,8 @@
                                   :uri "/v3/catalog/bar"
                                   :content-type "application/x-www-form-urlencoded"}
                                  (mock/body "environment=environment1234"))))))
-    (is (= 404 (:status (request "/foo"))))
-    (is (= 404 (:status (request "/foo/bar"))))
+    (is (nil? (request "/foo")))
+    (is (nil? (request "/foo/bar")))
     (doseq [[method paths]
             {:get ["node"
                    "environment"


### PR DESCRIPTION
The `not-found` handler for `/puppet` did not appear to be strictly
necessary, and since we are referencing this route tree from other
namespaces (and potentially composing it with other route trees),
getting rid of it makes the code more re-usable.