### PR TITLE
(MAINT) Bump puppet-agent to 7282f09

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "7a3dae31b2ff7d2899b578c7321c64732897a375", :string)
+                         "7282f093e3c77b3382938a1c2e22d12b59b7973e", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit bumps Puppet Server's puppet agent dependency up to 7282f09
and corresponding Ruby Puppet submodule up to 3b36340.  These changes
enable Puppet Server CI runs to take advantage of the Ruby Puppet
acceptance test fix for puppet_lookup_cmd.rb, PUP-5997.