### PR TITLE
(SERVER-882) Restrict static_file_content endpoint

### DIFF
--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -310,16 +310,14 @@
    jruby-request/wrap-with-error-handling
    ring/wrap-params))
 
-(schema/defn ^:always-validate valid-static-file-path? :- schema/Bool
+(schema/defn ^:always-validate valid-static-file-path?
   "Helper function to decide if a static_file_content path is valid.
   The access here is designed to mimic Puppet's file_content endpoint."
   [path :- schema/Str]
-  (if-let [canonicalized-path (URIUtil/canonicalPath path)]
-    (not (nil?
-          (or
-           (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path)
-           (bidi.bidi/match-route [["environments/" :environment-name "/modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path))))
-    false))
+  (when-let [canonicalized-path (URIUtil/canonicalPath path)]
+    (or
+     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path)
+     (bidi.bidi/match-route [["environments/" :environment-name "/modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path))))
 
 (defn static-file-content-request-handler
   "Returns a function which is the main request handler for the

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -316,8 +316,11 @@
   [path :- schema/Str]
   (when-let [canonicalized-path (URIUtil/canonicalPath path)]
     (or
-     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path)
-     (bidi.bidi/match-route [["environments/" :environment-name "/modules/" :module-name "/files/" [#".*" :rest]] :helper] canonicalized-path))))
+     ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
+     ;; The second vector takes anything else that might be on the end of the path.
+     ;; In the first example, this corresponds to 'modules/*/files/**' in a filesystem glob.
+     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path)
+     (bidi.bidi/match-route [["environments/" :environment-name "/modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path))))
 
 (defn static-file-content-request-handler
   "Returns a function which is the main request handler for the

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -314,7 +314,7 @@
   "Helper function to decide if a static_file_content path is valid.
   The access here is designed to mimic Puppet's file_content endpoint."
   [path :- schema/Str]
-  (when-let [canonicalized-path (URIUtil/canonicalPath path)]
+  (when-let [canonicalized-path (-> path URIUtil/decodePath URIUtil/canonicalPath)]
     (or
      ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
      ;; The second vector takes anything else that might be on the end of the path.
@@ -341,7 +341,7 @@
          "the files directory of a module.")}
         :else
         {:status 200
-         :body (get-code-content environment code-id (URIUtil/canonicalPath file-path))}))))
+         :body (get-code-content environment code-id (-> file-path URIUtil/decodePath URIUtil/canonicalPath))}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -310,11 +310,16 @@
    jruby-request/wrap-with-error-handling
    ring/wrap-params))
 
+(schema/defn ^:always-validate decode-and-canonicalize-path :- (schema/maybe schema/Str)
+  "Takes a URI path and returns a decoded and canonicalized version."
+  [path :- schema/Str]
+  (-> path URIUtil/decodePath URIUtil/canonicalPath))
+
 (schema/defn ^:always-validate valid-static-file-path?
   "Helper function to decide if a static_file_content path is valid.
   The access here is designed to mimic Puppet's file_content endpoint."
   [path :- schema/Str]
-  (when-let [canonicalized-path (-> path URIUtil/decodePath URIUtil/canonicalPath)]
+  (when-let [canonicalized-path (decode-and-canonicalize-path path)]
      ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
      ;; The second vector takes anything else that might be on the end of the path.
      ;; Below, this corresponds to 'modules/*/files/**' in a filesystem glob.
@@ -340,7 +345,8 @@
          "the files directory of a module.")}
         :else
         {:status 200
-         :body (get-code-content environment code-id (-> file-path URIUtil/decodePath URIUtil/canonicalPath))}))))
+         :body (get-code-content environment code-id
+                                 (decode-and-canonicalize-path file-path))}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -331,13 +331,17 @@
     (let [environment (get-in req [:params "environment"])
           code-id (get-in req [:params "code_id"])
           file-path (get-in req [:params :rest])]
-      (if (or (nil? environment)
-              (nil? code-id)
-              (or (nil? file-path) (= "" file-path)))
+      (cond
+        (some empty? [environment code-id file-path])
         {:status 400
          :body "Error: A /static_file_content request requires an environment, a code-id, and a file-path"}
+        (not (valid-static-file-path? file-path))
+        {:status 403
+         :body (str "Request Denied: A /static_file_content request must be a file within "
+         "the files directory of a module or a module in an environment")}
+        :else
         {:status 200
-         :body   (get-code-content environment code-id file-path)}))))
+         :body (get-code-content environment code-id (URIUtil/canonicalPath file-path))}))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -315,12 +315,11 @@
   The access here is designed to mimic Puppet's file_content endpoint."
   [path :- schema/Str]
   (when-let [canonicalized-path (-> path URIUtil/decodePath URIUtil/canonicalPath)]
-    (or
      ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
      ;; The second vector takes anything else that might be on the end of the path.
      ;; Below, this corresponds to 'modules/*/files/**' in a filesystem glob.
      (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_]
-                            canonicalized-path))))
+                            canonicalized-path)))
 
 (defn static-file-content-request-handler
   "Returns a function which is the main request handler for the

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -318,9 +318,8 @@
     (or
      ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
      ;; The second vector takes anything else that might be on the end of the path.
-     ;; In the first example, this corresponds to 'modules/*/files/**' in a filesystem glob.
-     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path)
-     (bidi.bidi/match-route [["environments/" :environment-name "/modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path))))
+     ;; Below, this corresponds to 'modules/*/files/**' in a filesystem glob.
+     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path))))
 
 (defn static-file-content-request-handler
   "Returns a function which is the main request handler for the
@@ -338,7 +337,7 @@
         (not (valid-static-file-path? file-path))
         {:status 403
          :body (str "Request Denied: A /static_file_content request must be a file within "
-         "the files directory of a module or a module in an environment")}
+         "the files directory of a module.")}
         :else
         {:status 200
          :body (get-code-content environment code-id (URIUtil/canonicalPath file-path))}))))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -319,7 +319,8 @@
      ;; Here, keywords represent a single element in the path. Anything between two '/' counts.
      ;; The second vector takes anything else that might be on the end of the path.
      ;; Below, this corresponds to 'modules/*/files/**' in a filesystem glob.
