### PR TITLE
(SERVER-1130) Add a per-environment timestamp into the env-classes cache

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -349,6 +349,10 @@
   {:tag (schema/maybe schema/Str)
    :last-updated schema/Int})
 
+(def EnvironmentClassInfoCache
+  "Data structure for the environment_classes info cache"
+  {schema/Str EnvironmentClassInfoCacheEntry})
+
 (schema/defn ^:always-validate environment-class-info-entry
   :- EnvironmentClassInfoCacheEntry
   "Create an environment class info entry"
@@ -357,3 +361,28 @@
   ([tag :- (schema/maybe schema/Str)]
    {:tag tag
     :last-updated (System/currentTimeMillis)}))
+
+(schema/defn ^:always-validate
+  environment-class-info-cache-updated-with-tag :- EnvironmentClassInfoCache
+  "Return the supplied environment class info cache argument, updated per
+  supplied arguments.  last-updated-before-tag-computed should represent what
+  the client received for a 'get-environment-class-info-tag-last-updated' call
+  for the environment, made before the client started doing the work to parse
+  environment class info / compute the new tag.  If
+  last-updated-before-tag-computed equals the 'last-updated' value stored in the
+  cache for the environment, the new 'tag' will be stored for the environment
+  and the corresponding 'last-updated' value will be updated to the number of
+  milliseconds between now and midnight, January 1, 1970 UTC.  If
+  last-updated-before-tag-computed is different than the 'last-updated' value
+  stored in the cache for the environment, the cache will remain unchanged as a
+  result of this call."
+  [environment-class-info-cache :- EnvironmentClassInfoCache
+   env-name :- schema/Str
+   tag :- (schema/maybe schema/Str)
+   last-updated-before-tag-computed :- (schema/maybe schema/Int)]
+  (let [cache-last-updated (get-in environment-class-info-cache
+                                   [env-name :last-updated])]
+    (if (= cache-last-updated last-updated-before-tag-computed)
+      (assoc environment-class-info-cache env-name
+                                          (environment-class-info-entry tag))
+      environment-class-info-cache)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -342,3 +342,18 @@
       (cli-ruby! config
         (concat ["-e" (format "load '%s'" url) "--"] args))
       (log/errorf "command %s could not be found in %s" command bin-dir))))
+
+(def EnvironmentClassInfoCacheEntry
+  "Data structure that holds per-environment cache information for the
+  environment_classes info cache"
+  {:tag (schema/maybe schema/Str)
+   :last-updated schema/Int})
+
+(schema/defn ^:always-validate environment-class-info-entry
+  :- EnvironmentClassInfoCacheEntry
+  "Create an environment class info entry"
+  ([]
+   (environment-class-info-entry nil))
+  ([tag :- (schema/maybe schema/Str)]
+   {:tag tag
+    :last-updated (System/currentTimeMillis)}))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -6,7 +6,8 @@
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby-puppet :as jruby]
             [slingshot.slingshot :as sling]
