### PR TITLE
(SERVER-1185) Add enable setting for environment class cache

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -115,3 +115,8 @@ authorization: {
         }
     ]
 }
+
+# general puppetserver settings
+puppetserver: {
+    environment-class-cache-enabled: true
+}

--- a/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
+++ b/src/clj/puppetlabs/services/legacy_routes/legacy_routes_service.clj
@@ -32,7 +32,8 @@
           master-route-handler (-> (master-core/root-routes handle-request
                                                             (partial identity)
                                                             jruby-service
-                                                            (constantly nil))
+                                                            (constantly nil)
+                                                            false)
                                    ((partial comidi/context path))
                                    comidi/routes->handler)
           master-handler-info {:mount       (master-core/get-master-mount

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -33,7 +33,11 @@
          use-legacy-auth-conf (get-in config
                                       [:jruby-puppet :use-legacy-auth-conf]
                                       true)
-         jruby-service (tk-services/get-service this :JRubyPuppetService)]
+         jruby-service (tk-services/get-service this :JRubyPuppetService)
+         environment-class-cache-enabled (get-in config
+                                                 [:puppetserver
+                                                  :environment-class-cache-enabled]
+                                                 false)]
      (version-check/check-for-updates! {:product-name product-name} update-server-url)
 
      (retrieve-ca-cert! localcacert)
@@ -49,7 +53,8 @@
                                                           jruby-service
                                                           get-code-content
                                                           handle-request
-                                                          wrap-with-authorization-check)
+                                                          wrap-with-authorization-check
+                                                          environment-class-cache-enabled)
                               ((partial comidi/context path))
                               comidi/routes->handler))]
        ;; if the webrouting config uses the old-style config where

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -46,7 +46,9 @@
 
 (use-fixtures :once
               (testutils/with-puppet-conf
-               (fs/file test-resources-dir "puppet.conf"))
+               (fs/file test-resources-dir "puppet.conf")))
+
+(use-fixtures :each
               (fn [f]
                 (purge-env-dir)
                 (try
@@ -92,9 +94,47 @@
   [response]
   (-> response :body cheshire/parse-string))
 
-(deftest ^:integration environment-classes-integration-test
+(deftest ^:integration environment-classes-integration-cache-disabled-test
+  (testing "when environment classes cache is disabled for a class request"
+    (bootstrap/with-puppetserver-running-with-config
+     app
+     (-> {:jruby-puppet {:max-active-instances 1}}
+         (bootstrap/load-dev-config-with-overrides)
+         (ks/dissoc-in [:puppetserver
+                        :environment-class-cache-enabled]))
+     (let [foo-file (testutils/write-foo-pp-file
+                     "class foo (String $foo_1 = \"is foo\"){}")
+           expected-response {
+                              "files"
+                              [
+                               {"path" foo-file,
+                                "classes"
+                                [
+                                 {
+                                  "name" "foo"
+                                  "params"
+                                  [
+                                   {"name" "foo_1",
+                                    "type" "String",
+                                    "default_literal" "is foo",
+                                    "default_source" "\"is foo\""}]}]}]
+                              "name" "production"}
+           response (get-env-classes "production")]
+       (testing "a successful status code is returned"
+         (is (= 200 (:status response))
+             (str
+              "unexpected status code for response, response: "
+              (ks/pprint-to-string response))))
+       (testing "no etag is returned"
+         (is (false? (contains? (:headers response) "etag"))))
+       (testing "the expected response body is returned"
+         (is (= expected-response
+                (response->class-info-map response))))))))
+
+(deftest ^:integration environment-classes-integration-cache-enabled-test
   (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:max-active-instances 1}}
+   {:jruby-puppet {:max-active-instances 1}
+    :puppetserver {:environment-class-cache-enabled true}}
    (let [foo-file (testutils/write-pp-file
                    "class foo (String $foo_1 = \"is foo\"){}"
                    "foo")

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -19,7 +19,10 @@
 
 (defn build-ring-handler
   [request-handler puppet-version jruby-service]
-  (-> (root-routes request-handler ring/wrap-params jruby-service (constantly nil))
+  (-> (root-routes request-handler ring/wrap-params
+                   jruby-service
+                   (constantly nil)
+                   true)
       (comidi/routes->handler)
       (wrap-middleware puppet-version)))
 
@@ -99,7 +102,8 @@
                     "production"
                     jruby-service
                     nil
-                    nil)
+                    nil
+                    true)
                    (rr/get-header "Etag"))
           map-with-classes #(doto (HashMap.)
                              (.put "classes" %))]


### PR DESCRIPTION
This commit adds a Trapperkeeper-level configuration setting for use in
enabling/disabling the environment class cache.  When set to "false"
(disabled), an Etag is no longer computed/returned with the payload for
a environment_classes API GET request.  When set to "true" (enabled),
the Etag will be computed and returned with the GET request payload as
was true in prior commits.