-     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_] canonicalized-path))))
+     (bidi.bidi/match-route [["modules/" :module-name "/files/" [#".*" :rest]] :_]
+                            canonicalized-path))))
 
 (defn static-file-content-request-handler
   "Returns a function which is the main request handler for the

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -3,7 +3,6 @@
            (clojure.lang IFn)
            (java.util Map Map$Entry)
            (org.jruby RubySymbol)
-           (java.util Map)
            (org.eclipse.jetty.util URIUtil))
   (:require [me.raynes.fs :as fs]
             [puppetlabs.puppetserver.ringutils :as ringutils]

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -106,33 +106,7 @@
         (testing "the /static_file_content endpoint returns an error if file-path is not provided"
           (let [response (get-static-file-content "?code_id=foobar&environment=test")]
             (is (= 400 (:status response)))
-            (is (= error-message (:body response))))))
-      (let [error-message "Request Denied: A /static_file_content request must be a file within the files directory of a module or a module in an environment"
-            valid-paths ["modules/foo/files/bar.txt"
-                         "modules/foo/files/bar/"
-                         "modules/foo/files/bar/baz.txt"
-                         "environments/production/modules/foo/files/bar.txt"
-                         "environments/production/modules/foo/files/..conf..d../..bar..txt.."
-                         "environments/test/modules/foo/files/bar/baz.txt"
-                         "environments/dev/modules/foo/files/path/to/file/something.txt"]
-            invalid-paths ["modules/foo/manifests/bar.pp"
-                           "manifests/site.pp"
-                           "environments/foo/bar/files"
-                           "environments/../manifests/files/site.pp"
-                           "environments/production/files/~/.bash_profile"
-                           "environments/../modules/foo/files/site.pp"
-                           "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
-                           "environments/production/modules/foo/files/../../../../../../site.pp"]]
-        (testing "valid requests return 200 and the file"
-          (doseq [path valid-paths]
-            (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
-              (is (= 200 (:status response)))
-              (is (= (str "production foobar " path "\n") (:body response))))))
-        (testing "invalid requests return 403 and the error message"
-          (doseq [path invalid-paths]
-            (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
-              (is (= 403 (:status response)))
-              (is (= error-message (:body response)))))))))))
+            (is (= error-message (:body response))))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -83,56 +83,56 @@
 (deftest ^:integration static-file-content-endpoint-test
   (logging/with-test-logging
    (testing "the /static_file_content endpoint behaves as expected when :code-content-command is set"
-       (bootstrap/with-puppetserver-running
-        app
-        {:jruby-puppet
-         {:max-active-instances num-jrubies}
-         :versioned-code
-         {:code-content-command (script-path "echo")}}
-        (testing "the /static_file_content endpoint successfully streams file content"
-          (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
-            (is (= 200 (:status response)))
-            (is (= "test foobar modules/foo/files/bar.txt\n" (slurp (:body response))))))
+     (bootstrap/with-puppetserver-running
+      app
+      {:jruby-puppet
+       {:max-active-instances num-jrubies}
+       :versioned-code
+       {:code-content-command (script-path "echo")}}
+      (testing "the /static_file_content endpoint successfully streams file content"
+        (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)))
+          (is (= "test foobar modules/foo/files/bar.txt\n" (slurp (:body response))))))
 
-        (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
-          (testing "the /static_file_content endpoint returns an error if code_id is not provided"
-            (let [response (get-static-file-content "modules/foo/files/bar.txt?environment=test")]
-              (is (= 400 (:status response)))
-              (is (= error-message (slurp (:body response))))))
-          (testing "the /static_file_content endpoint returns an error if environment is not provided"
-            (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar")]
-              (is (= 400 (:status response)))
-              (is (= error-message (slurp (:body response))))))
-          (testing "the /static_file_content endpoint returns an error if file-path is not provided"
-            (let [response (get-static-file-content "?code_id=foobar&environment=test")]
-              (is (= 400 (:status response)))
-              (is (= error-message (slurp (:body response)))))))
-        (let [error-message "Request Denied: A /static_file_content request must be a file within the files directory of a module or a module in an environment"
-              valid-paths ["modules/foo/files/bar.txt"
-                           "modules/foo/files/bar/"
-                           "modules/foo/files/bar/baz.txt"
-                           "environments/production/modules/foo/files/bar.txt"
-                           "environments/production/modules/foo/files/..conf..d../..bar..txt.."
-                           "environments/test/modules/foo/files/bar/baz.txt"
-                           "environments/dev/modules/foo/files/path/to/file/something.txt"]
-              invalid-paths ["modules/foo/manifests/bar.pp"
-                             "manifests/site.pp"
-                             "environments/foo/bar/files"
-                             "environments/../manifests/files/site.pp"
-                             "environments/production/files/~/.bash_profile"
-                             "environments/../modules/foo/files/site.pp"
-                             "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
-                             "environments/production/modules/foo/files/../../../../../../site.pp"]]
-          (testing "valid requests return 200 and the file"
-            (doseq [path valid-paths]
-              (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
-                (is (= 200 (:status response)))
-                (is (= (str "production foobar " path "\n") (slurp (:body response)))))))
-          (testing "invalid requests return 403 and the error message"
-            (doseq [path invalid-paths]
-              (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
-                (is (= 403 (:status response)))
-                (is (= error-message (slurp (:body response))))))))))))
+      (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
+        (testing "the /static_file_content endpoint returns an error if code_id is not provided"
+          (let [response (get-static-file-content "modules/foo/files/bar.txt?environment=test")]
+            (is (= 400 (:status response)))
+            (is (= error-message (slurp (:body response))))))
+        (testing "the /static_file_content endpoint returns an error if environment is not provided"
+          (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar")]
+            (is (= 400 (:status response)))
+            (is (= error-message (slurp (:body response))))))
+        (testing "the /static_file_content endpoint returns an error if file-path is not provided"
+          (let [response (get-static-file-content "?code_id=foobar&environment=test")]
+            (is (= 400 (:status response)))
+            (is (= error-message (slurp (:body response)))))))
+      (let [error-message "Request Denied: A /static_file_content request must be a file within the files directory of a module or a module in an environment"
+            valid-paths ["modules/foo/files/bar.txt"
+                         "modules/foo/files/bar/"
+                         "modules/foo/files/bar/baz.txt"
+                         "environments/production/modules/foo/files/bar.txt"
+                         "environments/production/modules/foo/files/..conf..d../..bar..txt.."
+                         "environments/test/modules/foo/files/bar/baz.txt"
+                         "environments/dev/modules/foo/files/path/to/file/something.txt"]
+            invalid-paths ["modules/foo/manifests/bar.pp"
+                           "manifests/site.pp"
+                           "environments/foo/bar/files"
+                           "environments/../manifests/files/site.pp"
+                           "environments/production/files/~/.bash_profile"
+                           "environments/../modules/foo/files/site.pp"
+                           "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
+                           "environments/production/modules/foo/files/../../../../../../site.pp"]]
+        (testing "valid requests return 200 and the file"
+          (doseq [path valid-paths]
+            (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
+              (is (= 200 (:status response)))
+              (is (= (str "production foobar " path "\n") (slurp (:body response)))))))
+        (testing "invalid requests return 403 and the error message"
+          (doseq [path invalid-paths]
+            (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
+              (is (= 403 (:status response)))
+              (is (= error-message (slurp (:body response))))))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -111,8 +111,7 @@
         (let [response (get-static-file-content "modules/foo/files/bar/../../../..?environment=test&code_id=foobar")]
           (is (= 403 (:status response)))
           (is (= (str "Request Denied: A /static_file_content request must be "
-                      "a file within the files directory of a module or a module "
-                      "in an environment") (:body response)))))))))
+                      "a file within the files directory of a module.") (:body response)))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -112,13 +112,12 @@
           (is (= 403 (:status response)))
           (is (= (str "Request Denied: A /static_file_content request must be "
                       "a file within the files directory of a module.") (:body response)))))
