### PR TITLE
(SERVER-1142) Sanely handle auth and param parsing for clojure routes

### DIFF
--- a/dev-resources/puppetlabs/puppetserver/auth_conf_test/echo
+++ b/dev-resources/puppetlabs/puppetserver/auth_conf_test/echo
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo $@

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -30,6 +30,7 @@
                                 config)
           jruby-service (tk-services/get-service this :JRubyPuppetService)
           master-route-handler (-> (master-core/root-routes handle-request
+                                                            (partial identity)
                                                             jruby-service
                                                             (constantly nil))
                                    ((partial comidi/context path))
@@ -40,8 +41,8 @@
                                :handler     (master-core/get-wrapped-handler
                                               master-route-handler
                                               wrap-with-authorization-check
-                                              use-legacy-auth-conf
-                                              puppet-version)
+                                              puppet-version
+                                              use-legacy-auth-conf)
                                :api-version master-core/puppet-API-version}
           real-ca-service? (= (namespace (tk-services/service-symbol ca-service))
                               "puppetlabs.services.ca.certificate-authority-service")

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -406,13 +406,12 @@
 (schema/defn ^:always-validate
   v3-clojure-routes :- bidi-schema/RoutePair
   "v3 route tree for the clojure side of the master service."
-  [clojure-request-wrapper :- IFn
-   jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
+  [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    get-code-content-fn :- IFn]
   (let [environment-class-handler
-        (clojure-request-wrapper (environment-class-handler jruby-service))
+        (environment-class-handler jruby-service)
         static-file-content-handler
-        (clojure-request-wrapper (static-file-content-request-handler get-code-content-fn))]
+        (static-file-content-request-handler get-code-content-fn)]
     (comidi/routes
      (comidi/GET ["/environment_classes" [#".*" :rest]] request
                  (environment-class-handler request))
@@ -430,7 +429,9 @@
    get-code-content-fn :- IFn]
   (comidi/context "/v3"
                   (v3-ruby-routes ruby-request-handler)
-                  (v3-clojure-routes clojure-request-wrapper jruby-service get-code-content-fn)))
+                  (comidi/wrap-routes
+                   (v3-clojure-routes jruby-service get-code-content-fn)
+                   clojure-request-wrapper )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -375,41 +375,41 @@
   (let [environment-class-handler (environment-class-handler jruby-service)
         static-file-content-handler (static-file-content-request-handler get-code-content-fn)]
     (let [ruby-routes (comidi/routes
-     (comidi/GET ["/node/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_content/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_metadata/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
-                  (request-handler request))
+           (comidi/GET ["/node/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/file_content/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/file_metadata/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
+                        (request-handler request))
 
-     (comidi/GET ["/catalog/" [#".*" :rest]] request
-                 (request-handler (assoc request :include-code-id? true)))
-     (comidi/POST ["/catalog/" [#".*" :rest]] request
-                  (request-handler (assoc request :include-code-id? true)))
-     (comidi/PUT ["/report/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/resource_type/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/resource_types/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET ["/environment/" [#".*" :rest]] request
-                 (request-handler request))
-     (comidi/GET "/environments" request
-                 (request-handler request))
-     (comidi/GET ["/status/" [#".*" :rest]] request
+           (comidi/GET ["/catalog/" [#".*" :rest]] request
+                       (request-handler (assoc request :include-code-id? true)))
+           (comidi/POST ["/catalog/" [#".*" :rest]] request
+                        (request-handler (assoc request :include-code-id? true)))
+           (comidi/PUT ["/report/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/resource_type/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/resource_types/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET ["/environment/" [#".*" :rest]] request
+                       (request-handler request))
+           (comidi/GET "/environments" request
+                       (request-handler request))
+           (comidi/GET ["/status/" [#".*" :rest]] request
                        (request-handler request)))
           clojure-routes (comidi/routes
-     (comidi/GET ["/environment_classes" [#".*" :rest]] request
-                 (environment-class-handler request))
-     (comidi/GET ["/static_file_content/" [#".*" :rest]] request
+           (comidi/GET ["/environment_classes" [#".*" :rest]] request
+                       (environment-class-handler request))
+           (comidi/GET ["/static_file_content/" [#".*" :rest]] request
                        (static-file-content-handler request)))]
       (comidi/context "/v3" ruby-routes clojure-routes))))
 
@@ -464,8 +464,8 @@
   "Creates all of the web routes for the master."
   [request-handler jruby-service get-code-content-fn]
   (comidi/routes
-                    (v3-routes request-handler
-                               jruby-service
+   (v3-routes request-handler
+              jruby-service
               get-code-content-fn)))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -374,7 +374,7 @@
   [request-handler jruby-service get-code-content-fn]
   (let [environment-class-handler (environment-class-handler jruby-service)
         static-file-content-handler (static-file-content-request-handler get-code-content-fn)]
-    (comidi/routes
+    (let [ruby-routes (comidi/routes
      (comidi/GET ["/node/" [#".*" :rest]] request
                  (request-handler request))
      (comidi/GET ["/file_content/" [#".*" :rest]] request
@@ -405,12 +405,13 @@
      (comidi/GET "/environments" request
                  (request-handler request))
      (comidi/GET ["/status/" [#".*" :rest]] request
-                 (request-handler request))
-
+                       (request-handler request)))
+          clojure-routes (comidi/routes
      (comidi/GET ["/environment_classes" [#".*" :rest]] request
                  (environment-class-handler request))
      (comidi/GET ["/static_file_content/" [#".*" :rest]] request
-                 (static-file-content-handler request)))))
+                       (static-file-content-handler request)))]
+      (comidi/context "/v3" ruby-routes clojure-routes))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions
@@ -463,10 +464,9 @@
   "Creates all of the web routes for the master."
   [request-handler jruby-service get-code-content-fn]
   (comidi/routes
-    (comidi/context "/v3"
                     (v3-routes request-handler
                                jruby-service
-                               get-code-content-fn))))
+              get-code-content-fn)))
 
 (schema/defn ^:always-validate
   wrap-middleware :- IFn

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -409,8 +409,10 @@
   [clojure-request-wrapper :- IFn
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    get-code-content-fn :- IFn]
-  (let [environment-class-handler (clojure-request-wrapper (environment-class-handler jruby-service))
-        static-file-content-handler (clojure-request-wrapper (static-file-content-request-handler get-code-content-fn))]
+  (let [environment-class-handler
+        (clojure-request-wrapper (environment-class-handler jruby-service))
+        static-file-content-handler
+        (clojure-request-wrapper (static-file-content-request-handler get-code-content-fn))]
     (comidi/routes
      (comidi/GET ["/environment_classes" [#".*" :rest]] request
                  (environment-class-handler request))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -367,51 +367,61 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Routing
 
+(defn v3-ruby-routes
+  "v3 route tree for the ruby side of the master service."
+  [request-handler]
+  (comidi/routes
+   (comidi/GET ["/node/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_content/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_metadata/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
+                (request-handler request))
+
+   (comidi/GET ["/catalog/" [#".*" :rest]] request
+               (request-handler (assoc request :include-code-id? true)))
+   (comidi/POST ["/catalog/" [#".*" :rest]] request
+                (request-handler (assoc request :include-code-id? true)))
+   (comidi/PUT ["/report/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/resource_type/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/resource_types/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET ["/environment/" [#".*" :rest]] request
+               (request-handler request))
+   (comidi/GET "/environments" request
+               (request-handler request))
+   (comidi/GET ["/status/" [#".*" :rest]] request
+               (request-handler request))))
+
+(defn v3-clojure-routes
+  "v3 route tree for the clojure side of the master service."
+  [jruby-service get-code-content-fn]
+  (let [environment-class-handler (environment-class-handler jruby-service)
+        static-file-content-handler (static-file-content-request-handler get-code-content-fn)]
+    (comidi/routes
+     (comidi/GET ["/environment_classes" [#".*" :rest]] request
+                 (environment-class-handler request))
+     (comidi/GET ["/static_file_content/" [#".*" :rest]] request
+                 (static-file-content-handler request)))))
+
 (defn v3-routes
   "Creates the routes to handle the master's '/v3' routes, which
    includes '/environments' and the non-CA indirected routes. The CA-related
    endpoints are handled separately by the CA service."
   [request-handler jruby-service get-code-content-fn]
-  (let [environment-class-handler (environment-class-handler jruby-service)
-        static-file-content-handler (static-file-content-request-handler get-code-content-fn)]
-    (let [ruby-routes (comidi/routes
-           (comidi/GET ["/node/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/file_content/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/file_metadatas/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/file_metadata/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/file_bucket_file/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/PUT ["/file_bucket_file/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/HEAD ["/file_bucket_file/" [#".*" :rest]] request
-                        (request-handler request))
-
-           (comidi/GET ["/catalog/" [#".*" :rest]] request
-                       (request-handler (assoc request :include-code-id? true)))
-           (comidi/POST ["/catalog/" [#".*" :rest]] request
-                        (request-handler (assoc request :include-code-id? true)))
-           (comidi/PUT ["/report/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/resource_type/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/resource_types/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET ["/environment/" [#".*" :rest]] request
-                       (request-handler request))
-           (comidi/GET "/environments" request
-                       (request-handler request))
-           (comidi/GET ["/status/" [#".*" :rest]] request
-                       (request-handler request)))
-          clojure-routes (comidi/routes
-           (comidi/GET ["/environment_classes" [#".*" :rest]] request
-                       (environment-class-handler request))
-           (comidi/GET ["/static_file_content/" [#".*" :rest]] request
-                       (static-file-content-handler request)))]
-      (comidi/context "/v3" ruby-routes clojure-routes))))
+  (comidi/context "/v3"
+                  (v3-ruby-routes request-handler)
+                  (v3-clojure-routes jruby-service get-code-content-fn)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Lifecycle Helper Functions

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -44,8 +44,16 @@
      (log/info "Master Service adding ring handlers")
      (let [route-config (core/get-master-route-config ::master-service config)
            path (core/get-master-mount ::master-service route-config)
-           ring-handler (let [ruby-request-handler (core/get-wrapped-handler handle-request wrap-with-authorization-check puppet-version use-legacy-auth-conf)
-                              clojure-request-wrapper (fn [handler] (core/get-wrapped-handler (ring/wrap-params handler) wrap-with-authorization-check puppet-version))]
+           ring-handler (let [ruby-request-handler
+                              (core/get-wrapped-handler handle-request
+                                                        wrap-with-authorization-check
+                                                        puppet-version
+                                                        use-legacy-auth-conf)
+                              clojure-request-wrapper (fn [handler]
+                                                        (core/get-wrapped-handler
+                                                         (ring/wrap-params handler)
+                                                         wrap-with-authorization-check
+                                                         puppet-version))]
                           (when path
                             (-> (core/root-routes ruby-request-handler
                                                   clojure-request-wrapper

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -148,18 +148,3 @@
         (is (= 500 (:status response)))
         (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"
                         (:body response))))))))
-
-(deftest ^:integration static-file-content-works-with-legacy-auth
-  (testing "The static_file_content endpoint works even if legacy-auth is enabled."
-    ;; with-test-logging is used here to supress a warning about running with legacy auth enabled.
-    (logging/with-test-logging
-     (bootstrap/with-puppetserver-running
-      app
-      {:jruby-puppet {:use-legacy-auth-conf true}
-       :versioned-code
-       {:code-content-command (script-path "echo")
-        :code-id-command (script-path "echo")}}
-      (testing "for legacy puppet routes"
-        (let [response (get-static-file-content "modules/foo/files/bar?code_id=foobar&environment=test")]
-          (is (= 200 (:status response)) (ks/pprint-to-string response))
-          (is (= "test foobar modules/foo/files/bar\n" (:body response)) (ks/pprint-to-string response))))))))

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -154,3 +154,18 @@
         (is (= 500 (:status response)))
         (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"
                         (:body response))))))))
+
+(deftest ^:integration static-file-content-works-with-legacy-auth
+  (testing "The static_file_content endpoint works even if legacy-auth is enabled."
+    ;; with-test-logging is used here to supress a warning about running with legacy auth enabled.
+    (logging/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app
+      {:jruby-puppet {:use-legacy-auth-conf true}
+       :versioned-code
+       {:code-content-command (script-path "echo")
+        :code-id-command (script-path "echo")}}
+      (testing "for legacy puppet routes"
+        (let [response (get-static-file-content "modules/foo/files/bar?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)) (ks/pprint-to-string response))
+          (is (= "test foobar modules/foo/files/bar\n" (:body response)) (ks/pprint-to-string response))))))))

--- a/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
+++ b/test/integration/puppetlabs/puppetserver/auth_conf_test.clj
@@ -11,11 +11,16 @@
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.puppetserver.testutils :as testutils :refer [http-get]]
             [me.raynes.fs :as fs]
-            [ring.util.codec :as ring-codec])
+            [ring.util.codec :as ring-codec]
+            [puppetlabs.trapperkeeper.testutils.logging :as logging])
   (:import (java.io StringWriter)))
 
 (def test-resources-dir
-  "./dev-resources/puppetlabs/puppetserver/auth_conf_test")
+  (ks/absolute-path "./dev-resources/puppetlabs/puppetserver/auth_conf_test"))
+
+(defn script-path
+  [script-name]
+  (str test-resources-dir "/" script-name))
 
 (use-fixtures
   :once
@@ -174,3 +179,31 @@
                          "' in full response body: " (:body response))))
               (finally
                 (fs/delete-dir environment-dir))))))))))
+
+(deftest ^:integration static-file-content-works-with-legacy-auth
+  (testing "The static_file_content endpoint works even if legacy-auth is enabled."
+    ;; with-test-logging is used here to suppress a warning about running with legacy auth enabled.
+    (logging/with-test-logging
+     (bootstrap/with-puppetserver-running
+      app
+      {:jruby-puppet {:use-legacy-auth-conf true}
+       :authorization {:version 1
+                       :rules
+                       [{:match-request {:path "/puppet/v3/static_file_content"
+                                         :type "path"}
+                         :allow ["private" "localhost"]
+                         :sort-order 1
+                         :name "static file content"}]}
+       :versioned-code
+       {:code-content-command (script-path "echo")
+        :code-id-command (script-path "echo")}}
+      (testing "for legacy puppet routes with a valid cert"
+        (let [response (testutils/get-static-file-content
+                        "modules/foo/files/bar?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)) (ks/pprint-to-string response))
+          (is (= "test foobar modules/foo/files/bar\n" (:body response)) (ks/pprint-to-string response))))
+      (testing "for legacy puppet routes without a valid cert"
+        (let [response (testutils/get-static-file-content
+                        "modules/foo/files/bar?code_id=foobar&environment=test" false)]
+          (is (= 403 (:status response)) (ks/pprint-to-string response))
+          (is (re-find #"Forbidden request" (:body response)) (ks/pprint-to-string response))))))))

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -141,11 +141,18 @@
   [foo-pp-contents]
   (write-pp-file foo-pp-contents "foo"))
 
-(defn get-static-file-content
-  [url-end]
-  (http-client/get (str "https://localhost:8140/puppet/v3/static_file_content/" url-end)
-                   (assoc ssl-request-options
-                     :as :text)))
+(schema/defn ^:always-validate get-static-file-content
+  ([url-end :- schema/Str]
+   (get-static-file-content url-end true))
+  ([url-end :- schema/Str
+    include-ssl-certs? :- schema/Bool]
+   (let [request-options (if include-ssl-certs?
+                           catalog-request-options
+                           {:ssl-ca-cert ca-cert
+                            :headers     {"Accept" "pson"}})]
+     (http-client/get (str "https://localhost:8140/puppet/v3/static_file_content/" url-end)
+                      (assoc request-options
+                        :as :text)))))
 
 (schema/defn ^:always-validate get-catalog :- PuppetCatalog
   "Make an HTTP get request for a catalog."

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -141,6 +141,12 @@
   [foo-pp-contents]
   (write-pp-file foo-pp-contents "foo"))
 
+(defn get-static-file-content
+  [url-end]
+  (http-client/get (str "https://localhost:8140/puppet/v3/static_file_content/" url-end)
+                   (assoc ssl-request-options
+                     :as :text)))
+
 (schema/defn ^:always-validate get-catalog :- PuppetCatalog
   "Make an HTTP get request for a catalog."
   []

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -19,7 +19,7 @@
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]
-  (-> (root-routes request-handler #(ring/wrap-params %) jruby-service (constantly nil))
+  (-> (root-routes request-handler ring/wrap-params jruby-service (constantly nil))
       (comidi/routes->handler)
       (wrap-middleware puppet-version)))
 

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [ring.util.response :as rr]
             [ring.mock.request :as ring-mock]
-            [puppetlabs.kitchensink.core :as ks])
+            [puppetlabs.kitchensink.core :as ks]
+            [ring.middleware.params :as ring])
   (:import (java.util HashMap)))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -18,7 +19,7 @@
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]
-  (-> (root-routes request-handler jruby-service (constantly nil))
+  (-> (root-routes request-handler #(ring/wrap-params %) jruby-service (constantly nil))
       (comidi/routes->handler)
       (wrap-middleware puppet-version)))
 


### PR DESCRIPTION
Previously clojure routes were unauthenticated if legacy auth was
enabled because it was presumed that all routes would be handed down
into puppet for auth via auth.conf. As that is not the case, this commit
separates the jruby request handler from a new clojure request wrapper.
The jruby request handler is applied to all ruby routes, and conditional
authentication is applied to that handler. The new clojure wrapper
unconditionally applies authentication and parses the request for
params.
The legacy routes service also needed a corresponding change to account
for the changes to get-wrapped-handler and root-routes.
Additionally, this commit defines schemas for some of the existing and
all of the new functions in master-core.