### PR TITLE
(TK-338) Bump to tk-j9 1.5.3 to handle TimeoutException

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.7.0")
 (def tk-version "1.3.0")
-(def tk-jetty-version "1.5.2")
+(def tk-jetty-version "1.5.3")
 (def ks-version "1.3.0")
 (def ps-version "2.3.0-stable-SNAPSHOT")
 


### PR DESCRIPTION
This commit bumps us to tk-j9 v1.5.3, which includes a fix for
an issue that would happen if Jetty's stopTimeout was hit during
a HUP restart.  Without the fix, this will be treated as a fatal
error.  With the fix, the exception is handled and the HUP restart
can proceed.