### PR TITLE
(SERVER-542) Gracefully handle missing params to /certificate_status PUT

### DIFF
--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -432,7 +432,15 @@
                              :request-method :put
                              :body           (body-stream "{\"desired_state\":\"revoked\"}")}
                     response (test-app request)]
-                (is (= 204 (:status response))))))))
+                (is (= 204 (:status response)))))
+
+            (testing "failing to provide a desired_state returns 400"
+              (let [request {:uri            "/v1/certificate_status/revoked-agent"
+                             :request-method :put
+                             :body           (body-stream "{\"foo_state\":\"revoked\"}")}
+                    response (test-app request)]
+                (is (= 400 (:status response)))
+                (is (= (:body response) "Missing required parameter \"desired_state\"")))))))
 
       (testing "DELETE"
         (let [csr (ca/path-to-cert-request (:csrdir settings) "test-agent")]


### PR DESCRIPTION
Prior to this we weren't checking that `(:desired_state json-body)` returned a non-nil value. If it had returned nil our error message formatting will cause an NPE (with `(name nil)`).

We now check for nil and return an appropriate error message and code when the parameter is missing.