### PR TITLE
(SERVER-1183) Add entry to env class cache if not present during get

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -451,9 +451,8 @@
   all environment entries in the environment class info cache as expired."
   [context :- jruby-schemas/PoolContext
    environment-class-info-cache :- (schema/atom EnvironmentClassInfoCache)]
-  (->> invalidated-environment-class-info-entry
-       (partial ks/mapvals)
-       (swap! environment-class-info-cache))
+  (swap! environment-class-info-cache
+         (partial ks/mapvals invalidated-environment-class-info-entry))
   (doseq [jruby-instance (registered-instances context)]
     (-> jruby-instance
         :environment-registry

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -244,23 +244,6 @@
   @(:state jruby-puppet))
 
 (schema/defn ^:always-validate
-  mark-environment-expired!
-  [context :- jruby-schemas/PoolContext
-   env-name :- schema/Str]
-  (doseq [jruby-instance (registered-instances context)]
-    (-> jruby-instance
-      :environment-registry
-      (puppet-env/mark-environment-expired! env-name))))
-
-(schema/defn ^:always-validate
-  mark-all-environments-expired!
-  [context :- jruby-schemas/PoolContext]
-  (doseq [jruby-instance (registered-instances context)]
-    (-> jruby-instance
-        :environment-registry
-        puppet-env/mark-all-environments-expired!)))
-
-(schema/defn ^:always-validate
   borrow-from-pool :- jruby-schemas/JRubyPuppetInstanceOrPill
   "Borrows a JRubyPuppet interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."
@@ -431,3 +414,20 @@
          #(if (contains? % env-name)
            %
            (assoc % env-name (environment-class-info-entry)))))
+
+(schema/defn ^:always-validate
+  mark-environment-expired!
+  [context :- jruby-schemas/PoolContext
+   env-name :- schema/Str]
+  (doseq [jruby-instance (registered-instances context)]
+    (-> jruby-instance
+        :environment-registry
+        (puppet-env/mark-environment-expired! env-name))))
+
+(schema/defn ^:always-validate
+  mark-all-environments-expired!
+  [context :- jruby-schemas/PoolContext]
+  (doseq [jruby-instance (registered-instances context)]
+    (-> jruby-instance
+        :environment-registry
+        puppet-env/mark-all-environments-expired!)))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -416,6 +416,21 @@
            (assoc % env-name (environment-class-info-entry)))))
 
 (schema/defn ^:always-validate
+  get-environment-class-info-tag-last-updated! :- schema/Int
+  "Get the 'time' that a tag was last set for a specific environment's
+  class info.   Return value will be a schema/Int representing the number of
+  milliseconds between the last time the tag was updated for an environment
+  and midnight, January 1, 1970 UTC.  If no entry for the environment had
+  existed at the point this function was called this function would, as a
+  side effect, populate a new entry for that environment into the cache."
+  [environment-class-info-cache :- (schema/atom EnvironmentClassInfoCache)
+   env-name :- schema/Str]
+  (-> (add-environment-class-info-cache-entry-if-not-present!
+       environment-class-info-cache
+       env-name)
+      (get-in [env-name :last-updated])))
+
+(schema/defn ^:always-validate
   mark-environment-expired!
   "Mark the environment-registry entry for each JRubyPuppet instance and the
   environment's entry in the environment class info cache as expired."

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -381,7 +381,7 @@
   environment-class-info-cache-updated-with-tag :- EnvironmentClassInfoCache
   "Return the supplied environment class info cache argument, updated per
   supplied arguments.  last-updated-before-tag-computed should represent what
-  the client received for a 'get-environment-class-info-tag-last-updated' call
+  the client received for a 'get-environment-class-info-tag-last-updated!' call
   for the environment, made before the client started doing the work to parse
   environment class info / compute the new tag.  If
   last-updated-before-tag-computed equals the 'last-updated' value stored in the

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -98,10 +98,9 @@
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (-> (core/add-environment-class-info-cache-entry-if-not-present!
-          environment-class-info
-          env-name)
-         (get-in [env-name :last-updated]))))
+     (core/get-environment-class-info-tag-last-updated!
+      environment-class-info
+      env-name)))
 
   (set-environment-class-info-tag!
    [this env-name tag last-update-before-tag-computed]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -94,7 +94,7 @@
                                  (tk-services/service-context this))]
      (get-in @environment-class-info [env-name :tag])))
 
