### PR TITLE
(MAINT) Bump puppet-agent to 7a3dae3

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "112d4793cc8ff126697f8dd0657bbaa03d84fa7a", :string)
+                         "7a3dae31b2ff7d2899b578c7321c64732897a375", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit bumps the puppet-agent dependency up to 7a3dae3 and Puppet
submodule to 7fd84f34 in order to pick up a fix for the the
exported_resources.rb Puppet acceptance test, in PUP-5996.