### PR TITLE
(MAINT) Bump puppet-agent to 112d479 and puppet submodule

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "6e35df8a0b38ddef209c21434c28833691df6ea7", :string)
+                         "112d4793cc8ff126697f8dd0657bbaa03d84fa7a", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit bumps our puppet-agent dependency for CI to 112d479, latest
full OS matrix build that passed puppet-agent CI.  The prior build,
6e35df8, only included a partial OS matrix and so was not suitable for
the full OS matrix puppet-server nightly job runs.

This commit also bumps our puppet submodule dependency to 2256ed8 in
order to pick up a fix for the cached_catalog_remediate_local_drift.rb
test for ubuntu-1404.