-      (testing "the /static_file_content endpoint does not decode alternate encodings of .."
-        ;; Currently the versions of ring and jetty that we depend upon do not decode the following URI.
-        ;; If that changes, this test will hopefully begin failing.
+      (testing "the /static_file_content decodes and rejects alternate encodings of .."
         (let [response (get-static-file-content
                         "modules/foo/files/bar/%2E%2E/%2E%2E/%2E%2E/%2E%2E?environment=test&code_id=foobar")]
-          (is (= 200 (:status response)))
-          (is (= "test foobar modules/foo/files/bar/%2E%2E/%2E%2E/%2E%2E/%2E%2E\n" (:body response)))))))))
+          (is (= 403 (:status response)))
+          (is (= (str "Request Denied: A /static_file_content request must be "
+                      "a file within the files directory of a module.") (:body response)))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -106,7 +106,13 @@
         (testing "the /static_file_content endpoint returns an error if file-path is not provided"
           (let [response (get-static-file-content "?code_id=foobar&environment=test")]
             (is (= 400 (:status response)))
-            (is (= error-message (:body response))))))))))
+            (is (= error-message (:body response))))))
+      (testing "the /static_file_content endpoint returns an error (403) for invalid file-paths"
+        (let [response (get-static-file-content "modules/foo/files/bar/../../../..?environment=test&code_id=foobar")]
+          (is (= 403 (:status response)))
+          (is (= (str "Request Denied: A /static_file_content request must be "
+                      "a file within the files directory of a module or a module "
+                      "in an environment") (:body response)))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -24,7 +24,7 @@
   [url-end]
   (http-client/get (str "https://localhost:8140/puppet/v3/static_file_content/" url-end)
                    (assoc testutils/ssl-request-options
-                     :as :stream)))
+                     :as :text)))
 
 (deftest ^:integration test-external-command-execution
   (testing "puppet functions can call external commands successfully"
@@ -92,21 +92,21 @@
       (testing "the /static_file_content endpoint successfully streams file content"
         (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
-          (is (= "test foobar modules/foo/files/bar.txt\n" (slurp (:body response))))))
+          (is (= "test foobar modules/foo/files/bar.txt\n" (:body response)))))
 
       (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
         (testing "the /static_file_content endpoint returns an error if code_id is not provided"
           (let [response (get-static-file-content "modules/foo/files/bar.txt?environment=test")]
             (is (= 400 (:status response)))
-            (is (= error-message (slurp (:body response))))))
+            (is (= error-message (:body response)))))
         (testing "the /static_file_content endpoint returns an error if environment is not provided"
           (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar")]
             (is (= 400 (:status response)))
-            (is (= error-message (slurp (:body response))))))
+            (is (= error-message (:body response)))))
         (testing "the /static_file_content endpoint returns an error if file-path is not provided"
           (let [response (get-static-file-content "?code_id=foobar&environment=test")]
             (is (= 400 (:status response)))
-            (is (= error-message (slurp (:body response)))))))
+            (is (= error-message (:body response))))))
       (let [error-message "Request Denied: A /static_file_content request must be a file within the files directory of a module or a module in an environment"
             valid-paths ["modules/foo/files/bar.txt"
                          "modules/foo/files/bar/"
@@ -127,12 +127,12 @@
           (doseq [path valid-paths]
             (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
               (is (= 200 (:status response)))
-              (is (= (str "production foobar " path "\n") (slurp (:body response)))))))
+              (is (= (str "production foobar " path "\n") (:body response))))))
         (testing "invalid requests return 403 and the error message"
           (doseq [path invalid-paths]
             (let [response (get-static-file-content (str path "?code_id=foobar&environment=production"))]
               (is (= 403 (:status response)))
-              (is (= error-message (slurp (:body response))))))))))))
+              (is (= error-message (:body response)))))))))))
 
 (deftest ^:integration static-file-content-endpoint-test-no-code-content-command
   (logging/with-test-logging
@@ -146,4 +146,4 @@
       (let [response (get-static-file-content "modules/foo/files/bar/?code_id=foobar&environment=test")]
         (is (= 500 (:status response)))
         (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"
-                        (slurp (:body response)))))))))
+                        (:body response))))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -203,10 +203,7 @@
   (let [valid-paths ["modules/foo/files/bar.txt"
                      "modules/foo/files/bar/"
                      "modules/foo/files/bar/baz.txt"
-                     "environments/production/modules/foo/files/bar.txt"
-                     "environments/production/modules/foo/files/..conf..d../..bar..txt.."
-                     "environments/test/modules/foo/files/bar/baz.txt"
-                     "environments/dev/modules/foo/files/path/to/file/something.txt"]
+                     "modules/foo/files/bar/more/path/elements/baz.txt"]
         invalid-paths ["modules/foo/manifests/bar.pp"
                        "manifests/site.pp"
                        "environments/foo/bar/files"
@@ -214,12 +211,16 @@
                        "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
                        "environments/production/files/~/.bash_profile"
                        "environments/../modules/foo/files/site.pp"
-                       "environments/production/modules/foo/files/../../../../../../site.pp"]
+                       "environments/production/modules/foo/files/../../../../../../site.pp"
+                       "environments/production/modules/foo/files/bar.txt"
+                       "environments/production/modules/foo/files/..conf..d../..bar..txt.."
+                       "environments/test/modules/foo/files/bar/baz.txt"
+                       "environments/dev/modules/foo/files/path/to/file/something.txt"]
         check-valid-path (fn [path] {:path path :valid? (valid-static-file-path? path)})
         valid-path-results (map check-valid-path valid-paths)
         invalid-path-results (map check-valid-path invalid-paths)
         get-validity (fn [{:keys [valid?]}] valid?)]
