### PR TITLE
(MAINT) Bump tk-jetty9 dep to 1.5.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.7.0")
 (def tk-version "1.3.0")
-(def tk-jetty-version "1.3.1")
+(def tk-jetty-version "1.5.2")
 (def ks-version "1.3.0")
 (def ps-version "2.2.2-master-SNAPSHOT")
 


### PR DESCRIPTION
This commit bumps Puppet Server's dependency on
trapperkeeper-webserver-jetty9 to 1.5.2. This is being done primarily
in order for Puppet Server to utilize some memory leak fixes related to
JMX beans in a HUP/restart scenario that were added in the latest
release.