### PR TITLE
(SERVER-1193) Consume stdin in ruby-autosign-exe-false test script

### DIFF
--- a/dev-resources/puppetlabs/services/ca/certificate_authority_core_test/autosign/ruby-autosign-executable-false
+++ b/dev-resources/puppetlabs/services/ca/certificate_authority_core_test/autosign/ruby-autosign-executable-false
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 
+STDIN.read
 exit 1


### PR DESCRIPTION
This commit changes the ruby-autosign-executable-false ruby script to
consume stdin fully before exiting.  This is needed per the changes in
SERVER-1094 which could lead to new shell utils library we use for
autosigning throwing an `IllegalStateException` on JDK 8 when stdin is
not fully consumed by the spawned process.