### PR TITLE
(SERVER-1111) Add Etag / If-None-Match Processing to environment_classes Endpoint

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/ssl-utils "0.8.1"]
                  [puppetlabs/dujour-version-check "0.1.2" :exclusions [org.clojure/tools.logging]]
-                 [puppetlabs/http-client "0.4.4"]
+                 [puppetlabs/http-client "0.5.0"]
                  [puppetlabs/comidi "0.3.1"]]
 
   :main puppetlabs.trapperkeeper.main

--- a/src/clj/puppetlabs/puppetserver/ringutils.clj
+++ b/src/clj/puppetlabs/puppetserver/ringutils.clj
@@ -21,6 +21,12 @@
    (schema/optional-key :ssl-client-cert) (schema/maybe X509Certificate)
    schema/Keyword schema/Any})
 
+(def RingResponse
+  {:status schema/Int
+   :headers {schema/Str schema/Any}
+   :body schema/Any
+   schema/Keyword schema/Any})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -40,7 +40,8 @@
         (-> context
             (assoc :pool-context pool-context)
             (assoc :borrow-timeout (:borrow-timeout config))
-            (assoc :event-callbacks (atom []))))))
+            (assoc :event-callbacks (atom []))
+            (assoc :environment-class-info (atom {}))))))
   (stop
    [this context]
    (let [{:keys [pool-context]} (tk-services/service-context this)
@@ -69,17 +70,35 @@
 
   (mark-environment-expired!
     [this env-name]
-    (let [pool-context (:pool-context (tk-services/service-context this))]
+    (let [environment-class-info (:environment-class-info
+                                  (tk-services/service-context this))
+          pool-context (:pool-context (tk-services/service-context this))]
+      (swap! environment-class-info dissoc env-name)
       (core/mark-environment-expired! pool-context env-name)))
 
   (mark-all-environments-expired!
     [this]
-    (let [pool-context (:pool-context (tk-services/service-context this))]
+    (let [environment-class-info (:environment-class-info
+                                  (tk-services/service-context this))
+          pool-context (:pool-context (tk-services/service-context this))]
+      (reset! environment-class-info {})
       (core/mark-all-environments-expired! pool-context)))
 
   (get-environment-class-info
     [this jruby-instance env-name]
     (.getClassInfoForEnvironment jruby-instance env-name))
+
+  (get-environment-class-info-tag
+   [this env-name]
+   (let [environment-class-info (:environment-class-info
+                                 (tk-services/service-context this))]
+     (get @environment-class-info env-name)))
+
+  (set-environment-class-info-tag!
+   [this env-name tag]
+   (let [environment-class-info (:environment-class-info
+                                 (tk-services/service-context this))]
+     (swap! environment-class-info assoc env-name tag)))
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -41,7 +41,7 @@
             (assoc :pool-context pool-context)
             (assoc :borrow-timeout (:borrow-timeout config))
             (assoc :event-callbacks (atom []))
-            (assoc :environment-class-info (atom {}))))))
+            (assoc :environment-class-info-tags (atom {}))))))
   (stop
    [this context]
    (let [{:keys [pool-context]} (tk-services/service-context this)
@@ -70,19 +70,17 @@
 
   (mark-environment-expired!
     [this env-name]
-    (let [environment-class-info (:environment-class-info
-                                  (tk-services/service-context this))
-          pool-context (:pool-context (tk-services/service-context this))]
-      (swap! environment-class-info dissoc env-name)
+    (let [{:keys [environment-class-info-tags pool-context]}
+          (tk-services/service-context this)]
+      (swap! environment-class-info-tags dissoc env-name)
       (core/mark-environment-expired! pool-context env-name)))
 
   (mark-all-environments-expired!
     [this]
-    (let [environment-class-info (:environment-class-info
-                                  (tk-services/service-context this))
-          pool-context (:pool-context (tk-services/service-context this))]
-      (reset! environment-class-info {})
-      (core/mark-all-environments-expired! pool-context)))
+    (let [{:keys [environment-class-info-tags pool-context]}
+          (tk-services/service-context this)]
+     (reset! environment-class-info-tags {})
+     (core/mark-all-environments-expired! pool-context)))
 
   (get-environment-class-info
     [this jruby-instance env-name]
@@ -90,13 +88,13 @@
 
   (get-environment-class-info-tag
    [this env-name]
-   (let [environment-class-info (:environment-class-info
+   (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (get @environment-class-info env-name)))
 
   (set-environment-class-info-tag!
    [this env-name tag]
-   (let [environment-class-info (:environment-class-info
+   (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (swap! environment-class-info assoc env-name tag)))
 

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -40,6 +40,16 @@
     [this jruby-instance env-name]
     "Get class information for a specific environment")
 
+  (get-environment-class-info-tag
+    [this env-name]
+    "Get a tag for the latest class information parsed for a specific
+    environment")
+
+  (set-environment-class-info-tag!
+    [this env-name tag]
+    "Set the tag computed for the latest class information parsed for a
+    specific environment")
+
   (flush-jruby-pool!
     [this]
     "Flush all the current JRuby instances and repopulate the pool.")

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -115,13 +115,17 @@
 ;;; Interacting with puppet code and catalogs
 
 (schema/defn ^:always-validate write-foo-pp-file :- schema/Str
-  ([foo-pp-contents]
+  ([foo-pp-contents :- schema/Str]
    (write-foo-pp-file foo-pp-contents "init"))
   ([foo-pp-contents :- schema/Str
     pp-name :- schema/Str]
+   (write-foo-pp-file foo-pp-contents pp-name "production"))
+  ([foo-pp-contents :- schema/Str
+    pp-name :- schema/Str
+    env-name :- schema/Str]
    (let [foo-pp-file (fs/file conf-dir
                               "environments"
-                              "production"
+                              env-name
                               "modules"
                               "foo"
                               "manifests"

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -114,25 +114,32 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Interacting with puppet code and catalogs
 
-(schema/defn ^:always-validate write-foo-pp-file :- schema/Str
-  ([foo-pp-contents :- schema/Str]
-   (write-foo-pp-file foo-pp-contents "init"))
-  ([foo-pp-contents :- schema/Str
+(schema/defn ^:always-validate write-pp-file :- schema/Str
+  ([pp-contents :- schema/Str
+    module-name :- schema/Str]
+   (write-pp-file pp-contents module-name "init"))
+  ([pp-contents :- schema/Str
+    module-name :- schema/Str
     pp-name :- schema/Str]
-   (write-foo-pp-file foo-pp-contents pp-name "production"))
-  ([foo-pp-contents :- schema/Str
+   (write-pp-file pp-contents module-name pp-name "production"))
+  ([pp-contents :- schema/Str
+    module-name :- schema/Str
     pp-name :- schema/Str
     env-name :- schema/Str]
-   (let [foo-pp-file (fs/file conf-dir
-                              "environments"
-                              env-name
-                              "modules"
-                              "foo"
-                              "manifests"
-                              (str pp-name ".pp"))]
-     (fs/mkdirs (fs/parent foo-pp-file))
-     (spit foo-pp-file foo-pp-contents)
-     (.getCanonicalPath foo-pp-file))))
+   (let [pp-file (fs/file conf-dir
+                          "environments"
+                          env-name
+                          "modules"
+                          module-name
+                          "manifests"
+                          (str pp-name ".pp"))]
+     (fs/mkdirs (fs/parent pp-file))
+     (spit pp-file pp-contents)
+     (.getCanonicalPath pp-file))))
+
+(schema/defn ^:always-validate write-foo-pp-file :- schema/Str
+  [foo-pp-contents]
+  (write-pp-file foo-pp-contents "foo"))
 
 (schema/defn ^:always-validate get-catalog :- PuppetCatalog
   "Make an HTTP get request for a catalog."

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -1,38 +1,65 @@
 (ns puppetlabs.services.master.environment-classes-int-test
   (:require [clojure.test :refer :all]
             [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [puppetlabs.puppetserver.testutils :as testutils]
             [cheshire.core :as cheshire]
-            [me.raynes.fs :as fs]
-            [ring.util.response :as ring]))
+            [me.raynes.fs :as fs]))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/master/environment_classes_int_test")
+
+(defn purge-env-dir
+  []
+  (-> testutils/conf-dir
+      (fs/file "environments")
+      fs/delete-dir))
 
 (use-fixtures :once
               (testutils/with-puppet-conf
                (fs/file test-resources-dir "puppet.conf"))
               (fn [f]
-                (let [env-dir (fs/file testutils/conf-dir
-                                       "environments")]
-                  (fs/delete-dir env-dir)
-                  (try
-                    (f)
-                    (finally
-                      (fs/delete-dir env-dir))))))
+                (purge-env-dir)
+                (try
+                  (f)
+                  (finally
+                    (purge-env-dir)))))
+
+(defn get-env-classes
+  ([env-name]
+   (get-env-classes env-name nil))
+  ([env-name if-none-match]
+   (let [opts (if if-none-match
+                {:headers {"If-None-Match" if-none-match}})]
+     (http-client/get
+      (str "https://localhost:8140/puppet/v3/"
+           "environment_classes?"
+           "environment="
+           env-name)
+      (merge
+       testutils/ssl-request-options
+       {:as :text}
+       opts)))))
+
+(defn purge-all-env-caches
+  []
+  (http-client/delete
+   "https://localhost:8140/puppet-admin-api/v1/environment-cache"
+   testutils/ssl-request-options))
+
+(defn purge-env-cache
+  [env]
+  (http-client/delete
+   (str "https://localhost:8140/puppet-admin-api/v1/environment-cache?"
+        "environment="
+        env)
+   testutils/ssl-request-options))
 
 (deftest ^:integration environment-classes-integration-test
   (bootstrap/with-puppetserver-running app
    {:jruby-puppet {:max-active-instances 1}}
-   (let [get-production-env-classes #(http-client/get
-                                      (str "https://localhost:8140/puppet/v3/"
-                                           "environment_classes?"
-                                           "environment=production")
-                                      (merge
-                                       testutils/ssl-request-options
-                                       {:as :text}))
-         response->class-info-map #(-> %1 :body cheshire/parse-string)
+   (let [response->class-info-map #(-> %1 :body cheshire/parse-string)
          foo-file (testutils/write-foo-pp-file
                    "class foo (String $foo_1 = \"is foo\"){}")
          bar-file (testutils/write-foo-pp-file
@@ -63,28 +90,41 @@
                                           "default_literal" "is foo",
                                           "default_source" "\"is foo\""}]}]}]
                                     "name" "production"}
-         initial-response (get-production-env-classes)
-         response-e-tag #(ring/get-header % "Etag")
-         initial-e-tag (response-e-tag initial-response)]
+         initial-response (get-env-classes "production")
+         response-etag #(get-in % [:headers "etag"])
+         initial-etag (response-etag initial-response)]
      (testing "initial fetch of environment_classes info is good"
        (is (= 200 (:status initial-response))
-           "unexpected status code for initial response")
-       (is (not (nil? initial-e-tag))
-           "no e-tag found for initial response")
+           (str
+            "unexpected status code for initial response, response: "
+            (ks/pprint-to-string initial-response)))
+       (is (not (nil? initial-etag))
+           "no etag found for initial response")
        (is (= expected-initial-response
               (response->class-info-map initial-response))
            "unexpected body for initial response"))
-     (testing "e-tag not updated for second fetch when code has not changed"
-       (let [response (get-production-env-classes)]
+     (testing "etag not updated when code has not changed"
+       (let [response (get-env-classes "production")]
          (is (= 200 (:status response))
              "unexpected status code for response following no code change")
-         (is (= initial-e-tag (response-e-tag response))
-             "e-tag changed even though code did not")
+         (is (= initial-etag (response-etag response))
+             "etag changed even though code did not")
          (is (= expected-initial-response
-                (response->class-info-map initial-response))
-             "unexpected body for initial response")))
-     (testing (str "environment_classes fetch includes latest info after "
-                   "code update")
+                (response->class-info-map response))
+             "unexpected body for response")))
+     (testing (str "HTTP 304 (not modified) returned when request "
+                   "roundtrips last etag and code has not changed")
+       (let [response (get-env-classes "production" initial-etag)]
+         (is (= 304 (:status response))
+             (str
+              "unexpected status code for response for no code change and "
+              "original etag roundtripped"))
+         (is (= initial-etag (response-etag response))
+             "etag changed even though code did not")
+         (is (empty? (:body response))
+             "unexpected body for response")))
+    (testing (str "environment_classes fetch without if-none-match "
+                  "header includes latest info after code update")
        (testutils/write-foo-pp-file
         (str "class foo (Hash[String, Integer] $foo_hash = {"
              " foo_1 => 1, foo_2 => 2 }){}"))
@@ -97,11 +137,14 @@
                        "baz")
              borked-file (testutils/write-foo-pp-file
                           (str "borked manifest") "borked")
-             response (get-production-env-classes)]
+             response (get-env-classes "production")]
          (is (= 200 (:status response))
-             "unexpected status code for response following code change")
-         (is (not= initial-e-tag (response-e-tag response))
-             "e-tag did not change even though code did")
+             (str
+              "unexpected status code for response following code change,"
+              "response: "
+              (ks/pprint-to-string response)))
+         (is (not= initial-etag (response-etag response))
+             "etag did not change even though code did")
          (is (= {"name" "production",
                  "files" [
                           {"path" bar-file
@@ -146,4 +189,261 @@
                                                    "{ foo_1 => 1, "
                                                    "foo_2 => 2 }")}]}]}]}
                 (response->class-info-map response))
-             "unexpected body following code change"))))))
+             "unexpected body following code change")))
+     (testing "environment class cache invalidation for one environment"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit for a single environment that only that the
+       ;; environment class info cached for that environment - but not the
+       ;; info cached for other environments - is invalidated, meaning that
+       ;; the next request for class info for that environment will get fresh
+       ;; data.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_classes queries return the right info for
+       ;;    them.
+       ;; 3) Do one more environment_classes query for each environment,
+       ;;    using the etag from the initial queries, to ensure that a 304
+       ;;    (Not Modified) is returned.
+       ;; 4) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 5) Hit the environment-cache endpoint for the 'production'
+       ;;    environment (but not for the 'test' environment).
+       ;; 6) Do two more environment_classes queries for the 'test' and
+       ;;    'production' environments using the etags from the initial
+       ;;    queries.  Confirm that the information reflects the latest data on
+       ;;    disk for the 'production' environment but still reflects the old
+       ;;    data for the 'test' environment - expected, in this case, because
+       ;;    the 'test' environment was not flushed.
+       (purge-env-dir)
+       (purge-all-env-caches)
+       (let [prod-file (testutils/write-foo-pp-file "class oneprod {}"
+                                                    "prod"
+                                                    "production")
+             test-file (testutils/write-foo-pp-file "class onetest {}"
+                                                    "test"
+                                                    "test")
+             production-response-initial (get-env-classes "production")
+             production-etag-initial (response-etag production-response-initial)
+             test-response-initial (get-env-classes "test")
+             test-etag-initial (response-etag test-response-initial)]
+         (is (= 200 (:status production-response-initial))
+             (str
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
+             "no etag returned for production response")
+         (is (= {"name" "production",
+                 "files" [ {"path" prod-file,
+                            "classes" [{"name" "oneprod", "params" []}]}]}
+                (response->class-info-map production-response-initial))
+             "unexpected body for production response")
+         (is (= 200 (:status test-response-initial))
+             (str
+              "unexpected status code for initial test response"
+              "response: "
+              (ks/pprint-to-string test-response-initial)))
+         (is (not (nil? test-etag-initial))
+             "no etag returned for test response")
+         (is (= {"name" "test",
+                 "files" [ {"path" test-file,
+                            "classes" [{"name" "onetest", "params" []}]}]}
+                (response->class-info-map test-response-initial))
+             "unexpected body for test response")
+
+         (testutils/write-foo-pp-file "class oneflushprod {}"
+                                      "prod"
+                                      "production")
+         (testutils/write-foo-pp-file "class oneflushtest {}"
+                                      "test"
+                                      "test")
+
+         (let [production-response-before-flush (get-env-classes
+                                                 "production"
+                                                 production-etag-initial)
+               test-response-before-flush (get-env-classes
+                                           "test"
+                                           test-etag-initial)]
+           (is (= 304 (:status production-response-before-flush))
+               (str
+                "unexpected status code for prod response after code change "
+                "but before flush"))
+           (is (= production-etag-initial (response-etag
+                                           production-response-before-flush))
+               "unexpected etag change when no production environment change")
+           (is (empty? (:body production-response-before-flush))
+               "unexpected body for production response")
+           (is (= 304 (:status test-response-before-flush))
+               (str
+                "unexpected status code for test response after code change "
+                "but before flush"))
+           (is (= test-etag-initial (response-etag
+                                     test-response-before-flush))
+               "unexpected etag change when no test environment change")
+           (is (empty? (:body test-response-before-flush))
+               "unexpected body for test response")
+
+           (purge-env-cache "production")
+
+           (let [production-response-after-prod-flush (get-env-classes
+                                                       "production"
+                                                       production-etag-initial)
+                 production-etag-after-prod-flush (response-etag
+                                                   production-response-after-prod-flush)
+                 test-response-after-prod-flush (get-env-classes
+                                                 "test"
+                                                 test-etag-initial)]
+             (is (= 200 (:status production-response-after-prod-flush))
+                 (str
+                  "unexpected status code for prod response after code change "
+                  "and prod flush"))
+             (is (not (nil? production-etag-after-prod-flush))
+                 "no etag returned for production response")
+             (is (not= production-etag-initial
+                       production-etag-after-prod-flush)
+                 (str
+                  "etag unexpectedly stayed the same even though "
+                  "the production environment changed"))
+             (is (= {"name" "production",
+                     "files" [{"path" prod-file
+                               "classes" [{"name" "oneflushprod",
+                                           "params" []}]}]}
+                    (response->class-info-map
+                     production-response-after-prod-flush))
+                 "unexpected body for production response")
+             (is (= 304 (:status test-response-after-prod-flush))
+                 (str
+                  "unexpected status code for test response after code change "
+                  "but test environment not invalidated"))
+             (is (= test-etag-initial (response-etag
+                                       test-response-after-prod-flush))
+                 "unexpected etag change when test environment not invalidated")
+             (is (empty? (:body test-response-after-prod-flush))
+                 "unexpected body for test response")))))
+     (testing "environment class cache invalidation for all environments"
+       ;; This test is about ensuring that when the environment-cache
+       ;; endpoint is hit with no environment parameter that any previously
+       ;; cached environment class info is invalidated, meaning that
+       ;; the next request for class info for all environments will get fresh
+       ;; data.
+       ;;
+       ;; To eliminate some of the redundancy between tests, this test doesn't
+       ;; repeat the intermediate step of checking to see that the first two
+       ;; environment queries were cached - 304 (Not Modified) returns -
+       ;; between the first set of environment_classes queries and the second
+       ;; set, done after the code on disk for both environments has changed.
+       ;;
+       ;; The test has the following basic steps:
+       ;;
+       ;; 1) Purge the current environment files on disk and hit the
+       ;;    environment-cache endpoint to flush the cache for all
+       ;;    environments, basically to ensure nothing is left around from
+       ;;    other tests.
+       ;; 2) Populate code for the 'test' and 'production' environments and
+       ;;    see that environment_classes queries return the right info for
+       ;;    them.
+       ;; 3) Change code on disk for both the 'test' and 'production'
+       ;;    environments.
+       ;; 4) Hit the environment-cache endpoint with no environment
+       ;;    parameter, expected to have the effect of flushing the cache for
+       ;;    all environments.
+       ;; 5) Do two more environment_classes queries for the 'test' and
+       ;;    'production' environments with the corresponding etags returned
+       ;;    from the first two queries.  Confirm that the information
+       ;;    reflects the latest data on disk for both environments.
+       (purge-env-dir)
+       (purge-all-env-caches)
+       (let [prod-file (testutils/write-foo-pp-file "class allprod {}"
+                                                    "prod"
+                                                    "production")
+             test-file (testutils/write-foo-pp-file "class alltest {}"
+                                                    "test"
+                                                    "test")
+             production-response-initial (get-env-classes "production")
+             production-etag-initial (response-etag production-response-initial)
+             test-response-initial (get-env-classes "test")
+             test-etag-initial (response-etag test-response-initial)]
+         (is (= 200 (:status production-response-initial))
+             (str
+              "unexpected status code for initial production response"
+              "response: "
+              (ks/pprint-to-string production-response-initial)))
+         (is (not (nil? production-etag-initial))
+             "no etag returned for production response")
+         (is (= {"name" "production",
+                 "files" [ {"path" prod-file,
+                            "classes" [{"name" "allprod",
+                                        "params" []}]}]}
+                (response->class-info-map production-response-initial))
+             "unexpected body for production response")
+         (is (= 200 (:status test-response-initial))
+             (str
+              "unexpected status code for initial test response"
+              "response: "
+              (ks/pprint-to-string test-response-initial)))
+         (is (not (nil? test-etag-initial))
+             "no etag returned for test response")
+         (is (= {"name" "test",
+                 "files" [ {"path" test-file
+                            "classes" [{"name" "alltest"
+                                        "params" []}]}]}
+                (response->class-info-map test-response-initial))
+             "unexpected body for test response")
+
+         (testutils/write-foo-pp-file "class allflushprod {}"
+                                      "prod"
+                                      "production")
+         (testutils/write-foo-pp-file "class allflushtest {}"
+                                      "test"
+                                      "test")
+         (purge-all-env-caches)
+
+         (let [production-response-after-all-flush (get-env-classes
+                                                     "production"
+                                                     production-etag-initial)
+               production-etag-after-all-flush (response-etag
+                                                production-response-after-all-flush)]
+           (is (= 200 (:status production-response-after-all-flush))
+               (str
+                "unexpected status code for prod response after code change "
+                "and all environment flush"))
+           (is (not (nil? production-etag-after-all-flush))
+               "no etag returned for production response")
+           (is (not= production-etag-initial production-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the production environment changed"))
+           (is (= {"name" "production",
+                   "files" [{"path" prod-file
+                             "classes" [{"name" "allflushprod", "params" []}]}]}
+                  (response->class-info-map
+                   production-response-after-all-flush))
+               "unexpected body for production response"))
+
+         (let [test-response-after-all-flush (get-env-classes
+                                              "test"
+                                              test-etag-initial)
+               test-etag-after-all-flush (response-etag
+                                          test-response-after-all-flush)]
+           (is (= 200 (:status test-response-after-all-flush))
+               (str
+                "unexpected status code for test response after code change "
+                "and all environment flush"))
+           (is (not (nil? test-etag-after-all-flush))
+               "no etag returned for test response")
+           (is (not= test-etag-initial test-etag-after-all-flush)
+               (str
+                "etag unexpectedly stayed the same even though "
+                "the test environment changed"))
+           (is (= {"name" "test",
+                   "files" [{"path" test-file
+                             "classes" [{"name" "allflushtest", "params" []}]}]}
+                  (response->class-info-map
+                   test-response-after-all-flush))
+               "unexpected body for test response")))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -86,7 +86,7 @@
       (testing "calculates etag properly for response payload"
         (letfn [(etag [x]
                   (-> x
-                      (process-environment-class-info!
+                      (environment-class-response!
                        "production"
                        jruby-service
                        nil)


### PR DESCRIPTION
This commit generates a hash value from the JSON response to an
environment_classes request and adds that hash to the HTTP response in
an Etag header.  The commit includes some work to re-sort maps in the
response body prior to JSON serialization so that the generated hash is
consistent even if the order in which keys had been inserted into the
original sub-maps may differ from one object creation to another.

Requests made by clients with an 'If-None-Match' header matching the
last 'Etag' delivered for an environment_classes request for the corresponding
environment now result in an HTTP 304 (Not Modified) response being delivered,
with an empty response body, instead of re-parsing the environment content and
delivering a response body based on the latest manifests on disk.

This PR also upgrades the dependency on puppetlabs/http-client to
0.5.0.  This was needed in order for test functions to properly handle
an empty response body, which is delivered in cases where the
environment_classes endpoint returns an HTTP 304 (Not Modified) in
conjunction with an empty response body per the HTTP spec.