### PR TITLE
(SERVER-1126) Refactoring and tests to support PUP class_per_env changes

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "1.3.4", :string)
+                         "18ebd9ad3cdb6c54140db83c251ed77f3023a6b6", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -66,9 +66,10 @@
                         (fs/file dir
                                  "manifests"
                                  (str name ".pp")))
-                      [(expected-class-info name)
-                       (expected-class-info
-                         (str name "2"))]]))))))
+                      {"classes"
+                       [(expected-class-info name)
+                        (expected-class-info
+                         (str name "2"))]}]))))))
 
 (deftest ^:integration class-info-test
   (testing "class info properly enumerated for"
@@ -157,12 +158,13 @@
                                                           "manifests"
                                                           "foo.pp"))
                   expected-envs-info {"env1" {foo-manifest
-                                              [(expected-class-info "foo")
-                                               (expected-class-info "foo2")]}
+                                              {"classes"
+                                               [(expected-class-info "foo")
+                                                (expected-class-info "foo2")]}}
                                       "env2" (expected-manifests-info
-                                               [env-2-dir-and-manifests
-                                                env-1-mod-1-dir-and-manifests
-                                                env-1-mod-2-dir-and-manifests])}]
+                                              [env-2-dir-and-manifests
+                                               env-1-mod-1-dir-and-manifests
+                                               env-1-mod-2-dir-and-manifests])}]
               (puppet-env/mark-all-environments-expired! env-registry)
               (testing "one environment by name"
                 (is (= (expected-envs-info "env1")
@@ -179,11 +181,12 @@
                                                           "foo.pp"))
                   _ (create-file foo-manifest "class foo () {} \n")
                   expected-envs-info {"env1" {foo-manifest
-                                              [{"name" "foo"
-                                                "params" []}]}
+                                              {"classes"
+                                               [{"name" "foo"
+                                                 "params" []}]}}
                                       "env2" (expected-manifests-info
-                                               [env-2-dir-and-manifests
-                                                env-1-mod-1-dir-and-manifests])}]
+                                              [env-2-dir-and-manifests
+                                               env-1-mod-1-dir-and-manifests])}]
               (puppet-env/mark-environment-expired! env-registry "env1")
               (is (= (expected-envs-info "env1")
                      (get-class-info-for-env "env1"))
@@ -221,7 +224,105 @@
 
           (testing "non-existent environment"
             (is (nil? (get-class-info-for-env "bogus-env"))))
-
-        (finally
-          (.terminate jruby-puppet)
-          (.terminate container))))))
+          (testing "(PUP-5744) non-JSON safe default_literals omitted"
+            (let [env-5-dir (env-dir "env5")
+                  _ (create-env-conf env-5-dir "modulepath=\n")
+                  foo-manifest (.getAbsolutePath (fs/file env-5-dir
+                                                          "manifests"
+                                                          "foo.pp"))]
+              (create-file foo-manifest
+                           (str
+                            "class foo (\n"
+                            "  Regexp $some_regex = /^.*/,\n"
+                            "  Default $some_default = default,\n"
+                            "  Hash $some_hash = { 1 => 2, "
+                            "\"two\" => 3},\n"
+                            "  Hash $some_nested_hash = { \"one\" => 2, "
+                            "\"two\" => { 3 => 4 }},\n"
+                            "  Hash $another_nested_hash = { \"one\" => 2, "
+                            "\"two\" => { \"three\" => 4 }},\n"
+                            "  Array $some_array = [ 1, /^*$/ ],\n"
+                            "  Array $some_nested_array = [ 1, [ 2, "
+                            "default ] ],\n"
+                            "  Array $another_nested_array = [ 1, [ 2, 3 ] ]\n"
+                            "){}"))
+              ;; The values of "Hash[Scalar, Data, 0, default]" and
+              ;; "Array[Data, 0, default]" for "type" - as opposed to just
+              ;; "Hash" and "Array", respectively - for this example are
+              ;; expected per the current Ruby language implementation in
+              ;; Puppet.  However, the simpler types are probably what a user
+              ;; would expect to see instead.  PUP-5861 was filed to address
+              ;; this in the core Ruby Puppet implementation.  Whenever
+              ;; Puppet Server may be upgraded to referencing a Puppet Ruby
+              ;; version which includes these changes, these tests will need
+              ;; to be updated accordingly.
+              (is (= {foo-manifest
+                      {"classes"
+                       [{"name" "foo",
+                         "params" [{"default_source" "/^.*/"
+                                    "name" "some_regex"
+                                    "type" "Regexp"}
+                                   {"default_source" "default"
+                                    "name" "some_default"
+                                    "type" "Default"}
+                                   {"default_source" "{ 1 => 2, \"two\" => 3}"
+                                    "name" "some_hash"
+                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                   {"default_source" (str
+                                                      "{ \"one\" => 2, "
+                                                      "\"two\" => { 3 => 4 }}")
+                                    "name" "some_nested_hash"
+                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                   {"default_literal" {"one" 2
+                                                       "two" {"three" 4}}
+                                    "default_source" (str
+                                                      "{ \"one\" => 2, "
+                                                      "\"two\" => { \"three\""
+                                                      " => 4 }}")
+                                    "name" "another_nested_hash"
+                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                   {"default_source" "[ 1, /^*$/ ]"
+                                    "name" "some_array"
+                                    "type" "Array[Data, 0, default]"}
+                                   {"default_source" "[ 1, [ 2, default ] ]"
+                                    "name" "some_nested_array"
+                                    "type" "Array[Data, 0, default]"}
+                                   {"default_source" "[ 1, [ 2, 3 ] ]"
+                                    "default_literal" [ 1 [ 2 3 ]]
+                                    "name" "another_nested_array"
+                                    "type" "Array[Data, 0, default]"}]}]}}
+                     (get-class-info-for-env "env5"))
+                  "Unexpected info retrieved for 'env5'")))
+          (testing (str "(PUP-5713) Default parameter value with expression "
+                        "parsed properly")
+            (let [env-6-dir (env-dir "env6")
+                  _ (create-env-conf env-6-dir "modulepath=\n")
+                  foo-manifest (.getAbsolutePath (fs/file env-6-dir
+                                                          "manifests"
+                                                          "foo.pp"))]
+              (create-file foo-manifest
+                           (str
+                            "class foo (\n"
+                            "  String $one_literal = 'literal string',\n"
+                            "  String $another_literal = \"literal string\",\n"
+                            "  String $with_exp = \"for os in $::osfamily\")"
+                            "{} \n"))
+              (is (= {foo-manifest
+                      {"classes"
+                       [{"name" "foo",
+                         "params" [{"default_literal" "literal string"
+                                    "default_source" "'literal string'"
+                                    "name" "one_literal"
+                                    "type" "String"}
+                                   {"default_literal" "literal string"
+                                    "default_source" "\"literal string\""
+                                    "name" "another_literal"
+                                    "type" "String"}
+                                   {"default_source" "\"for os in $::osfamily\""
+                                    "name" "with_exp"
+                                    "type" "String"}]}]}}
+                     (get-class-info-for-env "env6"))
+                  "Unexpected info retrieved for 'env6'")))
+          (finally
+            (.terminate jruby-puppet)
+            (.terminate container))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -6,7 +6,8 @@
             [puppetlabs.comidi :as comidi]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [ring.util.response :as rr]))
+            [ring.util.response :as rr])
+  (:import (java.util HashMap)))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -74,7 +75,9 @@
                     "production"
                     jruby-service
                     nil)
