### PR TITLE
(MAINT) Bump puppet-agent to 6e35df8 and puppet submodule

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "18ebd9ad3cdb6c54140db83c251ed77f3023a6b6", :string)
+                         "6e35df8a0b38ddef209c21434c28833691df6ea7", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.3.2')
+      expect(subject).to eq('4.4.0')
     end
   end
 

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -29,7 +29,7 @@
 
 (def PuppetCatalog
   "Schema for a Puppet catalog. Based on
-  https://github.com/puppetlabs/puppet/blob/master/api/schemas/catalog.json"
+  https://github.com/puppetlabs/puppet/blob/stable/api/schemas/catalog.json"
   {(schema/required-key "name") schema/Str
    (schema/required-key "classes") [schema/Str]
    (schema/required-key "environment") schema/Str
@@ -39,6 +39,7 @@
    (schema/optional-key "code_id") (schema/maybe schema/Str)
    (schema/optional-key "tags") [schema/Str]
    (schema/optional-key "catalog_uuid") schema/Str
+   (schema/optional-key "catalog_format") schema/Int
    schema/Str schema/Str})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/integration/puppetlabs/services/jruby/class_info_test.clj
+++ b/test/integration/puppetlabs/services/jruby/class_info_test.clj
@@ -246,16 +246,6 @@
                             "default ] ],\n"
                             "  Array $another_nested_array = [ 1, [ 2, 3 ] ]\n"
                             "){}"))
-              ;; The values of "Hash[Scalar, Data, 0, default]" and
-              ;; "Array[Data, 0, default]" for "type" - as opposed to just
-              ;; "Hash" and "Array", respectively - for this example are
-              ;; expected per the current Ruby language implementation in
-              ;; Puppet.  However, the simpler types are probably what a user
-              ;; would expect to see instead.  PUP-5861 was filed to address
-              ;; this in the core Ruby Puppet implementation.  Whenever
-              ;; Puppet Server may be upgraded to referencing a Puppet Ruby
-              ;; version which includes these changes, these tests will need
-              ;; to be updated accordingly.
               (is (= {foo-manifest
                       {"classes"
                        [{"name" "foo",
@@ -267,12 +257,12 @@
                                     "type" "Default"}
                                    {"default_source" "{ 1 => 2, \"two\" => 3}"
                                     "name" "some_hash"
-                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                    "type" "Hash"}
                                    {"default_source" (str
                                                       "{ \"one\" => 2, "
                                                       "\"two\" => { 3 => 4 }}")
                                     "name" "some_nested_hash"
-                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                    "type" "Hash"}
                                    {"default_literal" {"one" 2
                                                        "two" {"three" 4}}
                                     "default_source" (str
@@ -280,17 +270,17 @@
                                                       "\"two\" => { \"three\""
                                                       " => 4 }}")
                                     "name" "another_nested_hash"
-                                    "type" "Hash[Scalar, Data, 0, default]"}
+                                    "type" "Hash"}
                                    {"default_source" "[ 1, /^*$/ ]"
                                     "name" "some_array"
-                                    "type" "Array[Data, 0, default]"}
+                                    "type" "Array"}
                                    {"default_source" "[ 1, [ 2, default ] ]"
                                     "name" "some_nested_array"
-                                    "type" "Array[Data, 0, default]"}
+                                    "type" "Array"}
                                    {"default_source" "[ 1, [ 2, 3 ] ]"
                                     "default_literal" [ 1 [ 2 3 ]]
                                     "name" "another_nested_array"
-                                    "type" "Array[Data, 0, default]"}]}]}}
+                                    "type" "Array"}]}]}}
                      (get-class-info-for-env "env5"))
                   "Unexpected info retrieved for 'env5'")))
           (testing (str "(PUP-5713) Default parameter value with expression "


### PR DESCRIPTION
This commit bumps our puppet-agent dependency for CI to 6e35df8 and our
puppet submodule dependency to 2ec5b3d.

Along with the bump, three changes to tests were necessary in order for
existing tests to continue passing:

1) Updated master_spec.rb Puppet version from 4.3.2 to 4.4.0.

2) Updated PuppetCatalog schema used for tests to tolerate existence of
   the new 'catalog_format' key in the catalog response format.

3) Update class_info_tests to look for simple types for Hash and Array
   instead of composite types like Hash[Scalar, Data, 0, default].  This
   change was expected per the resolution of PUP-5861.