-    (testing "Only files in 'modules/*/files/**' or 'environments/*/modules/*/files/**' are valid"
+    (testing "Only files in 'modules/*/files/**' are valid"
       (is (every? get-validity valid-path-results) (ks/pprint-to-string valid-path-results))
       (is (every? (complement get-validity) invalid-path-results) (ks/pprint-to-string invalid-path-results)))))
 

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -215,8 +215,8 @@
                          "environments/../modules/foo/files/site.pp"
                          "environments/production/modules/foo/files/../../../../../../site.pp"]]
       (testing "valid requests return true"
-      (doseq [path valid-paths]
-        (is (not (nil? (valid-static-file-path? path))))))
+        (doseq [path valid-paths]
+          (is (not (nil? (valid-static-file-path? path))))))
       (testing "invalid requests return false"
         (doseq [path invalid-paths]
           (is (nil? (valid-static-file-path? path)))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -198,6 +198,29 @@
                         "supported"]
                        "bogus"}])})))))))
 
+(deftest valid-static-file-path-test
+    (let [valid-paths ["modules/foo/files/bar.txt"
+                       "modules/foo/files/bar/"
+                       "modules/foo/files/bar/baz.txt"
+                       "environments/production/modules/foo/files/bar.txt"
+                       "environments/production/modules/foo/files/..conf..d../..bar..txt.."
+                       "environments/test/modules/foo/files/bar/baz.txt"
+                       "environments/dev/modules/foo/files/path/to/file/something.txt"]
+          invalid-paths ["modules/foo/manifests/bar.pp"
+                         "manifests/site.pp"
+                         "environments/foo/bar/files"
+                         "environments/../manifests/files/site.pp"
+                         "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
+                         "environments/production/files/~/.bash_profile"
+                         "environments/../modules/foo/files/site.pp"
+                         "environments/production/modules/foo/files/../../../../../../site.pp"]]
+      (testing "valid requests return true"
+      (doseq [path valid-paths]
+        (is (true? (valid-static-file-path? path)))))
+      (testing "invalid requests return false"
+        (doseq [path invalid-paths]
+          (is (false? (valid-static-file-path? path)))))))
+
 (deftest file-bucket-file-content-type-test
   (testing (str "The 'Content-Type' header on incoming /file_bucket_file requests "
                 "is not overwritten, and simply passed through unmodified.")

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -216,10 +216,10 @@
                          "environments/production/modules/foo/files/../../../../../../site.pp"]]
       (testing "valid requests return true"
       (doseq [path valid-paths]
-        (is (true? (valid-static-file-path? path)))))
+        (is (not (nil? (valid-static-file-path? path))))))
       (testing "invalid requests return false"
         (doseq [path invalid-paths]
-          (is (false? (valid-static-file-path? path)))))))
+          (is (nil? (valid-static-file-path? path)))))))
 
 (deftest file-bucket-file-content-type-test
   (testing (str "The 'Content-Type' header on incoming /file_bucket_file requests "

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -201,7 +201,7 @@
 
 (deftest valid-static-file-path-test
   (let [valid-paths ["modules/foo/files/bar.txt"
-                     "modules/foo/files/bar/"
+                     "modules/foo/files/bar"
                      "modules/foo/files/bar/baz.txt"
                      "modules/foo/files/bar/more/path/elements/baz.txt"]
         invalid-paths ["modules/foo/manifests/bar.pp"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -205,6 +205,7 @@
                      "modules/foo/files/bar/baz.txt"
                      "modules/foo/files/bar/more/path/elements/baz.txt"]
         invalid-paths ["modules/foo/manifests/bar.pp"
+                       "modules/foo/files/bar/\u002e\u002e/\u002e\u002e/\u002e\u002e/\u002e\u002e"
                        "manifests/site.pp"
                        "environments/foo/bar/files"
                        "environments/../manifests/files/site.pp"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -203,9 +203,11 @@
   (let [valid-paths ["modules/foo/files/bar.txt"
                      "modules/foo/files/bar"
                      "modules/foo/files/bar/baz.txt"
-                     "modules/foo/files/bar/more/path/elements/baz.txt"]
+                     "modules/foo/files/bar/more/path/elements/baz.txt"
+                     "modules/foo/files/bar/%2E%2E/baz.txt"]
         invalid-paths ["modules/foo/manifests/bar.pp"
                        "modules/foo/files/bar/\u002e\u002e/\u002e\u002e/\u002e\u002e/\u002e\u002e"
+                       "modules/foo/files/bar/%2E%2E/%2E%2E/%2E%2E/%2E%2E"
                        "manifests/site.pp"
                        "environments/foo/bar/files"
                        "environments/../manifests/files/site.pp"


### PR DESCRIPTION
This PR updates the static-file-content-endpoint to reject any
requests that would have been rejected by the file_content Puppet
endpoint. Tests are also updated to account for the new requirement. Any
files not within `modules/*/files/**` or `environments/*/modules/*/files/**`
will be rejected with a 403 error.