### PR TITLE
(SERVER-615) Gracefully handle invalid ca_ttl settings

### DIFF
--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -25,6 +25,10 @@ Puppet Server does not use this setting. Instead, Puppet Server acts as a
 certificate authority based on the certificate authority service configuration
 in the `bootstrap.cfg` file. See [Service Bootstrapping](./configuration.markdown#service-bootstrapping) for more details.
 
+### [`ca_ttl`](https://docs.puppetlabs.com/references/latest/configuration.html#cattl)
+
+Puppet Server enforces a max ttl of 50 standard years (up to 1576800000 seconds).
+
 ### [`cacert`](https://docs.puppetlabs.com/references/latest/configuration.html#cacert)
 
 If you enable Puppet Server's certificate authority service, it uses the `cacert` 

--- a/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_service.clj
@@ -15,33 +15,8 @@
    [this context]
    (let [path           (get-route this)
          settings       (ca/config->ca-settings (get-config))
-         puppet-version (get-in-config [:puppet-server :puppet-version])
-         certificate-status-access-control (get-in settings
-                                                   [:access-control
-                                                    :certificate-status])
-         certificate-status-whitelist (:client-whitelist
-                                       certificate-status-access-control)]
-     (cond
-       (or (false? (:authorization-required certificate-status-access-control))
-           (not-empty certificate-status-whitelist))
-         (log/warn
-          "The 'client-whitelist' and 'authorization-required' settings in the"
-          "'certificate-authority.certificate-status' section are deprecated and"
-          "will be removed in a future release.  Remove these settings and create"
-          "an appropriate authorization rule in the"
-          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.")
-       (not (nil? certificate-status-whitelist))
-         (log/warn
-          "The 'client-whitelist' and 'authorization-required' settings in the"
-          "'certificate-authority.certificate-status' section are deprecated"
-          "and will be removed in a future release.  Because the"
-          "'client-whitelist' is empty and 'authorization-required' is set to"
-          "'false', the 'certificate-authority.certificate-status' settings"
-          "will be ignored and authorization for the 'certificate_status'"
-          "endpoints will be done per the authorization rules in the"
-          "/etc/puppetlabs/puppetserver/conf.d/auth.conf file.  To suppress"
-          "this warning, remove the 'certificate-authority' configuration"
-          "settings."))
+         puppet-version (get-in-config [:puppet-server :puppet-version])]
+     (ca/validate-settings! settings)
      (ca/initialize! settings)
      (log/info "CA Service adding a ring handler")
      (add-ring-handler

--- a/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
+++ b/test/unit/puppetlabs/puppetserver/certificate_authority_test.clj
@@ -111,7 +111,8 @@
                      (testutils/ca-settings cadir)
                      :ca-ttl
                      (+ max-ca-ttl 1))]
-      (is (thrown? IllegalStateException (validate-settings! settings)))))
+      (is (thrown-with-msg? IllegalStateException #"ca_ttl must have a value below"
+                            (validate-settings! settings)))))
 
   (testing "warns if :client-whitelist is set in c-a.c-s section"
     (let [settings (assoc-in


### PR DESCRIPTION
Previously, if the ca_ttl setting was larger than a Java Integer
(2,147,483,647 -- representing ~68 years) the CA would fail to sign
certs.

This restricts the ca_ttl value to a value equivalent to 50 standard
years and adds validation of the ca_ttl setting to the service's init
phase, invalid ca_ttls will now fail on init, rather than when signing
certificates.

It also refactors existing deprecations warnings for various ca config
settings into core CA with our new validation function and adds tests
for the existing deprecation warnings.