-                   (rr/get-header "Etag"))]
+                   (rr/get-header "Etag"))
+          map-with-classes #(doto (HashMap.)
+                             (.put "classes" %))]
       (testing "returns 200 for environment that exists"
         (is (= 200 (:status (request
                              "/v3/environment_classes?environment=production")))))
@@ -91,89 +94,94 @@
                               "/v3/environment_classes?environment=~"))))))
       (testing "calculates etag properly for response payload"
         (is (= (etag {"/one/file"
-                      [
-                       {"name" "oneclass",
-                        "params" [
-                                  {"name" "oneparam",
-                                   "type" "String",
-                                   "default_literal" "'literal'",
-                                   "default_source" "literal"},
-                                  {"name" "twoparam",
-                                   "type" "Integer",
-                                   "default_literal" "3",
-                                   "default_source" "3"}]
-                        },
-                       {"name" "twoclass"
-                        "params" []}],
-                      "/two/file" []})
+                      (map-with-classes
+                       [
+                        {"name" "oneclass",
+                         "params" [
+                                   {"name" "oneparam",
+                                    "type" "String",
+                                    "default_literal" "'literal'",
+                                    "default_source" "literal"},
+                                   {"name" "twoparam",
+                                    "type" "Integer",
+                                    "default_literal" "3",
+                                    "default_source" "3"}]
+                         },
+                        {"name" "twoclass"
+                         "params" []}]),
+                      "/two/file" (map-with-classes [])})
                (etag {"/one/file"
-                      [
-                       {"name" "oneclass",
-                        "params" [
-                                  {"default_source" "literal"
-                                   "type" "String",
-                                   "name" "oneparam",
-                                   "default_literal" "'literal'"},
-                                  {"name" "twoparam",
-                                   "type" "Integer",
-                                   "default_literal" "3",
-                                   "default_source" "3"}]
-                        },
-                       {"name" "twoclass"
-                        "params" []}],
-                      "/two/file" []}))
+                      (map-with-classes
+                       [
+                        {"name" "oneclass",
+                         "params" [
+                                   {"default_source" "literal"
+                                    "type" "String",
+                                    "name" "oneparam",
+                                    "default_literal" "'literal'"},
+                                   {"name" "twoparam",
+                                    "type" "Integer",
+                                    "default_literal" "3",
+                                    "default_source" "3"}]
+                         },
+                        {"name" "twoclass"
+                         "params" []}]),
+                      "/two/file" (map-with-classes [])}))
             "hashes unexpectedly not equal for equal maps")
         (is (= (etag {"/one/file"
-                      [
-                       {"name" "oneclass",
-                        "params" [
-                                  {"name" "oneparam",
-                                   "type" "String",
-                                   "default_literal" "'literal'",
-                                   "default_source" "literal"},
-                                  {"name" "twoparam",
-                                   "type" "Integer",
-                                   "default_literal" "3",
-                                   "default_source" "3"}]
-                        },
-                       {"name" "twoclass"
-                        "params" []}],
-                      "/two/file" []})
+                      (map-with-classes
+                       [
+                        {"name" "oneclass",
+                         "params" [
+                                   {"name" "oneparam",
+                                    "type" "String",
+                                    "default_literal" "'literal'",
+                                    "default_source" "literal"},
+                                   {"name" "twoparam",
+                                    "type" "Integer",
+                                    "default_literal" "3",
+                                    "default_source" "3"}]
+                         },
+                        {"name" "twoclass"
+                         "params" []}]),
+                      "/two/file" (map-with-classes [])})
                (etag {"/one/file"
-                      [
-                       {"name" "oneclass",
-                        "params" [
-                                  {"default_source" "literal"
-                                   "type" "String",
-                                   "name" "oneparam",
-                                   "default_literal" "'literal'"},
-                                  {"type" "Integer",
-                                   "name" "twoparam",
-                                   "default_literal" "3"
-                                   "default_source" "3"}]
-                        },
-                       {"params" []
-                        "name" "twoclass"}],
-                      "/two/file" []}))
+                      (map-with-classes
+                       [
+                        {"name" "oneclass",
+                         "params" [
+                                   {"default_source" "literal"
+                                    "type" "String",
+                                    "name" "oneparam",
+                                    "default_literal" "'literal'"},
+                                   {"type" "Integer",
+                                    "name" "twoparam",
+                                    "default_literal" "3"
+                                    "default_source" "3"}]
+                         },
+                        {"params" []
+                         "name" "twoclass"}]),
+                      "/two/file" (map-with-classes [])}))
             (str "hashes unexpectedly not equal for equal maps with out of "
                  "order keys"))
         (is (not= (etag {"/one/file"
-                         [
-                          {"name" "oneclass",
-                           "params" [
-                                     {"name" "oneparam",
-                                      "type" "String",
-                                      "default_literal" "'literal'",
-                                      "default_source" "literal"},
-                                     {"name" "twoparam",
-                                      "type" "Integer",
-                                      "default_literal" "3",
-                                      "default_source" "3"}]
-                           },
-                          {"name" "twoclass"
-                           "params" []}],
-                         "/two/file" []})
-                  (etag {"/two/file" []}))
+                         (map-with-classes
+                          [
+                           {"name" "oneclass",
+                            "params" [
+                                      {"name" "oneparam",
+                                       "type" "String",
+                                       "default_literal" "'literal'",
+                                       "default_source" "literal"},
+                                      {"name" "twoparam",
+                                       "type" "Integer",
+                                       "default_literal" "3",
+                                       "default_source" "3"}]
+                            },
+                           {"name" "twoclass"
+                            "params" []}]),
+                         "/two/file" (map-with-classes [])})
+                  (etag {"/two/file" (map-with-classes [])}))
             "hashes unexpectedly equal for different payloads"))
       (testing (str "throws IllegalArgumentException for response "
                     "which contains invalid map key for etagging")
@@ -181,13 +189,14 @@
              IllegalArgumentException
              #"Object cannot be coerced to a keyword"
              (etag {"/one/file"
-                    [ {["array"
+                    (map-with-classes
+                     [{["array"
                         "as"
                         "map"
                         "key"
                         "not"
                         "supported"]
-                       "bogus"}]})))))))
+                       "bogus"}])})))))))
 
 (deftest file-bucket-file-content-type-test
   (testing (str "The 'Content-Type' header on incoming /file_bucket_file requests "


### PR DESCRIPTION
This commit contains some changes which validate / support some of
the fixes / changes done to the ClassInformationService in core Ruby
Puppet, including:

* Per PUP-5809, production code and tests updated to expect the
  ClassInformationService to wrap return values for successfully parsed
  classes in a `:classes` hash.

* As an optimization, removed one layer of RubyHash -> map conversion
  during translation of environment_class file info to the JSON
  response per the changes made in PUP-5809.

* Added a couple of tests to the class-info-test suite to validate the
  removal of literal parameter values for non-JSON safe types (PUP-5744)
  and values with expressions (PUP-5713).

* Bump the Puppet submodule to a81f968 and pinned puppet-agent up to
  18ebd9a in order for the above PUP changes to be picked up.