-            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby.jruby-puppet-schemas :as jruby-schemas]
+            [puppetlabs.kitchensink.core :as ks]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
@@ -75,8 +76,7 @@
       (swap! environment-class-info-tags
              assoc
              env-name
-             {:tag nil
-              :last-updated (System/currentTimeMillis)})
+             (core/environment-class-info-entry))
       (core/mark-environment-expired! pool-context env-name)))
 
   (mark-all-environments-expired!
@@ -84,10 +84,7 @@
     (let [{:keys [environment-class-info-tags pool-context]}
           (tk-services/service-context this)]
       (swap! environment-class-info-tags
-             #(let [now (System/currentTimeMillis)]
-               (into {} (for [k (keys %)]
-                          [k {:tag nil
-                              :last-updated now}]))))
+             #(ks/mapvals (fn [_] (core/environment-class-info-entry)) %))
      (core/mark-all-environments-expired! pool-context)))
 
   (get-environment-class-info
@@ -115,8 +112,7 @@
                    (get-in % [env-name :last-updated])]
               (if (= cache-last-updated last-update-before-tag-computed)
                 (assoc % env-name
-                         {:tag tag
-                          :last-updated (System/currentTimeMillis)})
+                         (core/environment-class-info-entry tag))
                 %)))))
 
   (flush-jruby-pool!

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -108,12 +108,10 @@
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (swap! environment-class-info
-            #(let [cache-last-updated
-                   (get-in % [env-name :last-updated])]
-              (if (= cache-last-updated last-update-before-tag-computed)
-                (assoc % env-name
-                         (core/environment-class-info-entry tag))
-                %)))))
+            core/environment-class-info-cache-updated-with-tag
+            env-name
+            tag
+            last-update-before-tag-computed)))
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -260,7 +260,8 @@
   [info-from-jruby :- Map
    environment :- schema/Str
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
-   request-tag :- (schema/maybe String)]
+   request-tag :- (schema/maybe String)
+   last-updated :- (schema/maybe schema/Int)]
   (let [info-for-json (class-info-from-jruby->class-info-for-json
                        info-from-jruby
                        environment)
@@ -269,7 +270,8 @@
     (jruby-protocol/set-environment-class-info-tag!
      jruby-service
      environment
-     parsed-tag)
+     parsed-tag
+     last-updated)
     (if (= parsed-tag request-tag)
       (not-modified-response parsed-tag)
       (-> (response-with-etag info-as-json parsed-tag)
@@ -281,7 +283,10 @@
   request for environment_classes information."
   [jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)]
   (fn [request]
-    (let [environment (jruby-request/get-environment-from-request request)]
+    (let [environment (jruby-request/get-environment-from-request request)
+          last-updated (jruby-protocol/get-environment-class-info-tag-last-updated
+                        jruby-service
+                        environment)]
       (if-let [class-info
                (jruby-protocol/get-environment-class-info jruby-service
                                                           (:jruby-instance
@@ -290,7 +295,8 @@
         (environment-class-response! class-info
                                      environment
                                      jruby-service
-                                     (if-none-match-from-request request))
+                                     (if-none-match-from-request request)
+                                     last-updated)
         (rr/not-found (str "Could not find environment '" environment "'"))))))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -30,11 +30,17 @@
 
   (mark-environment-expired!
     [this env-name]
-    "Mark the specified environment expired, in all JRuby instances.")
+    "Mark the specified environment expired, in all JRuby instances.  Resets
+    the cached class info for the environment's 'tag' to nil and 'last-updated'
+    value to the number of milliseconds between now and midnight, January 1,
+    1970 UTC.")
 
   (mark-all-environments-expired!
     [this]
-    "Mark all cached environments expired, in all JRuby instances.")
+    "Mark all cached environments expired, in all JRuby instances.  Resets the
+    cached class info for all previously stored environment 'tags' to nil and
+    'last-updated' value to the number of milliseconds between now and midnight,
+    January 1, 1970 UTC.")
 
   (get-environment-class-info
     [this jruby-instance env-name]
@@ -45,10 +51,25 @@
     "Get a tag for the latest class information parsed for a specific
     environment")
 
+  (get-environment-class-info-tag-last-updated
+    [this env-name]
+    "Get the 'time' that a tag was last set for a specific environment's
+    class info.  Return value will be 'nil' if the tag has not previously
+    been set for the environment or a schema/Int representing the
+    number of milliseconds between the last time the tag was updated for an
+    environment and midnight, January 1, 1970 UTC.")
+
   (set-environment-class-info-tag!
-    [this env-name tag]
+    [this env-name tag last-updated-before-tag-computed]
     "Set the tag computed for the latest class information parsed for a
-    specific environment")
+    specific environment.  last-updated-before-tag-computed should represent
+    what the client received for a 'get-environment-class-info-tag-last-updated'
+    call for the environment made before it started doing the work to parse
+    environment class info / compute the new tag.  If
+    last-updated-before-tag-computed equals the 'last-updated' value stored in
+    the cache for the environment, the new 'tag' will be stored for the
+    environment and the corresponding 'last-updated' value will be updated to
+    the number of milliseconds between now and midnight, January 1, 1970 UTC.")
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -69,7 +69,10 @@
     last-updated-before-tag-computed equals the 'last-updated' value stored in
     the cache for the environment, the new 'tag' will be stored for the
     environment and the corresponding 'last-updated' value will be updated to
-    the number of milliseconds between now and midnight, January 1, 1970 UTC.")
+    the number of milliseconds between now and midnight, January 1, 1970 UTC.
+    If last-updated-before-tag-computed is different than the 'last-updated'
+    value stored in the cache for the environment, the cache will remain
+    unchanged as a result of this call.")
 
   (flush-jruby-pool!
     [this]

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -658,7 +658,7 @@
                          "during a previous class info request")
              (is (= 200 (:status response-after-update))
                  (str
-                  "unexpected status code for response after update"
+                  "unexpected status code for response after update, "
                   "response: "
                   (ks/pprint-to-string response-after-update)))
              (is (not= initial-response-etag

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -645,7 +645,7 @@
                   "unexpected status code for initial response"
                   "response: "
                   (ks/pprint-to-string initial-response)))
-             (is (not (nil? initial-response))
+             (is (not (nil? initial-response-etag))
                  "no etag returned for initial response")
              (is (= {"name" "production",
                      "files" [{"path" "/some/file"

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -6,9 +6,34 @@
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
             [puppetlabs.services.master.master-core :as master-core]
-            [puppetlabs.services.protocols.jruby-puppet :as jruby]
+            [puppetlabs.services.protocols.jruby-puppet :as jruby-protocol]
             [cheshire.core :as cheshire]
-            [me.raynes.fs :as fs]))
+            [me.raynes.fs :as fs]
+            [puppetlabs.services.jruby.jruby-puppet-internal :as jruby-internal]
+            [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
+            [clojure.tools.logging :as log]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.services.protocols.puppet-server-config :as
+             ps-config-protocol]
+            [puppetlabs.services.ca.ca-testutils :as ca-testutils]
+            [puppetlabs.services.master.master-service :as master-service]
+            [puppetlabs.services.request-handler.request-handler-service :as
+             handler]
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby-service]
+            [puppetlabs.services.puppet-profiler.puppet-profiler-service :as
+             profiler]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as
+             webserver]
+            [puppetlabs.trapperkeeper.services.webrouting.webrouting-service
+             :as webrouting]
+            [puppetlabs.services.puppet-admin.puppet-admin-service :as admin]
+            [puppetlabs.services.ca.certificate-authority-service :as ca]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-service
+             :as authorization]
+            [puppetlabs.services.versioned-code-service.versioned-code-service
+             :as vcs])
+  (:import (com.puppetlabs.puppetserver JRubyPuppetResponse JRubyPuppet)
+           (java.util HashMap)))
 
 (def test-resources-dir
   "./dev-resources/puppetlabs/services/master/environment_classes_int_test")
@@ -63,11 +88,14 @@
   [request]
   (get-in request [:headers "etag"]))
 
+(defn response->class-info-map
+  [response]
+  (-> response :body cheshire/parse-string))
+
 (deftest ^:integration environment-classes-integration-test
   (bootstrap/with-puppetserver-running app
    {:jruby-puppet {:max-active-instances 1}}
-   (let [response->class-info-map #(-> %1 :body cheshire/parse-string)
-         foo-file (testutils/write-pp-file
+   (let [foo-file (testutils/write-pp-file
                    "class foo (String $foo_1 = \"is foo\"){}"
                    "foo")
          bar-file (testutils/write-pp-file
@@ -488,7 +516,7 @@
                 "roundtripping that etag returns an HTTP 304 (Not Modified)")
     (let [expected-etag "abcd1234"
           body-length 200000
-          jruby-service (reify jruby/JRubyPuppetService
+          jruby-service (reify jruby-protocol/JRubyPuppetService
                           (get-environment-class-info-tag [_ _]
                             expected-etag))
           app (->
@@ -522,3 +550,123 @@
              "unexpected body for request with prior etag")
          (is (= expected-etag (response-etag response-with-tag))
              "unexpected etag returned for request with prior etag"))))))
+
+(defn create-jruby-instance-with-mock-class-info
+  [wait-atom class-info-atom]
+  (reify JRubyPuppet
+    (getClassInfoForEnvironment [_ _]
+      (let [class-info
+            {"/some/file"
+             (doto (HashMap.)
+               (.put
+                "classes"
+                @class-info-atom))}]
+        (when-let [promises @wait-atom]
+          (deliver (:wait-promise promises) true)
+          @(:continue-promise promises))
+        class-info))
+    (handleRequest [_ _]
+      (JRubyPuppetResponse. 0 nil nil nil))
+    (terminate [_]
+      (log/info "Terminating Master"))))
+
+(tk/defservice mock-puppetserver-config-service
+               ps-config-protocol/PuppetServerConfigService
+               [[:ConfigService get-config get-in-config]]
+               (get-config [this] (get-config))
+               (get-in-config [this ks] (get-in-config ks)))
+
+(defn default-puppet-server-settings
+  []
+  (merge (ca-testutils/master-settings
+          bootstrap/master-conf-dir)
+         (ca-testutils/ca-settings
+          (fs/file bootstrap/master-conf-dir
+                   "ssl/ca"))
+         {:certname
+          "localhost"
+          :ssl-client-header
+          "X_ssl-client-header-FOO"
+          :ssl-client-verify-header
+          "X_ssl-client-verify-header-FOO"
+          :puppet-version
+          "1.2.3"}))
+
+(deftest ^:integration class-info-updated-after-cache-flush-during-prior-request
+  (let [puppet-server-settings (default-puppet-server-settings)
+        class-info-atom (atom [{"name" "someclass" "params" []}])
+        wait-atom (atom nil)]
+    ;; This test uses a mock jruby instance function which can provide mock
+    ;; data for an environment class info query and can suspend a request
+    ;; long enough for the cached environment data to be invalidated.
+    (with-redefs
+     [jruby-internal/create-pool-instance!
+      (partial jruby-testutils/create-mock-pool-instance
+               (partial create-jruby-instance-with-mock-class-info
+                        wait-atom
+                        class-info-atom))]
+      (bootstrap/with-puppetserver-running-with-services
+       app
+       [handler/request-handler-service
+        jruby-service/jruby-puppet-pooled-service
+        profiler/puppet-profiler-service
+        webserver/jetty9-service
+        webrouting/webrouting-service
+        mock-puppetserver-config-service
+        master-service/master-service
+        ca/certificate-authority-service
+        authorization/authorization-service
+        admin/puppet-admin-service
+        vcs/versioned-code-service]
+       {:jruby-puppet {:max-active-instances 1}
+        :webserver {:ssl-ca-cert (:localcacert puppet-server-settings)
+                    :ssl-cert (:hostcert puppet-server-settings)
+                    :ssl-key (:hostprivkey puppet-server-settings)}
+        :puppet-server puppet-server-settings}
+       (let [continue-promise (promise)
+             wait-promise (promise)
+             _ (reset! wait-atom {:continue-promise continue-promise
+                                  :wait-promise wait-promise})
+             initial-response-future (future (get-env-classes "production"))]
+         @wait-promise
+         (reset! class-info-atom [{"name" "updatedclass"
+                                   "params" []}])
+         (purge-env-cache "production")
+         (deliver continue-promise true)
+         (let [initial-response @initial-response-future
+               initial-response-etag (response-etag initial-response)
+               _ (reset! wait-atom nil)
+               response-after-update (get-env-classes "production"
+                                                      initial-response-etag)]
+           (testing (str "initial request in progress while environment "
+                         "cache is invalidated contains original class info")
+             (is (= 200 (:status initial-response))
+                 (str
+                  "unexpected status code for initial response"
+                  "response: "
+                  (ks/pprint-to-string initial-response)))
+             (is (not (nil? initial-response))
+                 "no etag returned for initial response")
+             (is (= {"name" "production",
+                     "files" [{"path" "/some/file"
+                               "classes" [{"name" "someclass"
+                                           "params" []}]}]}
+                    (response->class-info-map initial-response))
+                 "unexpected body for initial response"))
+           (testing (str "SERVER-1130 - class info updated properly for "
+                         "request made after environment cache was purged "
+                         "during a previous class info request")
+             (is (= 200 (:status response-after-update))
+                 (str
+                  "unexpected status code for response after update"
+                  "response: "
+                  (ks/pprint-to-string response-after-update)))
+             (is (not= initial-response-etag
+                       (response-etag response-after-update))
+                 "unexpected etag for response after update")
+             (is (= {"name" "production",
+                     "files" [{"path" "/some/file"
+                               "classes" [{"name" "updatedclass"
+                                           "params" []}]}]}
+                    (response->class-info-map response-after-update))
+                 "unexpected body for response after update"))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -289,3 +289,128 @@
         (jruby-testutils/wait-for-jrubies app)
         (is (true? (some #(= facter-jar (.getFile %))
                      (.getURLs (ClassLoader/getSystemClassLoader)))))))))
+
+(deftest environment-class-info-tags
+  (testing "environment-class-info-tags cache has proper data"
+    (bootstrap/with-app-with-config
+     app
+     default-services
+     (jruby-service-test-config 1)
+     (let [service (app/get-service app :JRubyPuppetService)]
+       (testing "when environment not previously loaded to cache"
+         (is (nil? (jruby-protocol/get-environment-class-info-tag
+                    service
+                    "production")))
+         (is (nil? (jruby-protocol/get-environment-class-info-tag-last-updated
+                    service
+                    "production"))))
+       (testing "when environment info first set to cache"
+         (jruby-protocol/set-environment-class-info-tag! service
+                                                         "production"
+                                                         "1234prod"
+                                                         nil)
+         (is (= "1234prod" (jruby-protocol/get-environment-class-info-tag
+                            service
+                            "production")))
+         (is (nil? (jruby-protocol/get-environment-class-info-tag
+                    service
+                    "test")))
+         (jruby-protocol/set-environment-class-info-tag! service
+                                                         "test"
+                                                         "1234test"
+                                                         nil)
+         (is (= "1234prod" (jruby-protocol/get-environment-class-info-tag
+                            service
+                            "production")))
+         (is (= "1234test" (jruby-protocol/get-environment-class-info-tag
+                            service
+                            "test"))))
+       (let [production-first-updated
+             (jruby-protocol/get-environment-class-info-tag-last-updated
+              service
+              "production")
+             test-first-updated
+             (jruby-protocol/get-environment-class-info-tag-last-updated
+              service
+              "test")]
+         (testing "when environment info reset in the cache"
+           (is (not (nil? production-first-updated)))
+           (is (not (nil? test-first-updated)))
+           (jruby-protocol/set-environment-class-info-tag!
+            service
+            "production"
+            "5678prod"
+            production-first-updated)
+           (is (= "5678prod" (jruby-protocol/get-environment-class-info-tag
+                              service
+                              "production")))
+           (is (= "1234test" (jruby-protocol/get-environment-class-info-tag
+                              service
+                              "test")))
+           (is (= test-first-updated
+                  (jruby-protocol/get-environment-class-info-tag-last-updated
+                   service
+                   "test")))
+           (let [production-second-update
+                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                  service
+                  "production")]
+             (is (not= production-first-updated production-second-update))
+             ;; Set a new tag with a different "last-updated" date than what
+             ;; should be in the cache right now - (dec
+             ;; production-first-updated) - in order to validate that what is
+             ;; already in the cache will just be retained.  This simulates
+             ;; what would happen if the tag had been updated again in
+             ;; between the prior 'get...last-updated' call and the
+             ;; next 'set...tag' call.
+             (jruby-protocol/set-environment-class-info-tag!
+              service
+              "production"
+              "89abprod"
+              (dec production-first-updated))
+             (is (= "5678prod" (jruby-protocol/get-environment-class-info-tag
+                                service
+                                "production")))
+             (is (= production-second-update
+                    (jruby-protocol/get-environment-class-info-tag-last-updated
+                     service
+                     "production")))))
+         (testing "when an individual environment is marked expired"
+           (jruby-protocol/mark-environment-expired! service "production")
+           (is (nil? (jruby-protocol/get-environment-class-info-tag
+                      service
+                      "production")))
+           (is (not= production-first-updated
+                     (jruby-protocol/get-environment-class-info-tag-last-updated
+                      service
+                      "production")))
+           (is (= "1234test" (jruby-protocol/get-environment-class-info-tag
+                              service
+                              "test")))
+           (is (= test-first-updated
+                  (jruby-protocol/get-environment-class-info-tag-last-updated
+                   service
+                   "test")))
+           (jruby-protocol/set-environment-class-info-tag! service
+                                                           "production"
+                                                           "8910prod"
+                                                           nil))
+         (testing "when all environments are marked expired"
+           (let [production-third-update
+                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                  service
+                  "production")]
+             (jruby-protocol/mark-all-environments-expired! service)
+             (is (nil? (jruby-protocol/get-environment-class-info-tag
+                        service
+                        "production")))
+             (is (not= production-third-update
+                       (jruby-protocol/get-environment-class-info-tag-last-updated
+                        service
+                        "production")))
+             (is (nil? (jruby-protocol/get-environment-class-info-tag service
+                                                                      "test")))
+             (is (not= test-first-updated
+                       (jruby-protocol/get-environment-class-info-tag-last-updated
+                        service
+                        "test"))))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -390,12 +390,12 @@
            (is (= test-first-updated
                   (jruby-protocol/get-environment-class-info-tag-last-updated
                    service
-                   "test")))
+                   "test"))))
+         (testing "when all environments are marked expired"
            (jruby-protocol/set-environment-class-info-tag! service
                                                            "production"
                                                            "8910prod"
-                                                           nil))
-         (testing "when all environments are marked expired"
+                                                           nil)
            (let [production-third-update
                  (jruby-protocol/get-environment-class-info-tag-last-updated
                   service

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -87,7 +87,9 @@
                           (get-environment-class-info [_ _ env]
                             (if (= env "production")
                               {}))
-                          (set-environment-class-info-tag! [_ _ _]))
+                          (get-environment-class-info-tag-last-updated
+                           [_ _])
+                          (set-environment-class-info-tag! [_ _ _ _]))
           handler (fn ([req] {:request req}))
           app (build-ring-handler handler "1.2.3" jruby-service)
           request (partial app-request app)
@@ -95,6 +97,7 @@
                    (environment-class-response!
                     "production"
                     jruby-service
+                    nil
                     nil)
                    (rr/get-header "Etag"))
           map-with-classes #(doto (HashMap.)


### PR DESCRIPTION
This commit adds a "last-updated" timestamp per environment to the
environment classes cache.  The timestamp is used by incoming
environment_classes cache requests to determine if the cache info has
changed between the time the request starts parsing for info and when
the cache is about to be updated, e.g., if a call from a separate
request to mark-environment-expired were to occur during parsing for
class info in a request.  If the timestamp has been updated during that
window, the cache is not updated with the latest parsed data, since that
data may already be stale.

This commit also adds an integration test,
class-info-updated-after-cache-flush-during-prior-request, which
performs an environment cache flush while a class info request is in
progress and validates that the following class info request gets the
latest data.