### PR TITLE
(MAINT)confine statement failed in PE; replaced with skip

### DIFF
--- a/acceptance/suites/tests/code_commands/code_scripts.rb
+++ b/acceptance/suites/tests/code_commands/code_scripts.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-confine :except, :type => 'pe'
+skip_test 'SKIP: This test should only run in puppet-server FOSS.' if options[:type] = 'pe'
 
 test_name 'SERVER-1118: Validate code-id-command feature in FOSS'
 


### PR DESCRIPTION
This test will cause the pe-puppet-server-extensions pipe to file until this PR is merged.