### PR TITLE
(SERVER-1107) Fail on non-zero exit from code-id-command

### DIFF
--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
@@ -41,22 +41,22 @@
   Non-zero return from code-id-script generates an IllegalStateException."
   [code-id-script :- schema/Str
    environment :- schema/Str]
-      (let [{:keys [exit-code stderr stdout]} (shell-utils/execute-command
-                                               code-id-script
-                                               {:args [environment]})]
-        ; TODO Decide what to do about normalizing/sanitizing output with respect to
-        ; control characters and encodings
+  (let [{:keys [exit-code stderr stdout]} (shell-utils/execute-command
+                                           code-id-script
+                                           {:args [environment]})]
+    ; TODO Decide what to do about normalizing/sanitizing output with respect to
+    ; control characters and encodings
 
-        ;; There are three cases we care about here:
-        ;; - exit code is 0 and no stderr generated: groovy. return stdout
-        ;; - exit code is 0 and stderr was generated: that's fine. log an error
-        ;;   about the stderr and return stdout.
+    ;; There are three cases we care about here:
+    ;; - exit code is 0 and no stderr generated: groovy. return stdout
+    ;; - exit code is 0 and stderr was generated: that's fine. log an error
+    ;;   about the stderr and return stdout.
     ;; - exit code is non-zero: oh no! throw an error with all the details
-        (if (zero? exit-code)
-          (do
-            (when-not (string/blank? stderr)
-              (log/error (success-with-stderr-msg code-id-script stderr)))
-            (string/trim-newline stdout))
+    (if (zero? exit-code)
+      (do
+        (when-not (string/blank? stderr)
+          (log/error (success-with-stderr-msg code-id-script stderr)))
+        (string/trim-newline stdout))
       (throw (IllegalStateException. (nonzero-msg code-id-script exit-code stdout stderr))))))
 
 (schema/defn valid-code-id? :- schema/Bool

--- a/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
+++ b/src/clj/puppetlabs/services/versioned_code_service/versioned_code_core.clj
@@ -60,7 +60,9 @@
             (string/trim-newline stdout))
           (do
             (log/error (nonzero-msg code-id-script exit-code stdout stderr))
-            nil)))
+            (throw
+              (IllegalStateException.
+                "code-id could not be retrieved")))))
       (catch IllegalArgumentException e
         (log-execution-error! e))
       (catch IOException e

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -67,23 +67,23 @@
            :code-content-command (script-path "echo")}}
      (let [catalog (testutils/post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
-  (testing "catalog request fails if code-id-command returns a non-zero exit code"
-    ; As we have set code-id-command to warn, the code id will
-    ; be the result of running `warn_echo_and_error $environment`, which will
-    ; exit non-zero and fail the catalog request.
-     (bootstrap/with-puppetserver-running
-      app {:jruby-puppet
-           {:max-active-instances num-jrubies}
-           :versioned-code
-           {:code-id-command (script-path "warn_echo_and_error")
-            :code-content-command (script-path "echo")}}
+    (testing "catalog request fails if code-id-command returns a non-zero exit code"
+      ; As we have set code-id-command to warn, the code id will
+      ; be the result of running `warn_echo_and_error $environment`, which will
+      ; exit non-zero and fail the catalog request.
+      (bootstrap/with-puppetserver-running
+       app {:jruby-puppet
+            {:max-active-instances num-jrubies}
+            :versioned-code
+            {:code-id-command (script-path "warn_echo_and_error")
+             :code-content-command (script-path "echo")}}
        (logging/with-test-logging
-      (let [catalog-response (http-client/get
-                               "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
-                               testutils/catalog-request-options)]
-        (is (= 500 (:status catalog-response)))
+        (let [catalog-response (http-client/get
+                                "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
+                                testutils/catalog-request-options)]
+          (is (= 500 (:status catalog-response)))
           (is (re-find #"Non-zero exit code returned while running" (:body catalog-response)))
-        (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
+          (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
   (testing "code id is not added and 400 is returned if environment is not included in request"
     (logging/with-test-logging
      (bootstrap/with-puppetserver-running

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -71,19 +71,18 @@
     ; As we have set code-id-command to warn, the code id will
     ; be the result of running `warn_echo_and_error $environment`, which will
     ; exit non-zero and fail the catalog request.
-    (logging/with-test-logging
      (bootstrap/with-puppetserver-running
       app {:jruby-puppet
            {:max-active-instances num-jrubies}
            :versioned-code
            {:code-id-command (script-path "warn_echo_and_error")
             :code-content-command (script-path "echo")}}
+       (logging/with-test-logging
       (let [catalog-response (http-client/get
                                "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
                                testutils/catalog-request-options)]
         (is (= 500 (:status catalog-response)))
-        (is (re-matches #".*code-id could not be retrieved" (:body catalog-response)))
-        (is (logged? #"Non-zero exit code returned while running" :error))
+          (is (re-find #"Non-zero exit code returned while running" (:body catalog-response)))
         (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
   (testing "code id is not added and 400 is returned if environment is not included in request"
     (logging/with-test-logging

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -42,8 +42,8 @@
        (let [catalog (testutils/get-catalog)]
          (is (testutils/catalog-contains? catalog "Notify" "this command echoes a thing\n")))))))
 
-(deftest ^:integration code-id-request-test
-  (testing "code id is added to the request body for catalog requests"
+(deftest ^:integration code-id-request-test-get-catalog
+  (testing "code id is added to the request body for catalog requests via get"
     ; As we have set code-id-command to echo, the code id will
     ; be the result of running `echo $environment`, which will
     ; be production here.
@@ -54,8 +54,10 @@
           {:code-id-command (script-path "echo")
            :code-content-command (script-path "echo")}}
      (let [catalog (testutils/get-catalog)]
-       (is (= "production" (get catalog "code_id"))))))
-  (testing "code id is added to the request body for catalog requests"
+       (is (= "production" (get catalog "code_id")))))))
+
+(deftest ^:integration code-id-request-test-post-catalog
+  (testing "code id is added to the request body for catalog requests via post"
     ; As we have set code-id-command to echo, the code id will
     ; be the result of running `echo $environment`, which will
     ; be production here.
@@ -66,7 +68,9 @@
           {:code-id-command (script-path "echo")
            :code-content-command (script-path "echo")}}
      (let [catalog (testutils/post-catalog)]
-       (is (= "production" (get catalog "code_id"))))))
+       (is (= "production" (get catalog "code_id")))))))
+
+(deftest ^:integration code-id-request-test-non-zero-exit
     (testing "catalog request fails if code-id-command returns a non-zero exit code"
       ; As we have set code-id-command to warn, the code id will
       ; be the result of running `warn_echo_and_error $environment`, which will
@@ -83,7 +87,9 @@
                                 testutils/catalog-request-options)]
           (is (= 500 (:status catalog-response)))
           (is (re-find #"Non-zero exit code returned while running" (:body catalog-response)))
-          (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
+          (is (logged? #"Executed an external process which logged to STDERR: production" :warn)))))))
+
+(deftest ^:integration code-id-request-test-no-environment
   (testing "code id is not added and 400 is returned if environment is not included in request"
     (logging/with-test-logging
      (bootstrap/with-puppetserver-running

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -67,10 +67,10 @@
            :code-content-command (script-path "echo")}}
      (let [catalog (testutils/post-catalog)]
        (is (= "production" (get catalog "code_id"))))))
-  (testing "code id is added to the request body for catalog requests"
+  (testing "catalog request fails if code-id-command returns a non-zero exit code"
     ; As we have set code-id-command to warn, the code id will
     ; be the result of running `warn_echo_and_error $environment`, which will
-    ; exit non-zero and return nil.
+    ; exit non-zero and fail the catalog request.
     (logging/with-test-logging
      (bootstrap/with-puppetserver-running
       app {:jruby-puppet
@@ -78,8 +78,11 @@
            :versioned-code
            {:code-id-command (script-path "warn_echo_and_error")
             :code-content-command (script-path "echo")}}
-      (let [catalog (testutils/get-catalog)]
-        (is (nil? (get catalog "code_id")))
+      (let [catalog-response (http-client/get
+                               "https://localhost:8140/puppet/v3/catalog/localhost?environment=production"
+                               testutils/catalog-request-options)]
+        (is (= 500 (:status catalog-response)))
+        (is (re-matches #".*code-id could not be retrieved" (:body catalog-response)))
         (is (logged? #"Non-zero exit code returned while running" :error))
         (is (logged? #"Executed an external process which logged to STDERR: production" :warn))))))
   (testing "code id is not added and 400 is returned if environment is not included in request"

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -29,9 +29,9 @@
                   (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
      (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
 
-  (testing "nil is returned and error logged for exception during execute-command"
+  (testing "exception thrown and error logged for exception during execute-command"
     (logging/with-test-logging
-     (is (nil? (vc-core/execute-code-id-script! "false" "foo")))
+     (is (thrown? IllegalStateException (vc-core/execute-code-id-script! "false" "foo")))
      (is (logged? "Running script generated an error. Command executed: 'false', error generated: 'An absolute path is required, but 'false' is not an absolute path'")))))
 
 (deftest test-code-content-execution

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -25,7 +25,8 @@
 
   (testing "exit-code, stdout and stderr are all logged for non-zero exit"
     (logging/with-test-logging
-     (is (nil? (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
+     (is (thrown? IllegalStateException
+                  (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
      (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
 
   (testing "nil is returned and error logged for exception during execute-command"

--- a/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
+++ b/test/unit/puppetlabs/services/versioned_code_service/versioned_code_core_test.clj
@@ -23,16 +23,15 @@
      (is (= "" (vc-core/execute-code-id-script! (script-path "warn") "foo")))
      (is (logged? (format "Error output generated while running '%s'. stderr: '%s'" (script-path "warn") "foo\n")))))
 
-  (testing "exit-code, stdout and stderr are all logged for non-zero exit"
+  (testing "an exception is thrown for non-zero exit of the code-id-script"
     (logging/with-test-logging
      (is (thrown? IllegalStateException
                   (vc-core/execute-code-id-script! (script-path "warn_echo_and_error") "foo")))
-     (is (logged? (format "Non-zero exit code returned while running '%s'. exit-code: '%d', stdout: '%s', stderr: '%s'" (script-path "warn_echo_and_error") 1 "foo\n" "foo\n")))))
+     (is (logged? "Executed an external process which logged to STDERR: foo\n"))))
 
   (testing "exception thrown and error logged for exception during execute-command"
     (logging/with-test-logging
-     (is (thrown? IllegalStateException (vc-core/execute-code-id-script! "false" "foo")))
-     (is (logged? "Running script generated an error. Command executed: 'false', error generated: 'An absolute path is required, but 'false' is not an absolute path'")))))
+     (is (thrown? IllegalArgumentException (vc-core/execute-code-id-script! "false" "foo"))))))
 
 (deftest test-code-content-execution
   (testing "when executing external code content command"


### PR DESCRIPTION
Previously, if the `code-id-command` returned a non-zero exit
code, `nil` was returned for the code-id and inserted into the
catalog.

This commit modifies this behavior so that instead of returning
nil, an exception is thrown, which causes the catalog request
to fail.