### PR TITLE
(SERVER-1194) Validate code-id, env for external scripts

### DIFF
--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -1,0 +1,18 @@
+(ns puppetlabs.puppetserver.common
+  (:require [schema.core :as schema]))
+
+(def Environment
+  "Schema for environment names. Alphanumeric and _ only."
+  (schema/pred (comp not nil? (partial re-matches #"\w+")) "environment"))
+
+(def CodeId
+  "Validates that code-id contains only alpha-numerics and
+  '-', '_', ';', or ':'."
+  (schema/pred (comp not (partial re-find #"[^_\-:;a-zA-Z0-9]")) "code-id"))
+
+(def environment-validation-error-msg
+  (partial format "The environment must be purely alphanumeric, not '%s'"))
+
+(def code-id-validation-error-msg
+  (partial format "Invalid code-id '%s'. Must contain only alpha-numerics and '-', '_', ';', or ':'"))
+

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -2,7 +2,9 @@
   (:require [clojure.tools.logging :as log]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
-            [puppetlabs.services.jruby.jruby-puppet-service :as jruby]))
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+            [schema.core :as schema]
+            [puppetlabs.puppetserver.common :as ps-common]))
 
 (defn throw-bad-request!
   "Throw a ::bad-request type slingshot error with the supplied message"
@@ -82,12 +84,9 @@
         (throw-bad-request!
          "An environment parameter must be specified")
 
-        (not (re-matches #"^\w+$" environment))
+        (not (nil? (schema/check ps-common/Environment environment)))
         (throw-bad-request!
-         (str
-          "The environment must be purely alphanumeric, not '"
-          environment
-          "'"))
+         (ps-common/environment-validation-error-msg environment))
 
         :else
         (handler request)))))

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -6,6 +6,7 @@
            (org.eclipse.jetty.util URIUtil))
   (:require [me.raynes.fs :as fs]
             [puppetlabs.puppetserver.ringutils :as ringutils]
+            [puppetlabs.puppetserver.common :as ps-common]
             [puppetlabs.comidi :as comidi]
             [ring.util.response :as rr]
             [schema.core :as schema]
@@ -385,10 +386,19 @@
         (some empty? [environment code-id file-path])
         {:status 400
          :body "Error: A /static_file_content request requires an environment, a code-id, and a file-path"}
+        (not (nil? (schema/check ps-common/Environment environment)))
+        {:status 400
+         :body (ps-common/environment-validation-error-msg environment)}
+
+        (not (nil? (schema/check ps-common/CodeId code-id)))
+        {:status 400
+         :body (ps-common/code-id-validation-error-msg code-id)}
+
         (not (valid-static-file-path? file-path))
         {:status 403
          :body (str "Request Denied: A /static_file_content request must be a file within "
          "the files directory of a module.")}
+
         :else
         {:status 200
          :body (get-code-content environment code-id

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -5,10 +5,12 @@
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
             [puppetlabs.ssl-utils.core :as ssl-utils]
+            [puppetlabs.puppetserver.common :as ps-common]
             [ring.util.codec :as ring-codec]
             [puppetlabs.trapperkeeper.authorization.ring :as ring-auth]
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
-            [puppetlabs.puppetserver.jruby-request :as jruby-request]))
+            [puppetlabs.puppetserver.jruby-request :as jruby-request]
+            [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Internal
@@ -258,6 +260,8 @@
   [current-code-id request]
   (if (:include-code-id? request)
     (let [env (jruby-request/get-environment-from-request request)]
+      (when-not (nil? (schema/check ps-common/Environment env))
+        (jruby-request/throw-bad-request! (ps-common/environment-validation-error-msg env)))
       (when-not env
         (jruby-request/throw-bad-request! "Environment is required in a catalog request."))
       (assoc-in request [:params "code_id"] (current-code-id env)))


### PR DESCRIPTION
This commit adds validation for inputs to the code id and code content
scripts. While ShellUtils ought to prevent any bash injection attacks,
we still deemed it wise to do validation on this sort of input.

To that end, this commit adds schemas for environment and code-id
strings and uses them at both the HTTP level and the schema level.

An old helper, `valid-code-id?`, was removed in favor of using schema.