### PR TITLE
(SERVER-1160) Fix command parsing

### DIFF
--- a/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/echo_foo
+++ b/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/echo_foo
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+
+echo foo

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -14,8 +14,21 @@ describe Puppet::Server::Execution do
       expect(result).to eq "hi\n"
     end
 
+    it "should return an instance of ProcessOutput for a command with args" do
+      result = Puppet::Server::Execution.execute("echo",  ["hi"])
+      expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+    end
+
+    it "should return the STDOUT of the process for a command with args" do
+      result = Puppet::Server::Execution.execute("echo", ["hi"])
+      expect(result).to eq "hi\n"
+    end
+
     it "should return the exit code of the process" do
       result = Puppet::Server::Execution.execute("echo hi")
+      expect(result.exitstatus).to eq 0
+
+      result = Puppet::Server::Execution.execute("echo",  ["hi"])
       expect(result.exitstatus).to eq 0
 
       result = Puppet::Server::Execution.execute("false")


### PR DESCRIPTION
Previously, Puppet Server failed to correctly parse more complex commands
(with lots of string escaping) passed to it by Puppet for execution.

This PR fixes that problem by updating execution.rb such that when an
array is passed it no longer concatenates that array to be a string, but
instead the first argument is passed to `ShellUtils/executeCommand` as a
string and the rest are passed as an array.