### PR TITLE
(SERVER-1131) Throw a better error message for commands with arguments

### DIFF
--- a/src/clj/puppetlabs/puppetserver/shell_utils.clj
+++ b/src/clj/puppetlabs/puppetserver/shell_utils.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.puppetserver.shell-utils
   (:require [schema.core :as schema]
             [clojure.java.io :as io]
-            [puppetlabs.kitchensink.core :as ks])
+            [puppetlabs.kitchensink.core :as ks]
+            [clojure.string :as string])
   (:import (com.puppetlabs.puppetserver ShellUtils)
            (java.io IOException InputStream OutputStream)
            (org.apache.commons.io IOUtils)))
@@ -42,8 +43,12 @@
       (throw (IllegalArgumentException.
               (format "An absolute path is required, but '%s' is not an absolute path" command)))
       (not (.exists command-file))
-      (throw (IllegalArgumentException.
-              (format "The referenced command '%s' does not exist" command)))
+      (let [cmds (string/split command #" ")]
+        (if (and (> (count cmds) 1) (.exists (io/as-file (first cmds))))
+          (throw (IllegalArgumentException.
+                  (format "Command '%s' appears to use command-line arguments, but this is not allowed." command)))
+          (throw (IllegalArgumentException.
+                  (format "The referenced command '%s' does not exist" command)))))
       (not (.canExecute command-file))
       (throw (IllegalArgumentException.
               (format "The referenced command '%s' is not executable" command))))))

--- a/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
+++ b/test/unit/puppetlabs/puppetserver/shell_utils_test.clj
@@ -51,11 +51,21 @@
 
 (deftest throws-exception-for-non-absolute-path
   (testing "Commands must be given using absolute paths"
-    (is (thrown? IllegalArgumentException (sh-utils/execute-command "echo")))))
+    (is (thrown? IllegalArgumentException
+                 (sh-utils/execute-command "echo")))))
 
 (deftest throws-exception-for-non-existent-file
   (testing "The given command must exist"
-    (is (thrown? IllegalArgumentException (sh-utils/execute-command "/usr/bin/footest")))))
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"command '/usr/bin/footest' does not exist"
+                          (sh-utils/execute-command "/usr/bin/footest")))))
+
+(deftest throws-reasonable-error-for-arguments-in-command
+  (testing "A meaningful error is raised if arguments are added to the command"
+    (is (thrown-with-msg? IllegalArgumentException
+                          #"appears to use command-line arguments, but this is not allowed"
+                          (sh-utils/execute-command
+                           (str (script-path "echo") " foo"))))))
 
 (deftest can-read-more-than-the-pipe-buffer
   (testing "Doesn't deadlock when reading more than the pipe can hold"


### PR DESCRIPTION
Previously if a command with arguments were passed to
shell-utils/execute-command, it would throw an error about
'/usr/bin/echo foo' command does not exist. This commit updates the
validation to throw an error if the command does not exist, but the
first part when split on a space does exist.