### PR TITLE
(SERVER-1134) Fail startup if vcs is partially configured

### DIFF
--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_service.clj
@@ -17,6 +17,7 @@
      (log/info "No code-id-command set for versioned-code-service. Code-id will be nil."))
    (if (nil? (get-in-config [:versioned-code :code-content-command]))
      (log/info "No code-content-command set for versioned-code-service. Attempting to fetch code content will fail."))
+   (vc-core/validate-config! (get-in-config [:versioned-code]))
    context)
 
   (current-code-id

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -51,7 +51,8 @@
      app {:jruby-puppet
           {:max-active-instances num-jrubies}
           :versioned-code
-          {:code-id-command (script-path "echo")}}
+          {:code-id-command (script-path "echo")
+           :code-content-command (script-path "echo")}}
      (let [catalog (testutils/get-catalog)]
        (is (= "production" (get catalog "code_id"))))))
   (testing "code id is added to the request body for catalog requests"
@@ -62,7 +63,8 @@
      app {:jruby-puppet
           {:max-active-instances num-jrubies}
           :versioned-code
-          {:code-id-command (script-path "echo")}}
+          {:code-id-command (script-path "echo")
+           :code-content-command (script-path "echo")}}
      (let [catalog (testutils/post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
   (testing "code id is added to the request body for catalog requests"
@@ -74,7 +76,8 @@
       app {:jruby-puppet
            {:max-active-instances num-jrubies}
            :versioned-code
-           {:code-id-command (script-path "warn_echo_and_error")}}
+           {:code-id-command (script-path "warn_echo_and_error")
+            :code-content-command (script-path "echo")}}
       (let [catalog (testutils/get-catalog)]
         (is (nil? (get catalog "code_id")))
         (is (logged? #"Non-zero exit code returned while running" :error))
@@ -88,12 +91,12 @@
       {:jruby-puppet
        {:max-active-instances num-jrubies}
        :versioned-code
-       {:code-content-command (script-path "echo")}}
+       {:code-content-command (script-path "echo")
+        :code-id-command (script-path "echo")}}
       (testing "the /static_file_content endpoint successfully streams file content"
         (let [response (get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
           (is (= "test foobar modules/foo/files/bar.txt\n" (:body response)))))
-
       (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
         (testing "the /static_file_content endpoint returns an error if code_id is not provided"
           (let [response (get-static-file-content "modules/foo/files/bar.txt?environment=test")]
@@ -127,7 +130,7 @@
       {:jruby-puppet
        {:max-active-instances num-jrubies}
        :versioned-code
-       {:code-content-command nil}}
+       {}}
       (let [response (get-static-file-content "modules/foo/files/bar/?code_id=foobar&environment=test")]
         (is (= 500 (:status response)))
         (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_service_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_service_test.clj
@@ -62,3 +62,23 @@
                 result (-> (vc/get-code-content vcs "test" "foobar" "foo/bar/")
                            (IOUtils/toString "UTF-8"))]
             (is (= "test foobar foo/bar/\n" result))))))))
+
+(deftest ^:integration vcs-fails-startup-if-misconfigured
+  (testing "If only :code-id-command is set, it will not start up"
+    (logging/with-test-logging
+     (try
+       (tk-testutils/with-app-with-config
+        app
+        [vcs/versioned-code-service]
+        {:versioned-code {:code-id-command (script-path "echo")}})
+       (catch IllegalStateException e
+         (is (re-find #"Only one of .* was set." (.getMessage e)))))))
+  (testing "If only :code-content-command is set, it will not start up"
+    (logging/with-test-logging
+     (try
+       (tk-testutils/with-app-with-config
+        app
+        [vcs/versioned-code-service]
+        {:versioned-code {:code-content-command (script-path "echo")}})
+       (catch IllegalStateException e
+         (is (re-find #"Only one of .* was set." (.getMessage e))))))))


### PR DESCRIPTION
Previously if the versioned-code-service were partially configured, code
id would still be added to catalog requests. This commit alters that
behavior so that if only one of the two configuration settings is
present the catalog request returns a 500 error.