### PR TITLE
(SERVER-1148) Add timed waits and instrumentation to jruby-pool-int-tests

### DIFF
--- a/dev-resources/puppetlabs/services/jruby/jruby_pool_int_test/logback-test-restart-comes-back.xml
+++ b/dev-resources/puppetlabs/services/jruby/jruby_pool_int_test/logback-test-restart-comes-back.xml
@@ -1,0 +1,15 @@
+<configuration scan="true">
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <file>./target/test-restart-comes-back.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="debug">
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -341,7 +341,7 @@
        (tk-internal/restart-tk-apps [app])
        (let [start (System/currentTimeMillis)]
          (while (and (not= (count @call-seq) 5)
-                     (< (- (System/currentTimeMillis) start) 90000))
+                     (< (- (System/currentTimeMillis) start) 300000))
            (Thread/yield)))
        (let [shutdown-service (tk-app/get-service app :ShutdownService)]
          (is (nil? (tk-internal/get-shutdown-reason shutdown-service))

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -43,7 +43,7 @@
 
 (defn timed-deref
   [ref]
-  (deref ref 120000 :timed-out))
+  (deref ref 240000 :timed-out))
 
 (def script-to-check-if-constant-is-defined
   "! $instance_id.nil?")


### PR DESCRIPTION
This PR adds some upper bounds on the maximum number of iterations /
wait time for specific operations to complete while running the
jruby-pool-int-tests.  The bounded operations include the maximum wait
time for a new pool to be initialized, instances to be borrowed, pool
flushes to complete, and for the puppetserver service stack to be
stopped.

This commit adds some extra instrumentation to the
`test-restart-comes-back` test to hopefully help with identifying why
the test has failed when it intermittently does.