### PR TITLE
(SERVER-1007) Print Timezone format with CA correctly on Java 8u60+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [clj-yaml "0.4.0" :exclusions [org.yaml/snakeyaml]]
                  [commons-lang "2.6"]
                  [commons-io "2.4"]
-                 [clj-time "0.10.0"]
+                 [clj-time "0.11.0"]
                  [prismatic/schema "1.0.4"]
                  [me.raynes/fs "1.4.6"]
                  [liberator "0.12.0"]


### PR DESCRIPTION
The version of Joda Time used by the previous version of clj-time had
an issue on Java 8u60+ that caused it to improperly print a different
timestamp.

This commit bumps the version of clj-time, which pins to a newer
version of Joda Time, which does not have this bug on Java 8u60 and
above.