### PR TITLE
(SERVER-1107) Fail fast on non-zero exit code

### DIFF
--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
@@ -31,10 +31,14 @@
                "Command executed: '%s', error generated: '%s'")
               cmd (.getMessage e)))
 
-(schema/defn ^:always-validate execute-code-id-script! :- (schema/maybe schema/Str)
+(schema/defn ^:always-validate execute-code-id-script! :- schema/Str
   [code-id-script :- schema/Str
    environment :- schema/Str]
-  (let [log-execution-error! #(log/error (execution-error-msg code-id-script %))]
+  (let [code-id-error-msg "code-id could not be retrieved"
+        log-execution-error! #(log/error (execution-error-msg code-id-script %))
+        throw-execution-error! (fn []
+                                 (throw (IllegalStateException.
+                                          code-id-error-msg)))]
     (try
       (let [{:keys [exit-code stderr stdout]} (shell-utils/execute-command
                                                code-id-script
@@ -55,15 +59,16 @@
             (string/trim-newline stdout))
           (do
             (log/error (nonzero-msg code-id-script exit-code stdout stderr))
-            (throw
-              (IllegalStateException.
-                "code-id could not be retrieved")))))
+            (throw-execution-error!))))
       (catch IllegalArgumentException e
-        (log-execution-error! e))
+        (log-execution-error! e)
+        (throw-execution-error!))
       (catch IOException e
-        (log-execution-error! e))
+        (log-execution-error! e)
+        (throw-execution-error!))
       (catch InterruptedException e
-        (log-execution-error! e)))))
+        (log-execution-error! e)
+        (throw-execution-error!)))))
 
 (schema/defn valid-code-id? :- schema/Bool
   "Returns false if code-id contains anything but alpha-numerics and

--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
@@ -55,7 +55,9 @@
             (string/trim-newline stdout))
           (do
             (log/error (nonzero-msg code-id-script exit-code stdout stderr))
-            nil)))
+            (throw
+              (IllegalStateException.
+                "code-id could not be retrieved")))))
       (catch IllegalArgumentException e
         (log-execution-error! e))
       (catch IOException e

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -59,18 +59,21 @@
           {:code-id-command (script-path "echo")}}
      (let [catalog (testutils/post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
-  (testing "code id is added to the request body for catalog requests"
+  (testing "catalog request fails if code-id-command returns a non-zero exit code"
     ; As we have set code-id-command to warn, the code id will
     ; be the result of running `warn_echo_and_error $environment`, which will
-    ; exit non-zero and return nil.
+    ; exit non-zero and fail the catalog request.
     (logging/with-test-logging
      (bootstrap/with-puppetserver-running
       app {:jruby-puppet
            {:max-active-instances num-jrubies}
            :versioned-code
            {:code-id-command (script-path "warn_echo_and_error")}}
-      (let [catalog (testutils/get-catalog)]
-        (is (nil? (get catalog "code_id")))
+      (let [catalog-response (http-client/get
+                               "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
+                               testutils/catalog-request-options)]
+        (is (= 500 (:status catalog-response)))
+        (is (re-matches #".*code-id could not be retrieved" (:body catalog-response)))
         (is (logged? #"Non-zero exit code returned while running" :error))
         (is (logged? #"Executed an external process which logged to STDERR: production" :warn)))))))
 

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -29,9 +29,9 @@
                   (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
      (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
 
-  (testing "nil is returned and error logged for exception during execute-command"
+  (testing "exception thrown and error logged for exception during execute-command"
     (logging/with-test-logging
-     (is (nil? (vc-core/execute-code-id-script! "false" "foo")))
+     (is (thrown? IllegalStateException (vc-core/execute-code-id-script! "false" "foo")))
      (is (logged? "Running script generated an error. Command executed: 'false', error generated: 'An absolute path is required, but 'false' is not an absolute path'")))))
 
 (deftest test-code-content-execution

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -25,7 +25,8 @@
 
   (testing "exit-code, stdout and stderr are all logged for non-zero exit"
     (logging/with-test-logging
-     (is (nil? (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
+     (is (thrown? IllegalStateException
+                  (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
      (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
 
   (testing "nil is returned and error logged for exception during execute-command"


### PR DESCRIPTION
Previously, if the `code-id-command` returned a non-zero exit
code, `nil` was returned for the code-id and inserted into the
catalog.

This commit modifies this behavior so that instead of returning
nil, an exception is thrown, which causes the catalog request
to fail.