### PR TITLE
Merge branch 'stable' into master at 529699e

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "112d4793cc8ff126697f8dd0657bbaa03d84fa7a", :string)
+                         "878f7e7c2084716a483544aeb5ebffb4ec48d9d6", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/dev-resources/puppetlabs/services/ca/certificate_authority_core_test/autosign/ruby-autosign-executable-false
+++ b/dev-resources/puppetlabs/services/ca/certificate_authority_core_test/autosign/ruby-autosign-executable-false
@@ -1,3 +1,4 @@
 #!/usr/bin/env ruby
 
+STDIN.read
 exit 1

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.3.0")
 (def tk-jetty-version "1.5.2")
 (def ks-version "1.3.0")
-(def ps-version "2.2.2-master-SNAPSHOT")
+(def ps-version "2.3.0-master-SNAPSHOT")
 
 (defn deploy-info
   [url]
@@ -124,7 +124,7 @@
                                                [puppetlabs/puppetserver ~ps-version]
                                                [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                                                [org.clojure/tools.nrepl "0.2.3"]]
-                      :plugins [[puppetlabs/lein-ezbake "0.3.21"]]
+                      :plugins [[puppetlabs/lein-ezbake "0.3.23"]]
                       :name "puppetserver"}
              :uberjar {:aot [puppetlabs.trapperkeeper.main]
                        :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]]}


### PR DESCRIPTION
stable:
  (MAINT) Bump puppet-agent to 7282f09
  (SERVER-1193) Consume stdin in ruby-autosign-exe-false test script
  (MAINT) Bump puppet-agent to 7a3dae3
  (maint) bump to 2.3.0-stable
  (maint) Bump EZBake version

Two "conflicts" resolved in the merge-up:

1) Pinned to a different - latest green - puppet-agent#master version
   (878f7e) since the one pulled in from puppet-server#stable (7282f0)
   was built from the puppet-agent#stable branch.

2) Changed the project.clj ps-version from 2.3.0-stable-SNAPSHOT to
   2.3.0-master-SNAPSHOT, reflecting the proper branch name.