### PR TITLE
(SERVER-1185) Move environment-class-cache-enabled setting

### DIFF
--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -67,6 +67,10 @@ jruby-puppet: {
     # in the legacy Puppet auth.conf file (if true or not specified) or via rules
     # specified in the Puppet Server HOCON-formatted auth.conf (if false).
     use-legacy-auth-conf: false
+
+    # (optional) whether to use the environment class cache. If unspecified
+    # defaults to false
+    environment-class-cache-enabled: true
 }
 
 # settings related to HTTP client requests made by Puppet Server
@@ -92,8 +96,6 @@ http-client: {
     # the timeout is infinite and if negative, the value is undefined in the
     # application and governed by the system default behavior.
     #connect-timeout-milliseconds: 120000
-
-    environment-class-cache-enabled: true
 }
 
 # settings related to profiling the puppet Ruby code

--- a/dev/puppet-server.conf.sample
+++ b/dev/puppet-server.conf.sample
@@ -92,6 +92,8 @@ http-client: {
     # the timeout is infinite and if negative, the value is undefined in the
     # application and governed by the system default behavior.
     #connect-timeout-milliseconds: 120000
+
+    environment-class-cache-enabled: true
 }
 
 # settings related to profiling the puppet Ruby code
@@ -114,9 +116,4 @@ authorization: {
             name: "allow all"
         }
     ]
-}
-
-# general puppetserver settings
-puppetserver: {
-    environment-class-cache-enabled: true
 }

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_core.clj
@@ -193,7 +193,8 @@
       (update-in [:master-log-dir] #(or % default-master-log-dir))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-requests-per-instance] #(or % 0))
-      (update-in [:use-legacy-auth-conf] #(or % (nil? %)))))
+      (update-in [:use-legacy-auth-conf] #(or % (nil? %)))
+      (dissoc :environment-class-cache-enabled)))
 
 (def facter-jar
   "Well-known name of the facter jar file"

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -92,7 +92,14 @@
 
     * :use-legacy-auth-conf - Whether to use the legacy core Puppet auth.conf
         (true) or trapperkeeper-authorization (false) to authorize requests
-        being made to core Puppet endpoints."
+        being made to core Puppet endpoints.
+
+    * environment-class-cache-enabled - Whether to use the environment class
+        cache. When disabled (set to 'false') an Etag is not computed/returned
+        with the payload for an environment_classes API GET request. When enabled
+        (set to 'true') the Etag will be computed and returned with the GET request
+        payload as was true in prior commits."
+
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
    :compile-mode SupportedJRubyCompileModes
@@ -108,7 +115,8 @@
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
    :max-requests-per-instance schema/Int
-   :use-legacy-auth-conf schema/Bool})
+   :use-legacy-auth-conf schema/Bool
+   (schema/optional-key :environment-class-cache-enabled) schema/Bool})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_schemas.clj
@@ -92,14 +92,7 @@
 
     * :use-legacy-auth-conf - Whether to use the legacy core Puppet auth.conf
         (true) or trapperkeeper-authorization (false) to authorize requests
-        being made to core Puppet endpoints.
-
-    * environment-class-cache-enabled - Whether to use the environment class
-        cache. When disabled (set to 'false') an Etag is not computed/returned
-        with the payload for an environment_classes API GET request. When enabled
-        (set to 'true') the Etag will be computed and returned with the GET request
-        payload as was true in prior commits."
-
+        being made to core Puppet endpoints."
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
    :compile-mode SupportedJRubyCompileModes
@@ -115,8 +108,7 @@
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
    :max-requests-per-instance schema/Int
-   :use-legacy-auth-conf schema/Bool
-   (schema/optional-key :environment-class-cache-enabled) schema/Bool})
+   :use-legacy-auth-conf schema/Bool})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/master/master_service.clj
+++ b/src/clj/puppetlabs/services/master/master_service.clj
@@ -35,7 +35,7 @@
                                       true)
          jruby-service (tk-services/get-service this :JRubyPuppetService)
          environment-class-cache-enabled (get-in config
-                                                 [:puppetserver
+                                                 [:jruby-puppet
                                                   :environment-class-cache-enabled]
                                                  false)]
      (version-check/check-for-updates! {:product-name product-name} update-server-url)

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -100,7 +100,7 @@
      app
      (-> {:jruby-puppet {:max-active-instances 1}}
          (bootstrap/load-dev-config-with-overrides)
-         (ks/dissoc-in [:puppetserver
+         (ks/dissoc-in [:jruby-puppet
                         :environment-class-cache-enabled]))
      (let [foo-file (testutils/write-foo-pp-file
                      "class foo (String $foo_1 = \"is foo\"){}")
@@ -133,8 +133,8 @@
 
 (deftest ^:integration environment-classes-integration-cache-enabled-test
   (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:max-active-instances 1}
-    :puppetserver {:environment-class-cache-enabled true}}
+   {:jruby-puppet {:max-active-instances 1
+                   :environment-class-cache-enabled true}}
    (let [foo-file (testutils/write-pp-file
                    "class foo (String $foo_1 = \"is foo\"){}"
                    "foo")


### PR DESCRIPTION
Previously, the `environment-class-cache-enabled` setting was in a
`puppetserver` block. This was the only setting in this block. Ultimately, we
would like to separate out the `jruby-puppet` setting block to only contain
the jruby-specific settings and move many of the settings to a `puppetserver`
block. However, we are not at the point of doing that yet, and in the meantime
only having one setting in the `puppetserver` block seems confusing to explain
to users (why is this here when all the other seemingly-puppet server related
settings aren't here?). This commit moves this setting to the `jruby-puppet`
block for now.

I spoke with @loriland and she agreed that this seems easier to explain to users and the best decision for now, until we have a chance to audit our config files.