### PR TITLE
(maint) Return 400 is no environment is in a catalog request

### DIFF
--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -259,7 +259,7 @@
   (if (:include-code-id? request)
     (let [env (jruby-request/get-environment-from-request request)]
       (when-not env
-        (throw (IllegalStateException. "Environment is required in a catalog request.")))
+        (jruby-request/throw-bad-request! "Environment is required in a catalog request."))
       (assoc-in request [:params "code_id"] (current-code-id env)))
     request))
 

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -81,7 +81,18 @@
       (let [catalog (testutils/get-catalog)]
         (is (nil? (get catalog "code_id")))
         (is (logged? #"Non-zero exit code returned while running" :error))
-        (is (logged? #"Executed an external process which logged to STDERR: production" :warn)))))))
+        (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
+  (testing "code id is not added and 400 is returned if environment is not included in request"
+    (logging/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app {:jruby-puppet
+           {:max-active-instances num-jrubies}
+           :versioned-code
+           {:code-content-command (script-path "echo")
+            :code-id-command (script-path "echo")}}
+      (let [response (testutils/http-get "puppet/v3/catalog/localhost")]
+        (is (= 400 (:status response)))
+        (is (logged? #"Error 400 on SERVER")))))))
 
 (deftest ^:integration static-file-content-endpoint-test
   (logging/with-test-logging


### PR DESCRIPTION
Previously, because with-code-id simply threw an exception, catalog
requests without an environment would return a 500. A bad request of 400
seems like a better match for the expected return code (as the client
controls whether or not an environment is included in the request), so
this commit updates with-code-id to throw a bad request if no
environment is present in the request.