### PR TITLE
(SERVER-1202) Rename run! in gem and irb namespaces 

### DIFF
--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -2,10 +2,10 @@
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
-(defn run!
+(defn gem-run!
   [config args]
   (jruby-core/cli-run! config "gem" args))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run gem-run! args))

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -2,10 +2,10 @@
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
-(defn run!
+(defn irb-run!
   [config args]
   (jruby-core/cli-run! config "irb" args))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run irb-run! args))


### PR DESCRIPTION
clojure 1.7.0 included a new function named run!, which has the same
name as existing functions in the gem and irb namespaces. This produces
unsightly warnings when using the gem subcommand.
This commit adds an exclusion on the run! command from clojure to avoid
these warnings.