-  (get-environment-class-info-tag-last-updated
+  (get-environment-class-info-tag-last-updated!
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -94,23 +94,23 @@
                                  (tk-services/service-context this))]
      (get-in @environment-class-info [env-name :tag])))
 
-  (get-environment-class-info-tag-last-updated!
+  (get-environment-class-info-cache-generation-id!
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (core/get-environment-class-info-tag-last-updated!
+     (core/get-environment-class-info-cache-generation-id!
       environment-class-info
       env-name)))
 
   (set-environment-class-info-tag!
-   [this env-name tag last-update-before-tag-computed]
+   [this env-name tag cache-generation-id-before-tag-computed]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (swap! environment-class-info
             core/environment-class-info-cache-updated-with-tag
             env-name
             tag
-            last-update-before-tag-computed)))
+            cache-generation-id-before-tag-computed)))
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -73,19 +73,16 @@
     [this env-name]
     (let [{:keys [environment-class-info-tags pool-context]}
           (tk-services/service-context this)]
-      (swap! environment-class-info-tags
-             core/environment-class-info-cache-with-invalidated-entry
-             env-name)
-      (core/mark-environment-expired! pool-context env-name)))
+      (core/mark-environment-expired! pool-context
+                                      env-name
+                                      environment-class-info-tags)))
 
   (mark-all-environments-expired!
     [this]
     (let [{:keys [environment-class-info-tags pool-context]}
           (tk-services/service-context this)]
-      (->> core/invalidated-environment-class-info-entry
-           (partial ks/mapvals)
-           (swap! environment-class-info-tags))
-      (core/mark-all-environments-expired! pool-context)))
+      (core/mark-all-environments-expired! pool-context
+                                           environment-class-info-tags)))
 
   (get-environment-class-info
     [this jruby-instance env-name]

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -256,8 +256,24 @@
 
 (schema/defn ^:always-validate
   environment-class-response! :- ringutils/RingResponse
-  "Process the environment class info, returning a ring response to be
-  propagated back up to the caller of the environment_classes endpoint"
+  "Process the environment class info, returning a Ring response to be
+  propagated back up to the caller of the environment_classes endpoint.
+
+  If the specified `environment-class-cache-enabled` is 'true', a SHA-1 hash
+  of the class info will be generated.  If the hash is equal to the supplied
+  `request-tag`, the response will have an HTTP 304 (Not Modified) status code
+  and the response body will be empty.  If the hash is not equal to the supplied
+  `request-tag`, the response will have an HTTP 200 (OK) status code and
+  the class info, serialized to JSON, will appear in the response body.  The
+  newly generated hash code, along with the specified `cache-generation-id`,
+  will be passed to the `jruby-service`, to be stored in its environment class
+  cache, and will also be returned in the response as the value for an HTTP
+  Etag header.
+
+  If the specified `environment-class-cache-enabled` is 'false', no hash
+  will be generated for the class info.  The response will always have an
+  HTTP 200 (OK) status code and the class info, serialized to JSON, as the
+  response body.  An HTTP Etag header will not appear in the response."
   [info-from-jruby :- Map
    environment :- schema/Str
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -289,7 +289,7 @@
    environment-class-cache-enabled :- schema/Bool]
   (fn [request]
     (let [environment (jruby-request/get-environment-from-request request)
-          last-updated (jruby-protocol/get-environment-class-info-tag-last-updated
+          last-updated (jruby-protocol/get-environment-class-info-tag-last-updated!
                         jruby-service
                         environment)]
       (if-let [class-info

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -262,7 +262,7 @@
    environment :- schema/Str
    jruby-service :- (schema/protocol jruby-protocol/JRubyPuppetService)
    request-tag :- (schema/maybe String)
-   last-updated :- (schema/maybe schema/Int)
+   cache-generation-id :- (schema/maybe schema/Int)
    environment-class-cache-enabled :- schema/Bool]
   (let [info-for-json (class-info-from-jruby->class-info-for-json
                        info-from-jruby
@@ -274,7 +274,7 @@
          jruby-service
          environment
          parsed-tag
-         last-updated)
+         cache-generation-id)
         (if (= parsed-tag request-tag)
           (not-modified-response parsed-tag)
           (-> (response-with-etag info-as-json parsed-tag)
@@ -289,9 +289,10 @@
    environment-class-cache-enabled :- schema/Bool]
   (fn [request]
     (let [environment (jruby-request/get-environment-from-request request)
-          last-updated (jruby-protocol/get-environment-class-info-tag-last-updated!
-                        jruby-service
-                        environment)]
+          cache-generation-id
+          (jruby-protocol/get-environment-class-info-cache-generation-id!
+           jruby-service
+           environment)]
       (if-let [class-info
                (jruby-protocol/get-environment-class-info jruby-service
                                                           (:jruby-instance
@@ -301,7 +302,7 @@
                                      environment
                                      jruby-service
                                      (if-none-match-from-request request)
-                                     last-updated
+                                     cache-generation-id
                                      environment-class-cache-enabled)
         (rr/not-found (str "Could not find environment '" environment "'"))))))
 

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -31,16 +31,14 @@
   (mark-environment-expired!
     [this env-name]
     "Mark the specified environment expired, in all JRuby instances.  Resets
-    the cached class info for the environment's 'tag' to nil and 'cache-generation-id'
-    value to the number of milliseconds between now and midnight, January 1,
-    1970 UTC.")
+    the cached class info for the environment's 'tag' to nil and increments the
+    'cache-generation-id' value.")
 
   (mark-all-environments-expired!
     [this]
     "Mark all cached environments expired, in all JRuby instances.  Resets the
     cached class info for all previously stored environment 'tags' to nil and
-    'cache-generation-id' value to the number of milliseconds between now and midnight,
-    January 1, 1970 UTC.")
+    increments the 'cache-generation-id' value.")
 
   (get-environment-class-info
     [this jruby-instance env-name]
@@ -53,27 +51,25 @@
 
   (get-environment-class-info-cache-generation-id!
     [this env-name]
-    "Get the 'time' that a tag was last set for a specific environment's
-    class info.   Return value will be a schema/Int representing the number of
-    milliseconds between the last time the tag was updated for an environment
-    and midnight, January 1, 1970 UTC.  If no entry for the environment had
-    existed at the point this function was called this function would, as a
-    side effect, populate a new entry for that environment into the cache.")
+    "Get the current cache generation id for a specific environment's class
+    info.  If no entry for the environment had existed at the point this
+    function was called this function would, as a side effect, populate a new
+    entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
     [this env-name tag cache-generation-id-before-tag-computed]
     "Set the tag computed for the latest class information parsed for a
-    specific environment.  cache-generation-id-before-tag-computed should represent
-    what the client received for a 'get-environment-class-info-cache-generation-id!'
-    call for the environment made before it started doing the work to parse
-    environment class info / compute the new tag.  If
-    cache-generation-id-before-tag-computed equals the 'cache-generation-id' value stored in
-    the cache for the environment, the new 'tag' will be stored for the
-    environment and the corresponding 'cache-generation-id' value will be updated to
-    the number of milliseconds between now and midnight, January 1, 1970 UTC.
-    If cache-generation-id-before-tag-computed is different than the 'cache-generation-id'
-    value stored in the cache for the environment, the cache will remain
-    unchanged as a result of this call.")
+    specific environment.  cache-generation-id-before-tag-computed should
+    represent what the client received for a
+    'get-environment-class-info-cache-generation-id!' call for the environment
+    made before it started doing the work to parse environment class info /
+    compute the new tag.  If cache-generation-id-before-tag-computed equals
+    the 'cache-generation-id' value stored in the cache for the environment, the
+    new 'tag' will be stored for the environment and the corresponding
+    'cache-generation-id' value will be incremented.  If
+    cache-generation-id-before-tag-computed is different than the
+    'cache-generation-id' value stored in the cache for the environment, the
+    cache will remain unchanged as a result of this call.")
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -51,19 +51,20 @@
     "Get a tag for the latest class information parsed for a specific
     environment")
 
-  (get-environment-class-info-tag-last-updated
+  (get-environment-class-info-tag-last-updated!
     [this env-name]
     "Get the 'time' that a tag was last set for a specific environment's
-    class info.  Return value will be 'nil' if the tag has not previously
-    been set for the environment or a schema/Int representing the
-    number of milliseconds between the last time the tag was updated for an
-    environment and midnight, January 1, 1970 UTC.")
+    class info.   Return value will be a schema/Int representing the number of
+    milliseconds between the last time the tag was updated for an environment
+    and midnight, January 1, 1970 UTC.  If no entry for the environment had
+    existed at the point this function was called this function would, as a
+    side effect, populate a new entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
     [this env-name tag last-updated-before-tag-computed]
     "Set the tag computed for the latest class information parsed for a
     specific environment.  last-updated-before-tag-computed should represent
-    what the client received for a 'get-environment-class-info-tag-last-updated'
+    what the client received for a 'get-environment-class-info-tag-last-updated!'
     call for the environment made before it started doing the work to parse
     environment class info / compute the new tag.  If
     last-updated-before-tag-computed equals the 'last-updated' value stored in

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -31,7 +31,7 @@
   (mark-environment-expired!
     [this env-name]
     "Mark the specified environment expired, in all JRuby instances.  Resets
-    the cached class info for the environment's 'tag' to nil and 'last-updated'
+    the cached class info for the environment's 'tag' to nil and 'cache-generation-id'
     value to the number of milliseconds between now and midnight, January 1,
     1970 UTC.")
 
@@ -39,7 +39,7 @@
     [this]
     "Mark all cached environments expired, in all JRuby instances.  Resets the
     cached class info for all previously stored environment 'tags' to nil and
-    'last-updated' value to the number of milliseconds between now and midnight,
+    'cache-generation-id' value to the number of milliseconds between now and midnight,
     January 1, 1970 UTC.")
 
   (get-environment-class-info
@@ -51,7 +51,7 @@
     "Get a tag for the latest class information parsed for a specific
     environment")
 
-  (get-environment-class-info-tag-last-updated!
+  (get-environment-class-info-cache-generation-id!
     [this env-name]
     "Get the 'time' that a tag was last set for a specific environment's
     class info.   Return value will be a schema/Int representing the number of
@@ -61,17 +61,17 @@
     side effect, populate a new entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
-    [this env-name tag last-updated-before-tag-computed]
+    [this env-name tag cache-generation-id-before-tag-computed]
     "Set the tag computed for the latest class information parsed for a
-    specific environment.  last-updated-before-tag-computed should represent
-    what the client received for a 'get-environment-class-info-tag-last-updated!'
+    specific environment.  cache-generation-id-before-tag-computed should represent
+    what the client received for a 'get-environment-class-info-cache-generation-id!'
     call for the environment made before it started doing the work to parse
     environment class info / compute the new tag.  If
-    last-updated-before-tag-computed equals the 'last-updated' value stored in
+    cache-generation-id-before-tag-computed equals the 'cache-generation-id' value stored in
     the cache for the environment, the new 'tag' will be stored for the
-    environment and the corresponding 'last-updated' value will be updated to
+    environment and the corresponding 'cache-generation-id' value will be updated to
     the number of milliseconds between now and midnight, January 1, 1970 UTC.
-    If last-updated-before-tag-computed is different than the 'last-updated'
+    If cache-generation-id-before-tag-computed is different than the 'cache-generation-id'
     value stored in the cache for the environment, the cache will remain
     unchanged as a result of this call.")
 

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -658,7 +658,8 @@
         authorization/authorization-service
         admin/puppet-admin-service
         vcs/versioned-code-service]
-       {:jruby-puppet {:max-active-instances 1}
+       {:jruby-puppet {:max-active-instances 1
+                       :environment-class-cache-enabled true}
         :webserver {:ssl-ca-cert (:localcacert puppet-server-settings)
                     :ssl-cert (:hostcert puppet-server-settings)
                     :ssl-key (:hostprivkey puppet-server-settings)}

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -298,7 +298,7 @@
      (jruby-service-test-config 1)
      (let [service (app/get-service app :JRubyPuppetService)
            production-before-first-update
-           (jruby-protocol/get-environment-class-info-tag-last-updated
+           (jruby-protocol/get-environment-class-info-tag-last-updated!
             service
             "production")]
        (testing "when environment not previously loaded to cache"
@@ -329,11 +329,11 @@
                             service
                             "test"))))
        (let [production-first-update
-             (jruby-protocol/get-environment-class-info-tag-last-updated
+             (jruby-protocol/get-environment-class-info-tag-last-updated!
               service
               "production")
              test-first-update
-             (jruby-protocol/get-environment-class-info-tag-last-updated
+             (jruby-protocol/get-environment-class-info-tag-last-updated!
               service
               "test")]
          (testing "when environment info reset in the cache"
@@ -351,18 +351,18 @@
                               service
                               "test")))
            (is (= test-first-update
-                  (jruby-protocol/get-environment-class-info-tag-last-updated
+                  (jruby-protocol/get-environment-class-info-tag-last-updated!
                    service
                    "test")))
            (testing "and environment expired between get and corresponding set"
              (let [production-second-update
-                   (jruby-protocol/get-environment-class-info-tag-last-updated
+                   (jruby-protocol/get-environment-class-info-tag-last-updated!
                     service
                     "production")
                    _ (jruby-protocol/mark-environment-expired! service
                                                                "production")
                    production-third-update
-                   (jruby-protocol/get-environment-class-info-tag-last-updated
+                   (jruby-protocol/get-environment-class-info-tag-last-updated!
                     service
                     "production")]
                (is (not= production-first-update production-second-update))
@@ -375,7 +375,7 @@
                            service
                            "production")))
                (is (= production-third-update
-                      (jruby-protocol/get-environment-class-info-tag-last-updated
+                      (jruby-protocol/get-environment-class-info-tag-last-updated!
                        service
                        "production"))))))
          (testing "when an individual environment is marked expired"
@@ -384,19 +384,19 @@
                       service
                       "production")))
            (is (not= production-first-update
-                     (jruby-protocol/get-environment-class-info-tag-last-updated
+                     (jruby-protocol/get-environment-class-info-tag-last-updated!
                       service
                       "production")))
            (is (= "1234test" (jruby-protocol/get-environment-class-info-tag
                               service
                               "test")))
            (is (= test-first-update
-                  (jruby-protocol/get-environment-class-info-tag-last-updated
+                  (jruby-protocol/get-environment-class-info-tag-last-updated!
                    service
                    "test"))))
          (testing "when all environments are marked expired"
            (let [production-update
-                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                 (jruby-protocol/get-environment-class-info-tag-last-updated!
                   service
                   "production")]
              (jruby-protocol/set-environment-class-info-tag!
@@ -408,7 +408,7 @@
                                 service
                                 "production"))))
            (let [production-third-update
-                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                 (jruby-protocol/get-environment-class-info-tag-last-updated!
                   service
                   "production")]
              (jruby-protocol/mark-all-environments-expired! service)
@@ -416,24 +416,24 @@
                         service
                         "production")))
              (is (not= production-third-update
-                       (jruby-protocol/get-environment-class-info-tag-last-updated
+                       (jruby-protocol/get-environment-class-info-tag-last-updated!
                         service
                         "production")))
              (is (nil? (jruby-protocol/get-environment-class-info-tag service
                                                                       "test")))
              (is (not= test-first-update
-                       (jruby-protocol/get-environment-class-info-tag-last-updated
+                       (jruby-protocol/get-environment-class-info-tag-last-updated!
                         service
                         "test")))))
          (testing (str "when all environments expired between get and set "
                        "for environment that did not previously exist")
            (let [staging-before-marked-expired
-                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                 (jruby-protocol/get-environment-class-info-tag-last-updated!
                   service
                   "staging")
                  _ (jruby-protocol/mark-all-environments-expired! service)
                  staging-after-marked-expired
-                 (jruby-protocol/get-environment-class-info-tag-last-updated
+                 (jruby-protocol/get-environment-class-info-tag-last-updated!
                   service
                   "staging")]
              (jruby-protocol/set-environment-class-info-tag!
@@ -445,6 +445,6 @@
                          service
                          "staging")))
              (is (= staging-after-marked-expired
-                    (jruby-protocol/get-environment-class-info-tag-last-updated
+                    (jruby-protocol/get-environment-class-info-tag-last-updated!
                      service
                      "staging"))))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -318,10 +318,13 @@
          (is (nil? (jruby-protocol/get-environment-class-info-tag
                     service
                     "test")))
-         (jruby-protocol/set-environment-class-info-tag! service
-                                                         "test"
-                                                         "1234test"
-                                                         nil)
+         (jruby-protocol/set-environment-class-info-tag!
+          service
+          "test"
+          "1234test"
+          (jruby-protocol/get-environment-class-info-cache-generation-id!
+           service
+           "test"))
          (is (= "1234prod" (jruby-protocol/get-environment-class-info-tag
                             service
                             "production")))

--- a/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_puppet_service_test.clj
@@ -298,7 +298,7 @@
      (jruby-service-test-config 1)
      (let [service (app/get-service app :JRubyPuppetService)
            production-before-first-update
-           (jruby-protocol/get-environment-class-info-tag-last-updated!
+           (jruby-protocol/get-environment-class-info-cache-generation-id!
             service
             "production")]
        (testing "when environment not previously loaded to cache"
@@ -329,11 +329,11 @@
                             service
                             "test"))))
        (let [production-first-update
-             (jruby-protocol/get-environment-class-info-tag-last-updated!
+             (jruby-protocol/get-environment-class-info-cache-generation-id!
               service
               "production")
              test-first-update
-             (jruby-protocol/get-environment-class-info-tag-last-updated!
+             (jruby-protocol/get-environment-class-info-cache-generation-id!
               service
               "test")]
          (testing "when environment info reset in the cache"
@@ -351,18 +351,18 @@
                               service
                               "test")))
            (is (= test-first-update
-                  (jruby-protocol/get-environment-class-info-tag-last-updated!
+                  (jruby-protocol/get-environment-class-info-cache-generation-id!
                    service
                    "test")))
            (testing "and environment expired between get and corresponding set"
              (let [production-second-update
-                   (jruby-protocol/get-environment-class-info-tag-last-updated!
+                   (jruby-protocol/get-environment-class-info-cache-generation-id!
                     service
                     "production")
                    _ (jruby-protocol/mark-environment-expired! service
                                                                "production")
                    production-third-update
-                   (jruby-protocol/get-environment-class-info-tag-last-updated!
+                   (jruby-protocol/get-environment-class-info-cache-generation-id!
                     service
                     "production")]
                (is (not= production-first-update production-second-update))
@@ -375,7 +375,7 @@
                            service
                            "production")))
                (is (= production-third-update
-                      (jruby-protocol/get-environment-class-info-tag-last-updated!
+                      (jruby-protocol/get-environment-class-info-cache-generation-id!
                        service
                        "production"))))))
          (testing "when an individual environment is marked expired"
@@ -384,19 +384,19 @@
                       service
                       "production")))
            (is (not= production-first-update
-                     (jruby-protocol/get-environment-class-info-tag-last-updated!
+                     (jruby-protocol/get-environment-class-info-cache-generation-id!
                       service
                       "production")))
            (is (= "1234test" (jruby-protocol/get-environment-class-info-tag
                               service
                               "test")))
            (is (= test-first-update
-                  (jruby-protocol/get-environment-class-info-tag-last-updated!
+                  (jruby-protocol/get-environment-class-info-cache-generation-id!
                    service
                    "test"))))
          (testing "when all environments are marked expired"
            (let [production-update
-                 (jruby-protocol/get-environment-class-info-tag-last-updated!
+                 (jruby-protocol/get-environment-class-info-cache-generation-id!
                   service
                   "production")]
              (jruby-protocol/set-environment-class-info-tag!
@@ -408,7 +408,7 @@
                                 service
                                 "production"))))
            (let [production-third-update
-                 (jruby-protocol/get-environment-class-info-tag-last-updated!
+                 (jruby-protocol/get-environment-class-info-cache-generation-id!
                   service
                   "production")]
              (jruby-protocol/mark-all-environments-expired! service)
@@ -416,24 +416,24 @@
                         service
                         "production")))
              (is (not= production-third-update
-                       (jruby-protocol/get-environment-class-info-tag-last-updated!
+                       (jruby-protocol/get-environment-class-info-cache-generation-id!
                         service
                         "production")))
              (is (nil? (jruby-protocol/get-environment-class-info-tag service
                                                                       "test")))
              (is (not= test-first-update
-                       (jruby-protocol/get-environment-class-info-tag-last-updated!
+                       (jruby-protocol/get-environment-class-info-cache-generation-id!
                         service
                         "test")))))
          (testing (str "when all environments expired between get and set "
                        "for environment that did not previously exist")
            (let [staging-before-marked-expired
-                 (jruby-protocol/get-environment-class-info-tag-last-updated!
+                 (jruby-protocol/get-environment-class-info-cache-generation-id!
                   service
                   "staging")
                  _ (jruby-protocol/mark-all-environments-expired! service)
                  staging-after-marked-expired
-                 (jruby-protocol/get-environment-class-info-tag-last-updated!
+                 (jruby-protocol/get-environment-class-info-cache-generation-id!
                   service
                   "staging")]
              (jruby-protocol/set-environment-class-info-tag!
@@ -445,6 +445,6 @@
                          service
                          "staging")))
              (is (= staging-after-marked-expired
-                    (jruby-protocol/get-environment-class-info-tag-last-updated!
+                    (jruby-protocol/get-environment-class-info-cache-generation-id!
                      service
                      "staging"))))))))))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -91,7 +91,7 @@
                           (get-environment-class-info [_ _ env]
                             (if (= env "production")
                               {}))
-                          (get-environment-class-info-tag-last-updated!
+                          (get-environment-class-info-cache-generation-id!
                            [_ _])
                           (set-environment-class-info-tag! [_ _ _ _]))
           handler (fn ([req] {:request req}))

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -91,7 +91,7 @@
                           (get-environment-class-info [_ _ env]
                             (if (= env "production")
                               {}))
-                          (get-environment-class-info-tag-last-updated
+                          (get-environment-class-info-tag-last-updated!
                            [_ _])
                           (set-environment-class-info-tag! [_ _ _ _]))
           handler (fn ([req] {:request req}))


### PR DESCRIPTION
This commit adds some logic behind the
`get-environment-class-info-tag-last-updated!` call in the
jruby-puppet-service to update the environment class info cache with a
new entry for the environment being queried in the event that no prior
entry existed for that environment.  This allows any subsequent
`mark-all-environments-expired!` call that may be made to the service to
update the `last-updated` date in the cache for the environment and,
therefore, for the logic added in SERVER-1130 to avoid updating the
cache with a stale tag to be used for the case where the get precedes a
`mark-all-environments-expired!` call.

This PR also refactors some of the logic in the jruby-puppet-service
namespace related to environment class cache maintenance down into
the jruby-puppet-core namespace.