### PR TITLE
(SERVER-1143) Auth rule for static file content

### DIFF
--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -135,6 +135,13 @@ with_puppet_running_on(master, {}) do
     assert_allowed
   end
 
+  step 'static file content endpoint' do
+    # We'd actually need to perform a commit and use its code-id in order to
+    # get back a 200, but we know that a 400 means we got past authorization
+    curl_authenticated('/puppet/v3/static_file_content/foo/bar?environment=production')
+    assert_allowed(400)
+  end
+
   step 'certificate_revocation_list endpoint' do
     curl_authenticated('/puppet-ca/v1/certificate_revocation_list/ca?environment=production')
     assert_allowed

--- a/acceptance/suites/tests/authorization/default_rules.rb
+++ b/acceptance/suites/tests/authorization/default_rules.rb
@@ -140,6 +140,9 @@ with_puppet_running_on(master, {}) do
     # get back a 200, but we know that a 400 means we got past authorization
     curl_authenticated('/puppet/v3/static_file_content/foo/bar?environment=production')
     assert_allowed(400)
+
+    curl_unauthenticated('/puppet/v3/static_file_content/foo/bar?environment=production')
+    assert_denied(/denied by rule 'puppetlabs static file content'/)
   end
 
   step 'certificate_revocation_list endpoint' do

--- a/ezbake/config/conf.d/auth.conf
+++ b/ezbake/config/conf.d/auth.conf
@@ -102,6 +102,16 @@ authorization: {
             name: "puppetlabs status"
         },
         {
+            match-request: {
+                path: "/puppet/v3/static_file_content"
+                type: path
+                method: get
+            }
+            allow: "*"
+            sort-order: 500
+            name: "puppetlabs static file content"
+        },
+        {
           # Deny everything else. This ACL is not strictly
           # necessary, but illustrates the default policy
           match-request: {


### PR DESCRIPTION
This PR adds an auth rule to allow authenticated access to the
static_file_content endpoint, and adds the associated acceptance test