### PR TITLE
Merge up from stable at a352065

### DIFF
--- a/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/echo_foo
+++ b/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/echo_foo
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+
+echo foo

--- a/dev-resources/puppetlabs/services/master/environment_classes_int_test/logback-environment-classes-integration-cache-enabled-test.xml
+++ b/dev-resources/puppetlabs/services/master/environment_classes_int_test/logback-environment-classes-integration-cache-enabled-test.xml
@@ -1,0 +1,15 @@
+<configuration scan="true">
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <file>./target/environment-classes-integration-cache-enabled.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="debug">
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>

--- a/documentation/_puppetserver_nav.html
+++ b/documentation/_puppetserver_nav.html
@@ -19,6 +19,8 @@
           <li><a href="/puppetserver/{{ server_version }}/config_file_global.html">global.conf: Trapperkeeper Settings</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_ca.html">ca.conf: CA Service Access Control (deprecated)</a></li>
           <li><a href="/puppetserver/{{ server_version }}/config_file_master.html">master.conf: Authorization by HTTP Header (deprecated)</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_file_logbackxml.html">logback.xml: Logging Level and Location</a></li>
+          <li><a href="/puppetserver/{{ server_version }}/config_logging_advanced.html">Advanced Logging Configuration</a></li>
         </ul>
       </li>
       <li><a href="/puppetserver/{{ server_version }}/puppet_conf_setting_diffs.html">Differing Behavior in puppet.conf</a></li>
@@ -28,6 +30,7 @@
       <li><a href="/puppetserver/{{ server_version }}/external_ca_configuration.html">Using an External CA</a></li>
       <li><a href="/puppetserver/{{ server_version }}/external_ssl_termination.html">External SSL Termination</a></li>
       <li><a href="/puppetserver/{{ server_version }}/tuning_guide.html">Tuning Guide</a></li>
+      <li><a href="/puppetserver/{{ server_version }}/restarting.html">Restarting the Server</a></li>
       <li><strong>Known Issues and Workarounds</strong>
         <ul>
           <li><a href="/puppetserver/{{ server_version }}/known_issues.html">Known Issues</a></li>

--- a/documentation/config_file_logbackxml.md
+++ b/documentation/config_file_logbackxml.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: "Puppet Server Configuration Files: logback.xml"
+canonical: "/puppetserver/latest/config_file_logbackxml.html"
+---
+
+Puppet Server’s logging is routed through the Java Virtual Machine's (JVM) [Logback library](http://logback.qos.ch/) and configured through a special XML file typically named `logback.xml`.
+
+> **Note:** This document covers basic, commonly modified options for Puppet Server logs. Logback is a powerful library with many options. For detailed information on configuring Logback, see the [Logback Configuration Manual](http://logback.qos.ch/manual/configuration.html).
+>
+> For advanced logging configuration tips specific to Puppet Server, such as configuring Logstash or outputting logs in JSON format, see [the Advanced Logging Configuration guide](./config_logging_advanced.html).
+
+## Puppet Server logging
+
+By default, Puppet Server logs messages and errors to `/var/log/puppetlabs/puppetserver/puppetserver.log`. The default log level is ‘INFO’, and Puppet Server sends nothing to `syslog`. You can change Puppet Server's logging behavior by editing `/etc/puppetlabs/puppetserver/logback.xml`, and you can specify a different Logback config file in [`global.conf`](#globalconf).
+
+Puppet Server picks up changes to `logback.xml` at runtime, so you don’t need to restart the service for changes to take effect.
+
+Puppet Server relies on `logrotate` to manage the log file, and installs a configuration file at `/etc/logrotate.d/puppetserver` (open source Puppet) or `/etc/logrotate.d/pe-puppetserver` (Puppet Enterprise).
+
+### Default Puppet Server `logback.xml`
+
+~~~ xml
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <!-- TODO: this path should not be hard-coded -->
+        <file>/var/log/puppetlabs/puppetserver/puppetserver.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d %-5p [%t] [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="INFO"/>
+
+    <root level="info">
+        <!--<appender-ref ref="STDOUT"/>-->
+        <!-- ${logappender} logs to console when running the foreground command -->
+        <appender-ref ref="${logappender}"/>
+        <appender-ref ref="F1"/>
+    </root>
+</configuration>
+~~~
+
+### Settings
+
+#### `level`
+
+To modify Puppet Server's logging level, change the `level` attribute of the `root` tag. For instance, the default logging level is set to `info`:
+
+    <root level="info">
+
+Supported logging levels, in order from most to least information logged, are `trace`, `debug`, `info`, `warn`, and `error`. For instance, to enable debug logging for Puppet Server, change `info` to `debug`:
+
+    <root level="debug">
+
+Puppet Server profiling data is included at the `debug` logging level.
+
+#### Logging location
+
+You can change the file to which Puppet Server writes its logs in the `appender` section named `F1`. For instance, the default location is set to `/var/log/puppetlabs/puppetserver/puppetserver.log`:
+
+~~~ xml
+...
+    <appender name="F1" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/puppetlabs/puppetserver/puppetserver.log</file>
+...
+~~~
+
+To change this to `/var/log/puppetserver.log`, modify the contents of the `file` element:
+
+~~~ xml
+        <file>/var/log/puppetserver.log</file>
+~~~
+
+Note that the user account that owns the Puppet Server process must have write permissions to the destination path.
+
+## HTTP request logging
+
+Puppet Server logs HTTP traffic separately, and this logging is configured in a different Logback configuration file located at `/etc/puppetlabs/puppetserver/request-logging.xml`. To specify a different Logback configuration file, use the `access-log-config` setting in Puppet Server's [`webserver.conf`](./config_file_webserver.html) file.
+
+The HTTP request log uses the same Logback configuration format and settings as the Puppet Server log. It also lets you configure what it logs using patterns, which follow Logback's [`PatternLayout` format](http://logback.qos.ch/manual/layouts.html#AccessPatternLayout).
+
+### Default `request-logging.xml`
+
+~~~ xml
+<configuration debug="false" scan="true">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/var/log/puppetlabs/puppetserver/puppetserver-access.log</file>
+    <encoder>
+        <pattern>%h %l %u %user %date "%r" %s %b %h %a %localPort %D</pattern>
+    </encoder>
+  </appender>
+  <appender-ref ref="FILE" />
+</configuration>
+~~~

--- a/documentation/config_file_puppetserver.md
+++ b/documentation/config_file_puppetserver.md
@@ -9,6 +9,9 @@ canonical: "/puppetserver/latest/config_file_puppetserver.html"
 [cache directory]: /puppet/latest/reference/dirs_vardir.html
 [`auth.conf` documentation]: ./config_file_auth.html
 [deprecated]: ./deprecated_features.html
+[static catalogs]: /puppet/latest/reference/static_catalogs.html
+[file resource]: /puppet/latest/reference/type.html#file
+[`static_file_content`]: ./puppet-api/v3/static_file_content.html
 
 The `puppetserver.conf` file contains settings for Puppet Server software. For an overview, see [Puppet Server Configuration](./configuration.html).
 
@@ -27,25 +30,47 @@ The `puppetserver.conf` file contains settings for Puppet Server software. For a
     * `max-active-instances`: Optional. The maximum number of JRuby instances allowed. The default is 'num-cpus - 1', with a minimum value of 1 and a maximum value of 4.
     * `max-requests-per-instance`: Optional. The number of HTTP requests a given JRuby instance will handle in its lifetime. When a JRuby instance reaches this limit, it is flushed from memory and replaced with a fresh one. The default is 0, which disables automatic JRuby flushing.
 
-    JRuby flushing can be useful for working around buggy module code that would otherwise cause memory leaks, but it slightly reduces performance whenever a new JRuby instance reloads all of the Puppet Ruby code. If memory leaks from module code are not an issue in your deployment, the default value of 0 performs best.
+        JRuby flushing can be useful for working around buggy module code that would otherwise cause memory leaks, but it slightly reduces performance whenever a new JRuby instance reloads all of the Puppet Ruby code. If memory leaks from module code are not an issue in your deployment, the default value of 0 performs best.
     * `borrow-timeout`: Optional. The timeout in milliseconds, when attempting to borrow an instance from the JRuby pool. The default is 1200000.
     * `use-legacy-auth-conf`: Optional. The method to be used for authorizing access to the HTTP endpoints served by the "master" service. The applicable endpoints are listed in [Puppet v3 HTTP API](/puppet/latest/reference/http_api/http_api_index.html#puppet-v3-http-api).
+    * `environment-class-cache-enabled`:  Optional.  Used to control whether 
+    or not a cache is maintained in conjunction with the use of the 
+    [`environment_classes` API](./puppet-api/v3/environment_classes.html).  If
+    this setting is set to `true`, the cache will be maintained, enabling an 
+    Etag header to be returned for each GET request to the API and for 
+    subsequent GET requests using the prior Etag value in an If-None-Match 
+    header to return an HTTP 304 (Not Modified) with no response body when 
+    the class information available for an environment has not changed.  If 
+    this setting is set to `false` or is not specified, no cache will be 
+    maintained.  In this case, an Etag header is not returned for GET 
+    requests and the If-None-Match header for an incoming request is ignored,
+    meaning that every incoming request will involve parsing the latest 
+    available code for an environment from disk.  For more information, see 
+    the `environment_classes` API documentation. 
     * `compile-mode`: Optional, experimental.  Used to control JRuby's "CompileMode", which may improve performance.  The default value is `off`, which is the most conservative value.  A value of `jit` will enable JRuby's "just in time" compilation of Ruby code.  A value of `force` will cause JRuby to attempt to pre-compile all Ruby code ahead of time.
 
-    If this setting is set to `true` or is not specified, Puppet uses the [deprecated][] Ruby `puppet-agent` authorization method and [Puppet `auth.conf`][`auth.conf` documentation] format, which will be removed in a future version of Puppet Server.
-    
-    For a value of `false`, Puppet uses the HOCON configuration file format and location. See the [`auth.conf` documentation](./config_file_auth.html) for more information.
+        If this setting is set to `true` or is not specified, Puppet uses the [deprecated][] Ruby `puppet-agent` authorization method and [Puppet `auth.conf`][`auth.conf` documentation] format, which will be removed in a future version of Puppet Server.
+
+        For a value of `false`, Puppet uses the HOCON configuration file format and location. See the [`auth.conf` documentation](./config_file_auth.html) for more information.
 * The `profiler` settings configure profiling:
     * `enabled`: If this is set to `true`, Puppet Server enables profiling for the Puppet Ruby code. The default is `false`.
 * The `puppet-admin` section configures Puppet Server's administrative API. (This API is unavailable with Rack or WEBrick Puppet masters.) The settings in this section are now deprecated. Remove these settings and replace them with the authorization method that was introduced in Puppet Server 2.2, using a HOCON format for `auth.conf`. See the [`auth.conf` documentation][] for more information.
     * `authorization-required` determines whether a client certificate is required to access the endpoints in this API. If set to `false`, all requests will be permitted to access this API. If set to `true`, only the clients whose certnames are included in the `client-whitelist` setting are allowed access to the admin API. If this setting is not specified but the `client-whitelist` setting is specified, the default value for this setting is `true`.
     * `client-whitelist` contains an array of client certificate names that are allowed to access the admin API. Puppet Server denies any requests made to this endpoint that do not present a valid client certificate mentioned in this array.
 
-    If neither the `authorization-required` nor the `client-whitelist` settings are specified, Puppet Server uses the new authorization methods and [`auth.conf` documentation][] formats to access the admin API endpoints.
+        If neither the `authorization-required` nor the `client-whitelist` settings are specified, Puppet Server uses the new authorization methods and [`auth.conf` documentation][] formats to access the admin API endpoints.
+
+* The `versioned-code` settings configure commands required to use [static catalogs][]:
+    * `code-id-command` contains the path to an executable script that Puppet Server invokes to generate a `code_id`. When compiling a static catalog, Puppet Server uses the output of this script as the catalog's `code_id`, which associates the catalog with that version of any [file resources][file resource] that has a `source` attribute with a `puppet:///` URI value.
+    * `code-content-command` contains the path to an executable script that Puppet Server invokes when an agent makes a [`static_file_content`][] API request for the contents of a [file resource][] that has a `source` attribute with a `puppet:///` URI value.
+
+> **Note:** The Puppet Server process must be able to execute the `code-id-command` and `code-content-command` scripts, and the scripts must return valid content to standard output and an error code of 0. For more information, see the [static catalogs][] and [`static_file_content` API][`static_file_content`] documentation.
+>
+> If you're using static catalogs, you **must** set and use **both** `code-id-command` and `code-content-command`. If only one of those settings are specified, Puppet Server fails to start. If neither setting is specified, Puppet Server defaults to generating catalogs without static features even when an agent requests a static catalog, which the agent will process as a normal catalog.
 
 ### Examples
 
-~~~
+``` hocon
 # Configuration for the JRuby interpreters.
 
 jruby-puppet: {
@@ -91,6 +116,14 @@ http-client: {
 profiler: {
     enabled: true
 }
-~~~
+
+# Settings related to static catalogs. These paths are examples; there are no default
+# scripts provided with Puppet Server, and no default path for the scripts. You must set
+# the paths and provide your own scripts.
+versioned-code: {
+    code-id-command: /opt/puppetlabs/server/apps/puppetserver/code-id-command_script.sh
+    code-content-command: /opt/puppetlabs/server/apps/puppetserver/code-content-command_script.sh
+}
+```
 
 > **Note:** The `puppet-admin` setting and `client-whitelist` parameter are deprecated in favor of authorization methods introduced in Puppet Server 2.2. For details, see the [`auth.conf` documentation][].

--- a/documentation/configuration.markdown
+++ b/documentation/configuration.markdown
@@ -9,7 +9,7 @@ canonical: "/puppetserver/latest/configuration.html"
 [`puppetserver.conf`]: ./config_file_puppetserver.html
 [deprecated]: ./deprecated_features.html
 
-Puppet Server honors most settings in `puppet.conf` and picks them up automatically. However, for some tasks, such as configuring the web server or an external Certificate Authority (CA), Puppet Server has separate configuration files and settings. 
+Puppet Server honors most settings in `puppet.conf` and picks them up automatically. However, for some tasks, such as configuring the web server or an external Certificate Authority (CA), Puppet Server has separate configuration files and settings.
 
 These files and settings are described below. For more information about differences between Puppet Server and the Ruby Puppet master's use of `puppet.conf` settings, see  [Puppet Server: Differing Behavior in `puppet.conf`](./puppet_conf_setting_diffs.markdown).
 
@@ -29,11 +29,9 @@ At startup, Puppet Server reads all the `.conf` files in the `conf.d` directory.
 
 ## Logging
 
-Puppet Server's logging is routed through the JVM [Logback](http://logback.qos.ch/) library. By default, it logs to `/var/log/puppetlabs/puppetserver/puppetserver-access.log`, the log level is 'INFO', and Puppet Server sends nothing to syslog.
+Puppet Server's logging is routed through the JVM [Logback](http://logback.qos.ch/) library. The default Logback configuration file is at `/etc/puppetserver/logback.xml` or `/etc/puppetlabs/puppetserver/logback.xml`. You can edit this file to change the logging behavior, or specify a different Logback config file in [`global.conf`](#globalconf).
 
-The default Logback configuration file is at `/etc/puppetserver/logback.xml` or `/etc/puppetlabs/puppetserver/logback.xml`. You can edit this file to change the logging behavior, or specify a different Logback config file in [`global.conf`](#globalconf). For more information on configuring Logback itself, see the [Logback Configuration Manual](http://logback.qos.ch/manual/configuration.html). Puppet Server picks up changes to logback.xml at runtime, so you don't need to restart the service for changes to take effect.
-
-Puppet Server relies on `logrotate` to manage the log file, and installs a configuration file at `/etc/logrotate.d/puppetserver` or `/etc/logrotate.d/pe-puppetserver`.
+For more information on the `logback.xml` file, see [its documentation](./config_file_logbackxml.html) and the [Logback documentation](http://logback.qos.ch/manual/configuration.html). For advanced logging configuration tips, such as configuring Logstash or outputting logs in JSON format, see [the Advanced Logging Configuration guide](./config_logging_advanced.html).
 
 For some tips on advanced logging configuration, including information about configuring your system to write logs in a JSON format suitable for sending to logstash or other external logging systems, see the [Advanced Logging Configuration](./config_logging_advanced.html) documentation.
 
@@ -78,7 +76,7 @@ authorization, add the following to Puppet Server's `logback.xml` file:
 
 ## Service Bootstrapping
 
-Puppet Server is built on top of our open-source Clojure application framework, [Trapperkeeper](https://github.com/puppetlabs/trapperkeeper). One of the features that Trapperkeeper provides is the ability to enable or disable individual services that an application provides. In Puppet Server, you can use this feature to enable or disable the CA service, by modifying your `bootstrap.cfg` file (usually located in `/etc/puppetserver/bootstrap.cfg`). In that file, find the lines that look like this: 
+Puppet Server is built on top of our open-source Clojure application framework, [Trapperkeeper](https://github.com/puppetlabs/trapperkeeper). One of the features that Trapperkeeper provides is the ability to enable or disable individual services that an application provides. In Puppet Server, you can use this feature to enable or disable the CA service, by modifying your `bootstrap.cfg` file (usually located in `/etc/puppetserver/bootstrap.cfg`). In that file, find the lines that look like this:
 
 ~~~
 # To enable the CA service, leave the following line uncommented

--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -27,6 +27,8 @@ Puppet Server is the next-generation application for managing Puppet agents.
 * **Administrative API**
     * [Environment Cache](./admin-api/v1/environment-cache.markdown)
     * [JRuby Pool](./admin-api/v1/jruby-pool.markdown)
+* **Puppet API**
+    * [Environment Classes](./puppet-api/v3/environment_classes.md)
 * **Developer Info**
     * [Debugging](./dev_debugging.markdown)
     * [Running From Source](./dev_running_from_source.markdown)

--- a/documentation/puppet-api/v3/environment_classes.json
+++ b/documentation/puppet-api/v3/environment_classes.json
@@ -1,0 +1,76 @@
+{
+  "$schema":     "http://json-schema.org/draft-04/schema#",
+  "title":       "Environment Classes",
+  "description": "Information about the classes in a Puppet code environment",
+  "type":        "object",
+  "properties": {
+    "files": {
+      "description": "The array of manifest files which exist in an environment.  Even files that do not contain any classes will appear in the array.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "description": "Fully-qualified path on the server to the manifest",
+            "type": "string"
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the class.  For example, if the class were defined as 'class myclass', the name would be 'myclass'.",
+                  "type": "string"
+                },
+                "params": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the class parameter.  For example, if a class parameter were defined as 'String $my_param', the name would be 'my_param'.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Data type, if defined, for the class parameter.  For example, if a class parameter were defined as 'String $my_param', the data type would be 'String'.  See https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html for information on the available data types.",
+                        "type": "string"
+                      },
+                      "default_source": {
+                        "description": "Source text for the default value, if defined, for the class parameter.  For example, if a class parameter were defined in the manifest as 'String $my_param = \"my value\"', the default_source would be '\"my value\"' where \" would appear literally in the text.  Note that no expressions in the default value - for example, references to other variables - are expanded.  The text for default_source matches the exact content in the parsed manifest.",
+                        "type": "string"
+                      },
+                      "default_literal": {
+                        "description": "Literal representation of the default value, if defined, for the class parameter.  This member is only present if the value can be expressed using primitive JSON data types.  For example, if a class parameter were defined in the manifest as 'Integer $my_integer = 3', the default_literal would be a JSON number whereas the corresponding default_source would be a JSON string containing '3'.  The default_literal would be omitted for the following cases: 1) The primitive Puppet value has no direct translation into a JSON primitive type (for example, a regular expression, default, or undef).  2) The value contains a Puppet hash - either top-level or nested under another array or hash - with at least one key that is not a string.  3) The value contains one or more expressions that would have to be evaluated at catalog compilation time in order for the actual default value to be determined.  See https://docs.puppetlabs.com/puppet/latest/reference/lang_data.html for information on the available data types and values."
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["name", "params"],
+              "additionalProperties": false
+            }
+          },
+          "error": {
+            "description": "If an error was encountered during manifest parsing, this member will be present instead of 'classes'.  The error string provides details about the specific error.",
+            "type": "string"
+          }
+        },
+        "required": ["path"],
+        "oneOf": [
+          {"required": ["classes"]},
+          {"required": ["error"]}
+        ],
+        "additionalProperties": false
+      }
+    },
+    "name": {
+      "description": "Name of the environment",
+      "type": "string"
+    }
+  },
+  "required": ["files", "name"],
+  "additionalProperties": false
+}

--- a/documentation/puppet-api/v3/environment_classes.md
+++ b/documentation/puppet-api/v3/environment_classes.md
@@ -1,0 +1,386 @@
+---
+layout: default
+title: "Puppet Server: Puppet API: Environment Classes"
+canonical: "/puppetserver/latest/puppet/v3/environment_classes.html"
+---
+
+[auth.conf]: /puppetserver/latest/config_file_auth.html
+
+The environment classes API serves as a replacement for the functionality
+available in the Puppet
+[resource type API](/puppet/latest/reference/http_api/http_resource_type.html)
+for classes.  Key differences between the two APIs include:
+
+* The environment classes API only covers "classes" whereas the resource
+  type API covers classes, nodes, and defined types.
+
+* Queries to the resource type API utilize cached class information per
+  the configuration of the
+  [environment_timeout](/puppet/latest/reference/config_file_environment.html#environmenttimeout)
+  setting for the corresponding environment.  The environment classes API
+  does not utilize the "environment_timeout" with respect to the data that it 
+  caches.  Instead, only when the `environment-class-cache-enabled` setting in
+  the `jruby-puppet` configuration section is set to `true`, the environment
+  classes API uses HTTP Etags to represent specific versions of the class
+  information and the Puppet Server
+  [environment-cache API](./admin-api/v1/environment-cache.html) as an
+  explicit mechanism for marking an Etag as expired.  See the
+  [Headers and Caching Behavior](#headers-and-caching-behavior) section for more
+  information about caching and invalidation of entries.
+  
+* The environment classes API includes a "type", if defined for a class 
+  parameter.  For example, if the class parameter were defined as
+  `String $some_str`, the "type" parameter would hold a value of "String".
+
+* For values that can be presented in pure JSON, the environment classes API 
+  provides a "default_literal" form of a class parameter's default value.  For
+  example, if an "Integer" type class parameter were defined in the manifest as
+  having a default value of "3", the "default_literal" element for the
+  parameter will contain a JSON Number type of 3.
+
+* The environment classes API does not provide a way to filter the list of
+  classes returned via use of a search string.  The environment classes API
+  returns information for all classes found within an environment's manifest
+  files.
+
+* Unlike the resource type API under Puppet 4, the environment classes API
+  does include the filename in which each class was found.  The resource 
+  type API under Puppet 3 does include the filename but the resource type 
+  API under Puppet 4 does not.
+
+* The environment classes API does not include the line number at which a
+  class is found in the file.
+
+* Unlike the resource types API under Puppet 3, the environment classes API 
+  does not include any doc strings for a class entry.  Note that doc strings 
+  are also not returned for class entries in the Puppet 4 resource type API.
+  
+* The environment classes API returns a file entry for manifests that exist 
+  in the environment but in which no classes were found.  The resource type
+  API omits entries for files which did not contain any classes.
+
+* The Content-Type in the response to an environment classes API query is 
+  "application/json" whereas the resource types API uses a Content-Type of 
+  "text/pson".
+  
+* If an error is encountered when parsing a manifest, the resource types API 
+  omits information from the manifest entirely - although it will, 
+  assuming none of the parsing errors were found in one of the files associated
+  with the environment's
+  [`manifest` setting](/puppet/latest/reference/config_file_environment.html#manifest),
+  include class information from other manifests that could successfully be
+  parsed.  In the case that one or more classes is returned but errors were 
+  encountered parsing other manifests, the response from the resource types API 
+  call does not include any explicit indication that a parsing error has been
+  encountered.  The environment classes API will include information for every
+  class that can successfully be parsed.  For any errors which occur when 
+  parsing individual manifest files, an entry for the corresponding manifest 
+  file is included, along with an "error" with a detail string about the failure
+  encountered during parsing.
+
+## `GET /puppet/v3/environment_classes?environment=:environment`
+
+Making a request with no query parameters is currently not supported and will
+provide an HTTP 400 (Bad Request) response.
+
+### Supported HTTP Methods
+
+GET
+
+### Supported Formats
+
+JSON
+
+### Query Parameters
+
+One parameter should be provided to the GET:
+
+* `environment`: Only the classes and parameter information pertaining to the
+  specified environment will be returned for the call.
+
+### Responses
+
+#### Get With Results
+
+```
+GET /puppet/v3/environment_classes?environment=env
+
+HTTP/1.1 200 OK
+Etag: b02ede6ecc432b134217a1cc681c406288ef9224
+Content-Type: text/json
+
+{
+  "files": [
+    {
+      "path": "/etc/puppetlabs/code/environments/env/manifests/site.pp",
+      "classes": []
+    },
+    {
+      "path": "/etc/puppetlabs/code/environments/env/modules/mymodule/manifests/init.pp",
+      "classes": [
+        {
+          "name": "mymodule",
+          "params": [
+            {
+              "default_literal": "this is a string",
+              "default_source": "\"this is a string\"",
+              "name": "a_string",
+              "type": "String"
+            },
+            {
+              "default_literal": 3,
+              "default_source": "3",
+              "name": "an_integer",
+              "type": "Integer"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "error": "Syntax error at '=>' at /etc/puppetlabs/code/environments/env/modules/mymodule/manifests/other.pp:20:19",
+      "path": "/etc/puppetlabs/code/environments/env/modules/mymodule/manifests/other.pp"
+    }
+  ],
+  "name": "env"
+}
+```
+
+#### Get With Etag Roundtripped from Previous Get
+ 
+If the Etag value returned from the previous request for information from an
+environment is sent to the server in a follow-up request and the underlying
+environment cache has not been invalidated, an HTTP 304 (Not Modified) response
+will be returned.  See the
+[Headers and Caching Behavior](#headers-and-caching-behavior) section for more
+information about caching and invalidation of entries.
+
+```
+GET /puppet/v3/environment_classes?environment=env
+If-None-Match: b02ede6ecc432b134217a1cc681c406288ef9224
+
+HTTP/1.1 304 Not Modified
+Etag: b02ede6ecc432b134217a1cc681c406288ef9224
+```
+
+If the environment cache has been updated from what was used to calculate the
+original Etag, the server will return a response with the full set of
+environment class information:
+
+```
+GET /puppet/v3/environment_classes?environment=env
+If-None-Match: b02ede6ecc432b134217a1cc681c406288ef9224
+
+HTTP/1.1 200 OK
+Etag: 2f4f83096265b9741c5304b3055f866df0336762
+Content-Type: text/json
+
+{
+  "files": [
+    {
+      "path": "/etc/puppetlabs/code/environments/env/manifests/site.pp",
+      "classes": []
+    },
+    {
+      "path": "/etc/puppetlabs/code/environments/env/modules/mymodule/manifests/init.pp",
+      "classes": [
+        {
+          "name": "mymodule",
+          "params": [
+            {
+              "default_literal": "this is a string",
+              "default_source": "\"this is a string\"",
+              "name": "a_string",
+              "type": "String"
+            },
+            {
+              "default_literal": 3,
+              "default_source": "3",
+              "name": "an_integer",
+              "type": "Integer"
+            },
+            {
+              "default_literal": {
+                "one": "foo",
+                "two": "hello"
+              },
+              "default_source": "{ \"one\" => \"foo\", \"two\" => \"hello\" }",
+              "name": "a_hash",
+              "type": "Hash"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "name": "env"
+}
+```
+
+#### Environment does not exist
+
+A request made with an environment parameter which does not correspond to the
+name of a directory environment on the server results in an HTTP 404 (Not
+Found) error:
+
+```
+GET /puppet/v3/environment_classes?environment=doesnotexist
+
+HTTP/1.1 404 Not Found
+
+Could not find environment 'doesnotexist'
+```
+
+#### No environment given
+
+```
+GET /puppet/v3/environment_classes
+
+HTTP/1.1 400 Bad Request
+
+An environment parameter must be specified.
+```
+
+Note that this endpoint may support the ability to provide a success response
+with valid data in a future release.
+
+#### Environment parameter specified with no value
+
+```
+GET /puppet/v3/environment_classes?environment=
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not ''
+```
+
+#### Environment does not include only alphanumeric characters
+
+A request made with an environment parameter which includes at least one
+character which is not among the following - A-Z, a-z, 0-9, or _ (underscore) -
+results in an HTTP 400 (Bad Request) error:
+
+```
+GET /puppet/v3/environment_classes?environment=bog|us
+
+HTTP/1.1 400 Bad Request
+
+The environment must be purely alphanumeric, not 'bog|us'
+```
+
+### Schema
+
+An environment classes response body conforms to
+[the environment classes schema](./environment_classes.json).
+ 
+### Headers and Caching Behavior
+
+If the `environment-class-cache-enabled` setting in the `jruby-puppet`
+configuration section is set to `true`, the `environment_classes` API can
+make use of caching for the response data.  This can provide a significant
+performance benefit and reduction in the amount of data that needs to be
+provided in a response when the underlying Puppet code on disk remains
+unchanged from one request to the next.  Use of the cache does, however,
+require that cache entries are invalidated after Puppet code has been
+updated.  To avoid having to invalidate cache entries, the
+`environment-class-cache-enabled` setting can be omitted from configuration 
+or explicitly set to `false`.  In this case, manifests will be re-discovered
+from disk and re-parsed for every incoming request.  This can involve
+significantly greater overhead in performance and bandwidth for repeated 
+requests where the underlying Puppet code does not change much.  This 
+approach does, however, ensure that the latest available data is returned 
+for every request made.  The rest of the content in this section pertains to the
+behaviors to keep in mind when the cache setting is enabled.
+
+When the `environment-class-cache-enabled` setting is set to `true`, the 
+response to a query to the `environment_classes`  endpoint includes an HTTP
+[Etag](https://tools.ietf.org/html/rfc7232#section-2.3) header.  The value 
+for the Etag header is a hash which represents the state of the latest class
+information available for the requested environment.  For example:
+
+```
+ETag: 31d64b8038258202b4f5eb508d7dab79c46327bb
+```
+
+A client may (but is not required to) provide the Etag value back to the server
+in a subsequent `environment_classes` request.  The client would provide the
+tag value as the value for an
+[If-None-Match](https://tools.ietf.org/html/rfc7232#section-3.2)
+HTTP header:
+
+```
+If-None-Match: 31d64b8038258202b4f5eb508d7dab79c46327bb
+```
+
+If the latest state of code available on the server matches that of the value
+in the `If-None-Match` header, the server will provide an HTTP 304 (Not
+Modified) response and no corresponding response body.  If the server has later
+code available than what is captured by the `If-None-Match` header value or
+no `If-None-Match` header is provided in the request, the server will re-parse
+code from manifest files on disk.  Assuming the resulting payload were different
+than in a previous request, the server would provide a different Etag value
+along new class information in the response payload.
+
+Note that the server may, in cases where the client has sent an
+`Accept-Encoding: gzip` HTTP header for the request and the server has chosen
+to provide a gzip-encoded response body, append the characters "--gzip" to
+the end of the Etag.  For example, the HTTP response headers could include:
+
+```
+Content-Encoding: gzip
+ETag: e84bbce5482243b3eb3a190e5c90e535cf4f20de--gzip
+```
+
+The server will accept both forms of an Etag - with or without the trailing
+"--gzip" characters - as being the same when validating the value in a
+request's `If-None-Match` header against its cache.
+
+It is best, however, for clients to utilize the Etag in an opaque manner, not
+parsing its content.  A client wanting to get an HTTP 304 (Not Modified)
+response if the cache has not been updated since the prior request should
+take the exact value returned in the `Etag` header from one request and provide
+that back to the server in an `If-None-Match` header in a subsequent request
+for the class information for an environment.
+
+---
+
+After Puppet code (manifests) on disk in an environment are updated, the cache 
+entries that the server holds for class information will need to be cleared. 
+This will allow the server to re-parse the latest manifest code on disk and 
+reflect any changes to the class information in later queries to the 
+environment_classes endpoint.  The following actions will clear cache entries on
+the server:
+
+1. Calling the
+   [environment-cache API](latest/admin-api/v1/environment-cache.html) endpoint.
+   
+   For best performance, it is best to call this endpoint with a query 
+   parameter for the specific `environment` whose cache should be flushed.
+   
+2. Performing a `commit` through the
+   [File Sync API](/pe/latest/cmgmt_filesync_api.html#post-file-syncv1commit)
+   endpoint.
+   
+   Note that the "File Sync" feature is only available in Puppet Enterprise. 
+   When a commit is performed through the "File Sync" API, it is unnecessary 
+   to also invoke the `environment-cache` API to flush the environment's 
+   cache.  The environment's cache is implicitly flushed as part of the sync 
+   of new commits to a master using the File Sync feature.
+
+3. Restarting Puppet Server.
+
+   The cache for every environment is held in memory for the Puppet Server 
+   process and so is effectively flushed whenever Puppet Server is restarted.
+
+### Authorization
+
+URI authorization for requests made to the environment classes API will always
+be performed by the "new" Trapperkeeper-based auth.conf feature in Puppet
+Server.  This is different than most other master service-based endpoints,
+for which the authorization mechanism used ("new" auth.conf vs. "legacy"
+auth.conf) is controlled by the `use-legacy-auth-conf` setting in the
+`jruby-puppet` configuration section.  The value of the `use-legacy-auth-conf`
+setting is ignored for the environment classes API and so the "legacy"
+auth.conf mechanism is never used when authorizing requests made to the
+environment classes API.  For more information about authorization, see
+the [`auth.conf` documentation][auth.conf].

--- a/documentation/puppet-api/v3/static_file_content.md
+++ b/documentation/puppet-api/v3/static_file_content.md
@@ -1,0 +1,97 @@
+---
+layout: default
+title: "Puppet Server: Puppet API: Static File Content"
+canonical: "/puppetserver/latest/puppet-api/v3/static_file_content.html"
+---
+
+[`code-content-command`]: https://docs.puppetlabs.com/puppetserver/latest/config_file_puppetserver.html
+[static catalog]: https://docs.puppetlabs.com/puppet/latest/reference/static_catalogs.html
+[catalog]: https://docs.puppetlabs.com/puppet/latest/reference/subsystem_catalog_compilation.html
+[file resource]: https://docs.puppetlabs.com/puppet/latest/reference/type.html#file
+[environment]: https://docs.puppetlabs.com/puppet/latest/reference/environments.html
+[auth.conf]: https://docs.puppetlabs.com/puppetserver/latest/config_file_auth.html
+
+The `static_file_content` endpoint returns the standard output of a
+[`code-content-command`][] script, which should output the contents of a specific version
+of a [file resource][] that has a `source` attribute with a `puppet:///` URI value. That
+source must be a file from the `files` directory of a module in a specific [environment][].
+
+Puppet Agent uses this endpoint only when applying a [static catalog][], and this endpoint
+is available only when the Puppet master is running Puppet Server. This endpoint does not
+exist on Ruby Puppet masters, such as the
+[deprecated WEBrick Puppet master](https://docs.puppetlabs.com/puppet/latest/reference/services_master_webrick.html).
+
+## `GET /puppet/v3/static_file_content/<FILE-PATH>`
+
+(Introduced in Puppet Server 2.3.0)
+
+To retrieve a specific version of a file at a given environment and path, make an HTTP
+request to this endpoint with the required parameters. The `<FILE-PATH>` segment of the
+endpoint corresponds to the requested file's path, relative to the given environment's
+root directory, and is required.
+
+### Query parameters
+
+You must also pass two parameters in the GET request:
+
+-   `code_id`: a unique string provided by the [catalog][] that identifies which version
+    of the file to return.
+-   `environment`: the environment that contains the desired file.
+
+### Response
+
+A successful request to this endpoint returns an `HTTP 200` response code, and the
+contents of the specified file's requested version in the response body.
+
+-   400: Error; returned when any of the parameters are not provided.
+-   403: Error; returned when requesting a file that is not within a module's `files`
+directory.
+-   500: Error; returned when `code-content-command` is not configured on the server, or
+when a requested file or version is not present in a repository.
+
+#### Example response
+
+On a server at `localhost`, assume a versioned file is located at
+`/modules/example/files/data.txt` in the `production` environment. The version is
+identified by a `code_id` of
+`urn:puppet:code-id:1:67eb71417fbd736a619c8b5f9bfc0056ea8c53ca;production`, and that version of the file contains `Puppet test`.
+
+Given this command:
+
+```
+curl -i -k 'https://localhost:8140/puppet/v3/static_file_content/modules/example/files/data.txt?code_id=urn:puppet:code-id:1:67eb71417fbd736a619c8b5f9bfc0056ea8c53ca;production&environment=production'
+```
+
+Puppet Server should return:
+
+```
+HTTP/1.1 200 OK
+Date: Wed, 2 Mar 2016 23:44:08 GMT
+X-Puppet-Version: 4.4.0
+Content-Length: 4
+Server: Jetty(9.2.10.v20150310)
+
+Puppet test
+```
+
+### Notes
+
+When requesting a file from this endpoint, Puppet Server passes the values of the
+`file-path`, `code_id`, and `environment` parameters as arguments to the
+`code-content-command` script. If the script returns an exit code of 0, Puppet Server
+returns the script's standard output, which should be the contents of the requested
+version of the file.
+
+This endpoint returns an error (status 500) if the [`code-content-command`][] setting
+is not configured on Puppet Server.
+
+#### Authorization
+
+Puppet Server **always** authorizes requests made to the `static_file_content` API endpoint
+with the [Trapperkeeper-based `auth.conf` feature][auth.conf] introduced in Puppet Server
+2.2. This is different than most other Puppet master service-based endpoints, for which
+the authorization mechanism is controlled by the `use-legacy-auth-conf` setting in the
+`jruby-puppet` configuration section. The value of the `use-legacy-auth-conf` setting is
+ignored for the `static_file_content` API endpoint, and Puppet Server **never** uses the
+legacy `auth.conf` mechanism when authorizing requests. For more information about
+authorization options, see the [`auth.conf` documentation][auth.conf].

--- a/documentation/restarting.markdown
+++ b/documentation/restarting.markdown
@@ -4,51 +4,46 @@ title: "Puppet Server: Restarting the Server"
 canonical: "/puppetserver/latest/restarting.html"
 ---
 
-In Puppet Server 2.3.0, we added support for sending a HUP signal to the running
-Puppet Server process.  You can do this via the normal unix `kill` command; you'll
-just need to know the PID of the puppet server process.  So, a command like this
-should work:
+[logback.xml]: ./config_file_logbackxml.html
+[Hiera]: /hiera/latest/configuring.html
+[gems]: /puppetserver/latest/gems.html
+[core dependencies]: /puppet/latest/reference/about_agent.html#what-are-puppet-agent-and-puppet-server
+[environment]: /puppet/latest/reference/environments.html
+[environment caching]: /puppet/latest/reference/configuration.html#environmenttimeout
+
+Puppet Server 2.3.0 and newer support being restarted by sending a hangup signal, also known as [HUP or SIGHUP](https://en.wikipedia.org/wiki/SIGHUP), to the running Puppet Server process. You can send this signal to the Puppet Server process using the standard [`kill`](http://linux.die.net/man/1/kill) command.
+
+For example, this command sends a HUP signal to the process named `puppet-server`:
 
     kill -HUP `pgrep -f puppet-server`
 
-Sending a HUP will cause the server to stop and reload, gracefully, without actually
-terminating the JVM process.  This is generally *much* faster than restarting the
-entire process.
+The HUP signal stops Puppet Server and reloads it gracefully, without terminating the JVM process. This is generally *much* faster than completely stopping and restarting the process. This allows you to quickly load changes to your Puppet Server master, including configuration changes.
 
-There are several reasons you might wish to consider restarting / reloading the
-server; here we'll go over the most common ones and what your options are for each.
+## Changes applied after a full Server restart, SIGHUP, or JRuby pool flush
 
-## Change Logging Configuration
+You can make Puppet Server apply the following types of changes by either restarting the Puppet Server process, sending a HUP signal to the process, or sending a request to the [HTTP Admin API to flush the JRuby pool](./admin-api/v1/jruby-pool.html):
 
-Logging configuration changes, made in logback.xml, actually do not require a
-server reload or restart; they will be picked up automatically.  It may take
-a minute or so for this to happen.
-
-## Changes that require a full server restart
-
-### JVM Arguments
-
-If you need to change JVM command-line arguments (e.g. memory settings such as
--Xms/-Xmx, etc., most likely changed in your `/etc/sysconfig/puppetserver` file),
-you'll need to do a full restart of the process via the operating
-system's service framework.  e.g. `systemctl restart puppetserver`.
-
-## Changes that will take effect either via restart or HUP
-
-### Change Puppet Server config in conf.d
-
-To pick up any changes to the config files in Puppet Server's conf.d directory,
-you can either restart the process or send it a HUP.
-
-## Changes that will take affect after restart, HUP, or JRuby pool flush
-
-For any of the following types of changes, you can make them take effect by
-restarting the process, HUP'ing the process, or by making a request to the
-[HTTP Admin API to flush the JRuby pool](./admin-api/v1/jruby-pool.html).
-
-* Changes to your hiera.yaml file to change your hiera configuration
-* Installation or removal of gems for Puppet Server via `puppetserver gem`
-* Changes to the Ruby code for the core dependencies (Puppet, Facter, Hiera)
-* Changes to Puppet modules in an environment where you've enabled environment
-  caching (you can also achieve this by hitting the
+* Changes to your `hiera.yaml` file to change your [Hiera][] configuration
+* [Installation or removal of gems][gems] for Puppet Server via `puppetserver gem`
+* Changes to the Ruby code for Puppet's [core dependencies][], such as Puppet, Facter, and Hiera
+* Changes to Puppet modules in an [environment][] where you've enabled [environment
+  caching][] (you can also achieve this by hitting the
   [Admin API for flushing the environment cache](./admin-api/v1/environment-cache.html)
+
+## Changes applied after a full Server restart or SIGHUP
+
+### Puppet Server's configuration in `conf.d`
+
+To have Puppet Server apply changes to the [configuration files](./configuration.html) in its `conf.d` directory, you can either restart the process or send it a HUP signal.
+
+> **Note:** Changes to Puppet Server's [logging configuration in `logback.xml`][logback.xml] don't require a server reload or restart. Puppet Server recognizes and applies them automatically, though it can take a minute or so for this to happen.
+
+## Changes that require a full Server restart
+
+### JVM arguments
+
+If you restart Puppet Server by sending it a HUP signal, it doesn't apply changes to JVM command-line arguments (such as the JVM's [heap size settings](./tuning_guide.html#jvm-heap-size)) that are typically configured in your `/etc/sysconfig/puppetserver` file. You must restart the process via the operating system's service framework, for instance by using the `systemctl` or `service` commands.
+
+### `bootstrap.cfg`
+
+If you modify [`bootstrap.cfg`](./configuration.html#service-bootstrapping) to enable or disable Puppet Server's certificate authority (CA) service, you must restart the Puppet Server process via the operating system's service framework.

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -45,9 +45,24 @@ Puppet Server uses a Jetty-based web server embedded in the service's JVM proces
 
 The web server's settings can be modified in [`webserver.conf`](./config_file_webserver.html). You might need to edit this file if you're [using an external CA][external_ca] or running Puppet on a non-standard port.
 
+### Puppet Master Service
+
+Puppet Server includes a "master" service that provides the same basic functions
+as Rack and WEBrick masters, using the same input and output formats.  See
+[Puppet V3 HTTP API](/puppet/latest/reference/http_api/http_api_index.html#puppet-v3-http-api)
+for more information on the basic APIs.  Puppet Server's master service
+provides some additional APIs that the Rack and WEBrick Puppet masters do not.
+
+- For docs on the Puppet Server-specific APIs hosted by the master service, see:
+
+    - [The `environment_classes` endpoint](./puppet-api/v3/environment_classes.md)
+
 ### Certificate Authority Service
 
 Puppet Server includes a certificate authority (CA) service that accepts certificate signing requests (CSRs) from nodes, serves certificates and a certificate revocation list (CRL) to nodes, and optionally accepts commands to sign or revoke certificates. It provides these services at the same URLs used by Rack and WEBrick Puppet masters, using the same input and output formats. (The specific endpoints are `certificate`, `certificate_request`, `certificate_revocation_list`, and `certificate_status`.)
+
+See [CA V1 HTTP API](/puppet/latest/reference/http_api/http_api_index.html#ca-v1-http-api)
+for more information on these APIs.
 
 Signing and revoking certificates over the network is disallowed by default; you can use the [`auth.conf`](./config_file_auth.html) file (or deprecated [`ca.conf`](./config_file_ca.html) file) to let specific certificate owners issue commands.
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.7.0")
 (def tk-version "1.3.0")
-(def tk-jetty-version "1.5.2")
+(def tk-jetty-version "1.5.4")
 (def ks-version "1.3.0")
 (def ps-version "2.3.0-master-SNAPSHOT")
 

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -14,8 +14,21 @@ describe Puppet::Server::Execution do
       expect(result).to eq "hi\n"
     end
 
+    it "should return an instance of ProcessOutput for a command with args" do
+      result = Puppet::Server::Execution.execute("echo",  ["hi"])
+      expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+    end
+
+    it "should return the STDOUT of the process for a command with args" do
+      result = Puppet::Server::Execution.execute("echo", ["hi"])
+      expect(result).to eq "hi\n"
+    end
+
     it "should return the exit code of the process" do
       result = Puppet::Server::Execution.execute("echo hi")
+      expect(result.exitstatus).to eq 0
+
+      result = Puppet::Server::Execution.execute("echo",  ["hi"])
       expect(result.exitstatus).to eq 0
 
       result = Puppet::Server::Execution.execute("false")

--- a/src/clj/puppetlabs/puppetserver/cli/gem.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/gem.clj
@@ -2,10 +2,10 @@
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
-(defn run!
+(defn gem-run!
   [config args]
   (jruby-core/cli-run! config "gem" args))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run gem-run! args))

--- a/src/clj/puppetlabs/puppetserver/cli/irb.clj
+++ b/src/clj/puppetlabs/puppetserver/cli/irb.clj
@@ -2,10 +2,10 @@
   (:require [puppetlabs.puppetserver.cli.subcommand :as cli]
             [puppetlabs.services.jruby.jruby-puppet-core :as jruby-core]))
 
-(defn run!
+(defn irb-run!
   [config args]
   (jruby-core/cli-run! config "irb" args))
 
 (defn -main
   [& args]
-  (cli/run run! args))
+  (cli/run irb-run! args))

--- a/src/clj/puppetlabs/puppetserver/common.clj
+++ b/src/clj/puppetlabs/puppetserver/common.clj
@@ -1,0 +1,18 @@
+(ns puppetlabs.puppetserver.common
+  (:require [schema.core :as schema]))
+
+(def Environment
+  "Schema for environment names. Alphanumeric and _ only."
+  (schema/pred (comp not nil? (partial re-matches #"\w+")) "environment"))
+
+(def CodeId
+  "Validates that code-id contains only alpha-numerics and
+  '-', '_', ';', or ':'."
+  (schema/pred (comp not (partial re-find #"[^_\-:;a-zA-Z0-9]")) "code-id"))
+
+(def environment-validation-error-msg
+  (partial format "The environment must be purely alphanumeric, not '%s'"))
+
+(def code-id-validation-error-msg
+  (partial format "Invalid code-id '%s'. Must contain only alpha-numerics and '-', '_', ';', or ':'"))
+

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -2,7 +2,9 @@
   (:require [clojure.tools.logging :as log]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
-            [puppetlabs.services.jruby.jruby-puppet-service :as jruby]))
+            [puppetlabs.services.jruby.jruby-puppet-service :as jruby]
+            [schema.core :as schema]
+            [puppetlabs.puppetserver.common :as ps-common]))
 
 (defn throw-bad-request!
   "Throw a ::bad-request type slingshot error with the supplied message"
@@ -82,12 +84,9 @@
         (throw-bad-request!
          "An environment parameter must be specified")
 
-        (not (re-matches #"^\w+$" environment))
+        (not (nil? (schema/check ps-common/Environment environment)))
         (throw-bad-request!
-         (str
-          "The environment must be purely alphanumeric, not '"
-          environment
-          "'"))
+         (ps-common/environment-validation-error-msg environment))
 
         :else
         (handler request)))))

--- a/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_puppet_service.clj
@@ -73,19 +73,16 @@
     [this env-name]
     (let [{:keys [environment-class-info-tags pool-context]}
           (tk-services/service-context this)]
-      (swap! environment-class-info-tags
-             assoc
-             env-name
-             (core/environment-class-info-entry))
-      (core/mark-environment-expired! pool-context env-name)))
+      (core/mark-environment-expired! pool-context
+                                      env-name
+                                      environment-class-info-tags)))
 
   (mark-all-environments-expired!
     [this]
     (let [{:keys [environment-class-info-tags pool-context]}
           (tk-services/service-context this)]
-      (swap! environment-class-info-tags
-             #(ks/mapvals (fn [_] (core/environment-class-info-entry)) %))
-     (core/mark-all-environments-expired! pool-context)))
+      (core/mark-all-environments-expired! pool-context
+                                           environment-class-info-tags)))
 
   (get-environment-class-info
     [this jruby-instance env-name]
@@ -97,21 +94,23 @@
                                  (tk-services/service-context this))]
      (get-in @environment-class-info [env-name :tag])))
 
-  (get-environment-class-info-tag-last-updated
+  (get-environment-class-info-cache-generation-id!
    [this env-name]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
-     (get-in @environment-class-info [env-name :last-updated])))
+     (core/get-environment-class-info-cache-generation-id!
+      environment-class-info
+      env-name)))
 
   (set-environment-class-info-tag!
-   [this env-name tag last-update-before-tag-computed]
+   [this env-name tag cache-generation-id-before-tag-computed]
    (let [environment-class-info (:environment-class-info-tags
                                  (tk-services/service-context this))]
      (swap! environment-class-info
             core/environment-class-info-cache-updated-with-tag
             env-name
             tag
-            last-update-before-tag-computed)))
+            cache-generation-id-before-tag-computed)))
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_puppet.clj
@@ -31,16 +31,14 @@
   (mark-environment-expired!
     [this env-name]
     "Mark the specified environment expired, in all JRuby instances.  Resets
-    the cached class info for the environment's 'tag' to nil and 'last-updated'
-    value to the number of milliseconds between now and midnight, January 1,
-    1970 UTC.")
+    the cached class info for the environment's 'tag' to nil and increments the
+    'cache-generation-id' value.")
 
   (mark-all-environments-expired!
     [this]
     "Mark all cached environments expired, in all JRuby instances.  Resets the
     cached class info for all previously stored environment 'tags' to nil and
-    'last-updated' value to the number of milliseconds between now and midnight,
-    January 1, 1970 UTC.")
+    increments the 'cache-generation-id' value.")
 
   (get-environment-class-info
     [this jruby-instance env-name]
@@ -51,28 +49,27 @@
     "Get a tag for the latest class information parsed for a specific
     environment")
 
-  (get-environment-class-info-tag-last-updated
+  (get-environment-class-info-cache-generation-id!
     [this env-name]
-    "Get the 'time' that a tag was last set for a specific environment's
-    class info.  Return value will be 'nil' if the tag has not previously
-    been set for the environment or a schema/Int representing the
-    number of milliseconds between the last time the tag was updated for an
-    environment and midnight, January 1, 1970 UTC.")
+    "Get the current cache generation id for a specific environment's class
+    info.  If no entry for the environment had existed at the point this
+    function was called this function would, as a side effect, populate a new
+    entry for that environment into the cache.")
 
   (set-environment-class-info-tag!
-    [this env-name tag last-updated-before-tag-computed]
+    [this env-name tag cache-generation-id-before-tag-computed]
     "Set the tag computed for the latest class information parsed for a
-    specific environment.  last-updated-before-tag-computed should represent
-    what the client received for a 'get-environment-class-info-tag-last-updated'
-    call for the environment made before it started doing the work to parse
-    environment class info / compute the new tag.  If
-    last-updated-before-tag-computed equals the 'last-updated' value stored in
-    the cache for the environment, the new 'tag' will be stored for the
-    environment and the corresponding 'last-updated' value will be updated to
-    the number of milliseconds between now and midnight, January 1, 1970 UTC.
-    If last-updated-before-tag-computed is different than the 'last-updated'
-    value stored in the cache for the environment, the cache will remain
-    unchanged as a result of this call.")
+    specific environment.  cache-generation-id-before-tag-computed should
+    represent what the client received for a
+    'get-environment-class-info-cache-generation-id!' call for the environment
+    made before it started doing the work to parse environment class info /
+    compute the new tag.  If cache-generation-id-before-tag-computed equals
+    the 'cache-generation-id' value stored in the cache for the environment, the
+    new 'tag' will be stored for the environment and the corresponding
+    'cache-generation-id' value will be incremented.  If
+    cache-generation-id-before-tag-computed is different than the
+    'cache-generation-id' value stored in the cache for the environment, the
+    cache will remain unchanged as a result of this call.")
 
   (flush-jruby-pool!
     [this]

--- a/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
+++ b/src/clj/puppetlabs/services/request_handler/request_handler_core.clj
@@ -5,10 +5,12 @@
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
             [puppetlabs.ssl-utils.core :as ssl-utils]
+            [puppetlabs.puppetserver.common :as ps-common]
             [ring.util.codec :as ring-codec]
             [puppetlabs.trapperkeeper.authorization.ring :as ring-auth]
             [puppetlabs.puppetserver.ring.middleware.params :as pl-ring-params]
-            [puppetlabs.puppetserver.jruby-request :as jruby-request]))
+            [puppetlabs.puppetserver.jruby-request :as jruby-request]
+            [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Internal
@@ -258,6 +260,8 @@
   [current-code-id request]
   (if (:include-code-id? request)
     (let [env (jruby-request/get-environment-from-request request)]
+      (when-not (nil? (schema/check ps-common/Environment env))
+        (jruby-request/throw-bad-request! (ps-common/environment-validation-error-msg env)))
       (when-not env
         (jruby-request/throw-bad-request! "Environment is required in a catalog request."))
       (assoc-in request [:params "code_id"] (current-code-id env)))

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -5,7 +5,8 @@
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
-            [puppetlabs.kitchensink.core :as ks]))
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.puppetserver.common :as ps-common]))
 
 (def test-resources-dir
   (ks/absolute-path "./dev-resources/puppetlabs/general_puppet/general_puppet_int_test"))
@@ -19,6 +20,21 @@
                (fs/file test-resources-dir "puppet.conf")))
 
 (def num-jrubies 1)
+
+(deftest ^:integration test-simple-external-command-execution
+  (testing "puppet functions can call external commands successfully that are just one argument"
+    ; The generate puppet function runs a fully qualified command with arguments.
+    ; This function calls into Puppet::Util::Execution.execute(), which calls into
+    ; our shell-utils code via Puppet::Util::ExecutionStub which we call in
+    ; Puppet::Server::Execution.
+    (testutils/write-site-pp-file
+     (format "$a = generate('%s'); notify {$a:}" (script-path "echo_foo")))
+    (bootstrap/with-puppetserver-running
+     app {:jruby-puppet
+          {:max-active-instances num-jrubies}}
+     (testing "calling generate successfully executes shell command"
+       (let [catalog (testutils/get-catalog)]
+         (is (testutils/catalog-contains? catalog "Notify" "foo\n")))))))
 
 (deftest ^:integration test-external-command-execution
   (testing "puppet functions can call external commands successfully"
@@ -36,33 +52,71 @@
        (let [catalog (testutils/get-catalog)]
          (is (testutils/catalog-contains? catalog "Notify" "this command echoes a thing\n")))))))
 
-(deftest ^:integration code-id-request-test-get-catalog
-  (testing "code id is added to the request body for catalog requests via get"
-    ; As we have set code-id-command to echo, the code id will
-    ; be the result of running `echo $environment`, which will
-    ; be production here.
+(deftest ^:integration test-complicated-external-command-execution
+  (testing "puppet functions can call more complicated external commands successfully"
+    ; The generate puppet function runs a fully qualified command with arguments.
+    ; This function calls into Puppet::Util::Execution.execute(), which calls into
+    ; our shell-utils code via Puppet::Util::ExecutionStub which we call in
+    ; Puppet::Server::Execution.
+    (testutils/write-site-pp-file
+     (format "$a = generate('%s', '-c', \"echo foo\"); notify {$a: }"
+             "/bin/sh"))
     (bootstrap/with-puppetserver-running
-     app {:jruby-puppet
-          {:max-active-instances num-jrubies}
-          :versioned-code
-          {:code-id-command (script-path "echo")
-           :code-content-command (script-path "echo")}}
-     (let [catalog (testutils/get-catalog)]
-       (is (= "production" (get catalog "code_id")))))))
+      app {:jruby-puppet
+           {:max-active-instances num-jrubies}}
+      (testing "calling generate successfully executes shell command"
+        (let [catalog (testutils/get-catalog)]
+          (is (testutils/catalog-contains? catalog "Notify" "foo\n")))))))
+
+(deftest ^:integration code-id-request-test-get-catalog
+  (testing "when making catalog requests with get"
+    (bootstrap/with-puppetserver-running
+      app {:jruby-puppet
+           {:max-active-instances num-jrubies}
+           :versioned-code
+           {:code-id-command (script-path "echo")
+            :code-content-command (script-path "echo")}}
+
+      (testing "and environment is valid code id is injected"
+        (let [catalog (testutils/get-catalog)]
+          ;; As we have set code-id-command to echo, the code id will
+          ;; be the result of running `echo $environment`, which will
+          ;; be production here.
+          (is (= "production" (get catalog "code_id")))))
+
+      (testing "and environment is invalid 400 is returned"
+        (logging/with-test-logging
+          (let [response (http-client/get
+                          "https://localhost:8140/puppet/v3/catalog/localhost?environment=production;cat"
+                          testutils/catalog-request-options)]
+            (is (= 400 (:status response)))
+            (is (= (ps-common/environment-validation-error-msg "production;cat")
+                   (:body response)))))))))
 
 (deftest ^:integration code-id-request-test-post-catalog
-  (testing "code id is added to the request body for catalog requests via post"
-    ; As we have set code-id-command to echo, the code id will
-    ; be the result of running `echo $environment`, which will
-    ; be production here.
+  (testing "when making catalog requests with post"
     (bootstrap/with-puppetserver-running
      app {:jruby-puppet
           {:max-active-instances num-jrubies}
           :versioned-code
           {:code-id-command (script-path "echo")
            :code-content-command (script-path "echo")}}
-     (let [catalog (testutils/post-catalog)]
-       (is (= "production" (get catalog "code_id")))))))
+      (testing "and environment is valid code id is injected"
+        (let [catalog (testutils/post-catalog)]
+          ;; As we have set code-id-command to echo, the code id will
+          ;; be the result of running `echo $environment`, which will
+          ;; be production here.
+          (is (= "production" (get catalog "code_id")))))
+      (testing "and environment is invalid the request fails"
+        (logging/with-test-logging
+          (let [response (http-client/post
+                          "https://localhost:8140/puppet/v3/catalog/localhost"
+                          (assoc-in (assoc testutils/catalog-request-options
+                                           :body "environment=production;cat")
+                                    [:headers "Content-Type"] "application/x-www-form-urlencoded"))]
+            (is (= 400 (:status response)))
+            (is (= (ps-common/environment-validation-error-msg "production;cat")
+                   (:body response)))))))))
 
 (deftest ^:integration code-id-request-test-non-zero-exit
     (testing "catalog request fails if code-id-command returns a non-zero exit code"
@@ -110,7 +164,45 @@
         (let [response (testutils/get-static-file-content "modules/foo/files/bar.txt?code_id=foobar&environment=test")]
           (is (= 200 (:status response)))
           (is (= "test foobar modules/foo/files/bar.txt\n" (:body response)))))
-      (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
+      (testing (str "the /static_file_content endpoint successfully streams file content "
+                    "from directories other than /modules")
+        (let [response (testutils/get-static-file-content "site/foo/files/bar.txt?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)))
+          (is (= "test foobar site/foo/files/bar.txt\n" (:body response))))
+        (let [response (testutils/get-static-file-content "dist/foo/files/bar.txt?code_id=foobar&environment=test")]
+          (is (= 200 (:status response)))
+          (is (= "test foobar dist/foo/files/bar.txt\n" (:body response)))))
+       (testing "the /static_file_content endpoint validates environment"
+         (doseq [[env-encoded env-decoded]
+                 [["hi%23cat" "hi#cat"]
+                  ["hi%20cat" "hi cat"]
+                  ["%20hicat" " hicat"]
+                  ["hi%3Bcat" "hi;cat"]
+                  ["hicat%20" "hicat "]]]
+           (let [response (testutils/get-static-file-content
+                           (format "modules/foo/files/bar.txt?code_id=foobar&environment=%s"
+                                   env-encoded))]
+             (is (= 400 (:status response)))
+             (is (= (ps-common/environment-validation-error-msg env-decoded)
+                    (:body response))))))
+
+       (testing "the /static_file_content endpoint validates code-id"
+         (doseq [[code-id-encoded code-id-decoded]
+                 [["hi%23cat" "hi#cat"]
+                  ["hi%20cat" "hi cat"]
+                  ["%20hicat" " hicat"]
+                  ["hicat%20" "hicat "]
+                  ["hi%3B%2Fusr%2Fbin%2Fcat" "hi;/usr/bin/cat"]]]
+           (let [response (testutils/get-static-file-content
+                           (format "modules/foo/files/bar.txt?code_id=%s&environment=test"
+                                   code-id-encoded))]
+             (is (= 400 (:status response)))
+             (is (= (ps-common/code-id-validation-error-msg code-id-decoded)
+                    (:body response))))))
+
+
+
+       (let [error-message "Error: A /static_file_content request requires an environment, a code-id, and a file-path"]
         (testing "the /static_file_content endpoint returns an error if code_id is not provided"
           (let [response (testutils/get-static-file-content "modules/foo/files/bar.txt?environment=test")]
             (is (= 400 (:status response)))

--- a/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
+++ b/test/integration/puppetlabs/services/master/environment_classes_int_test.clj
@@ -62,15 +62,18 @@
   ([env-name if-none-match]
    (let [opts (if if-none-match
                 {:headers {"If-None-Match" if-none-match}})]
-     (http-client/get
-      (str "https://localhost:8140/puppet/v3/"
-           "environment_classes?"
-           "environment="
-           env-name)
-      (merge
-       testutils/ssl-request-options
-       {:as :text}
-       opts)))))
+     (try
+       (http-client/get
+        (str "https://localhost:8140/puppet/v3/"
+             "environment_classes?"
+             "environment="
+             env-name)
+        (merge
+         testutils/ssl-request-options
+         {:as :text}
+         opts))
+       (catch Exception e
+         (throw (Exception. "environment_classes http get failed" e)))))))
 
 (defn purge-all-env-caches
   []
@@ -132,422 +135,432 @@
                 (response->class-info-map response))))))))
 
 (deftest ^:integration environment-classes-integration-cache-enabled-test
-  (bootstrap/with-puppetserver-running app
-   {:jruby-puppet {:max-active-instances 1
-                   :environment-class-cache-enabled true}}
-   (let [foo-file (testutils/write-pp-file
-                   "class foo (String $foo_1 = \"is foo\"){}"
-                   "foo")
-         bar-file (testutils/write-pp-file
-                   "class foo::bar (Integer $foo_2 = 3){}"
-                   "bar")
-         expected-initial-response {
-                                    "files"
-                                    [
-                                     {"path" bar-file
-                                      "classes"
-                                      [
-                                       {
-                                        "name" "foo::bar"
-                                        "params"
+  (let [debug-log "./target/environment-classes-integration-cache-enabled.log"]
+    (fs/delete debug-log)
+    (bootstrap/with-puppetserver-running app
+     {:global {:logging-config
+               (str "./dev-resources/puppetlabs/services/"
+                    "master/environment_classes_int_test/"
+                    "logback-environment-classes-integration-cache-enabled-test.xml")}
+      :jruby-puppet {:max-active-instances 1
+                     :environment-class-cache-enabled true}}
+     (try
+       (let [foo-file (testutils/write-pp-file
+                       "class foo (String $foo_1 = \"is foo\"){}"
+                       "foo")
+             bar-file (testutils/write-pp-file
+                       "class foo::bar (Integer $foo_2 = 3){}"
+                       "bar")
+             expected-initial-response {
+                                        "files"
                                         [
-                                         {"name" "foo_2",
-                                          "type" "Integer",
-                                          "default_literal" 3,
-                                          "default_source" "3"}]}]}
-                                     {"path" foo-file,
-                                      "classes"
-                                      [
-                                       {
-                                        "name" "foo"
-                                        "params"
-                                        [
-                                         {"name" "foo_1",
-                                          "type" "String",
-                                          "default_literal" "is foo",
-                                          "default_source" "\"is foo\""}]}]}]
-                                    "name" "production"}
-         initial-response (get-env-classes "production")
-         initial-etag (response-etag initial-response)]
-     (testing "initial fetch of environment_classes info is good"
-       (is (= 200 (:status initial-response))
-           (str
-            "unexpected status code for initial response, response: "
-            (ks/pprint-to-string initial-response)))
-       (is (not (nil? initial-etag))
-           "no etag found for initial response")
-       (is (= expected-initial-response
-              (response->class-info-map initial-response))
-           "unexpected body for initial response"))
-     (testing "etag not updated when code has not changed"
-       (let [response (get-env-classes "production")]
-         (is (= 200 (:status response))
-             "unexpected status code for response following no code change")
-         (is (= initial-etag (response-etag response))
-             "etag changed even though code did not")
-         (is (= expected-initial-response
-                (response->class-info-map response))
-             "unexpected body for response")))
-     (testing (str "HTTP 304 (not modified) returned when request "
-                   "roundtrips last etag and code has not changed")
-       (let [response (get-env-classes "production" initial-etag)]
-         (is (= 304 (:status response))
-             (str
-              "unexpected status code for response for no code change and "
-              "original etag roundtripped"))
-         (is (= initial-etag (response-etag response))
-             "etag changed even though code did not")
-         (is (empty? (:body response))
-             "unexpected body for response")))
-     (testing (str "SERVER-1153 - HTTP 304 (not modified) returned when "
-                   "request roundtrips last etag with '--gzip' suffix and "
-                   "code has not changed")
-       (let [etag-with-gzip-suffix (if (.endsWith initial-etag "--gzip")
-                                     initial-etag
-                                     (str initial-etag "--gzip"))
-             response (get-env-classes "production"
-                                       etag-with-gzip-suffix)]
-         (is (= 304 (:status response))
-             (str
-              "unexpected status code for response for no code change and "
-              "etag with '--gzip' suffix roundtripped"))
-         (is (= initial-etag (response-etag response))
-             "etag changed even though code did not")
-         (is (empty? (:body response))
-             "unexpected body for response")))
-     (testing (str "environment_classes fetch without if-none-match "
-                   "header includes latest info after code update")
-       (testutils/write-pp-file
-        (str "class foo (Hash[String, Integer] $foo_hash = {"
-             " foo_1 => 1, foo_2 => 2 }){}")
-        "foo")
-       (testutils/write-pp-file "" "bar")
-       (let [baz-file (testutils/write-pp-file
-                       (str "class foo::baz (String $baz_1 = 'the baz',\n"
-                            " Array[String] $baz_arr = ['one', 'two', "
-                            "'three']){}\n"
-                            "class foo::morebaz ($baz) {}")
-                       "baz")
-             borked-file (testutils/write-pp-file "borked manifest" "borked")
-             _ (purge-all-env-caches)
-             response (get-env-classes "production")]
-         (is (= 200 (:status response))
-             (str
-              "unexpected status code for response following code change,"
-              "response: "
-              (ks/pprint-to-string response)))
-         (is (not= initial-etag (response-etag response))
-             "etag did not change even though code did")
-         (is (= {"name" "production",
-                 "files" [
-                          {"path" bar-file
-                           "classes" []}
-                          {"path" baz-file
-                           "classes" [{
-                                       "name" "foo::baz"
-                                       "params" [
-                                                 {"name" "baz_1",
-                                                  "type" "String",
-                                                  "default_literal" "the baz",
-                                                  "default_source" "'the baz'"}
-                                                 {"name" "baz_arr"
-                                                  "type" "Array[String]"
-                                                  "default_literal"
-                                                  ["one" "two" "three"]
-                                                  "default_source"
-                                                  "['one', 'two', 'three']"}]}
-                                      {
-                                       "name" "foo::morebaz"
-                                       "params" [
-                                                 {"name" "baz"}]}]}
-                          {"path" borked-file
-                           "error" (str "This Name has no effect. A value "
-                                        "was produced and then forgotten ("
-                                        "one or more preceding expressions "
-                                        "may have the wrong form) at "
-                                        borked-file
-                                        ":1:1")}
-                          {"path" foo-file,
-                           "classes" [{
-                                       "name" "foo"
-                                       "params" [
-                                                 {"name" "foo_hash",
-                                                  "type"
-                                                  "Hash[String, Integer]",
-                                                  "default_literal"
-                                                  {"foo_1" 1
-                                                   "foo_2" 2},
-                                                  "default_source"
-                                                  (str
-                                                   "{ foo_1 => 1, "
-                                                   "foo_2 => 2 }")}]}]}]}
-                (response->class-info-map response))
-             "unexpected body following code change")))
-     (testing "environment class cache invalidation for one environment"
-       ;; This test is about ensuring that when the environment-cache
-       ;; endpoint is hit for a single environment that only that the
-       ;; environment class info cached for that environment - but not the
-       ;; info cached for other environments - is invalidated, meaning that
-       ;; the next request for class info for that environment will get fresh
-       ;; data.
-       ;;
-       ;; The test has the following basic steps:
-       ;;
-       ;; 1) Purge the current environment files on disk and hit the
-       ;;    environment-cache endpoint to flush the cache for all
-       ;;    environments, basically to ensure nothing is left around from
-       ;;    other tests.
-       ;; 2) Populate code for the 'test' and 'production' environments and
-       ;;    see that environment_classes queries return the right info for
-       ;;    them.
-       ;; 3) Do one more environment_classes query for each environment,
-       ;;    using the etag from the initial queries, to ensure that a 304
-       ;;    (Not Modified) is returned.
-       ;; 4) Change code on disk for both the 'test' and 'production'
-       ;;    environments.
-       ;; 5) Hit the environment-cache endpoint for the 'production'
-       ;;    environment (but not for the 'test' environment).
-       ;; 6) Do two more environment_classes queries for the 'test' and
-       ;;    'production' environments using the etags from the initial
-       ;;    queries.  Confirm that the information reflects the latest data on
-       ;;    disk for the 'production' environment but still reflects the old
-       ;;    data for the 'test' environment - expected, in this case, because
-       ;;    the 'test' environment was not flushed.
-       (purge-env-dir)
-       (purge-all-env-caches)
-       (let [prod-file (testutils/write-pp-file "class oneprod {}"
-                                                "somemod"
-                                                "prod"
-                                                "production")
-             test-file (testutils/write-pp-file "class onetest {}"
-                                                "somemod"
-                                                "test"
-                                                "test")
-             production-response-initial (get-env-classes "production")
-             production-etag-initial (response-etag production-response-initial)
-             test-response-initial (get-env-classes "test")
-             test-etag-initial (response-etag test-response-initial)]
-         (is (= 200 (:status production-response-initial))
-             (str
-              "unexpected status code for initial production response"
-              "response: "
-              (ks/pprint-to-string production-response-initial)))
-         (is (not (nil? production-etag-initial))
-             "no etag returned for production response")
-         (is (= {"name" "production",
-                 "files" [ {"path" prod-file,
-                            "classes" [{"name" "oneprod", "params" []}]}]}
-                (response->class-info-map production-response-initial))
-             "unexpected body for production response")
-         (is (= 200 (:status test-response-initial))
-             (str
-              "unexpected status code for initial test response"
-              "response: "
-              (ks/pprint-to-string test-response-initial)))
-         (is (not (nil? test-etag-initial))
-             "no etag returned for test response")
-         (is (= {"name" "test",
-                 "files" [ {"path" test-file,
-                            "classes" [{"name" "onetest", "params" []}]}]}
-                (response->class-info-map test-response-initial))
-             "unexpected body for test response")
-
-         (testutils/write-pp-file "class oneflushprod {}"
-                                  "somemod"
-                                  "prod"
-                                  "production")
-         (testutils/write-pp-file "class oneflushtest {}"
-                                  "somemod"
-                                  "test"
-                                  "test")
-
-         (let [production-response-before-flush (get-env-classes
-                                                 "production"
-                                                 production-etag-initial)
-               test-response-before-flush (get-env-classes
-                                           "test"
-                                           test-etag-initial)]
-           (is (= 304 (:status production-response-before-flush))
+                                         {"path" bar-file
+                                          "classes"
+                                          [
+                                           {
+                                            "name" "foo::bar"
+                                            "params"
+                                            [
+                                             {"name" "foo_2",
+                                              "type" "Integer",
+                                              "default_literal" 3,
+                                              "default_source" "3"}]}]}
+                                         {"path" foo-file,
+                                          "classes"
+                                          [
+                                           {
+                                            "name" "foo"
+                                            "params"
+                                            [
+                                             {"name" "foo_1",
+                                              "type" "String",
+                                              "default_literal" "is foo",
+                                              "default_source" "\"is foo\""}]}]}]
+                                        "name" "production"}
+             initial-response (get-env-classes "production")
+             initial-etag (response-etag initial-response)]
+         (testing "initial fetch of environment_classes info is good"
+           (is (= 200 (:status initial-response))
                (str
-                "unexpected status code for prod response after code change "
-                "but before flush"))
-           (is (= production-etag-initial (response-etag
-                                           production-response-before-flush))
-               "unexpected etag change when no production environment change")
-           (is (empty? (:body production-response-before-flush))
-               "unexpected body for production response")
-           (is (= 304 (:status test-response-before-flush))
-               (str
-                "unexpected status code for test response after code change "
-                "but before flush"))
-           (is (= test-etag-initial (response-etag
-                                     test-response-before-flush))
-               "unexpected etag change when no test environment change")
-           (is (empty? (:body test-response-before-flush))
-               "unexpected body for test response")
-
-           (purge-env-cache "production")
-
-           (let [production-response-after-prod-flush (get-env-classes
-                                                       "production"
-                                                       production-etag-initial)
-                 production-etag-after-prod-flush (response-etag
-                                                   production-response-after-prod-flush)
-                 test-response-after-prod-flush (get-env-classes
-                                                 "test"
-                                                 test-etag-initial)]
-             (is (= 200 (:status production-response-after-prod-flush))
+                "unexpected status code for initial response, response: "
+                (ks/pprint-to-string initial-response)))
+           (is (not (nil? initial-etag))
+               "no etag found for initial response")
+           (is (= expected-initial-response
+                  (response->class-info-map initial-response))
+               "unexpected body for initial response"))
+         (testing "etag not updated when code has not changed"
+           (let [response (get-env-classes "production")]
+             (is (= 200 (:status response))
+                 "unexpected status code for response following no code change")
+             (is (= initial-etag (response-etag response))
+                 "etag changed even though code did not")
+             (is (= expected-initial-response
+                    (response->class-info-map response))
+                 "unexpected body for response")))
+         (testing (str "HTTP 304 (not modified) returned when request "
+                       "roundtrips last etag and code has not changed")
+           (let [response (get-env-classes "production" initial-etag)]
+             (is (= 304 (:status response))
                  (str
-                  "unexpected status code for prod response after code change "
-                  "and prod flush"))
-             (is (not (nil? production-etag-after-prod-flush))
-                 "no etag returned for production response")
-             (is (not= production-etag-initial
-                       production-etag-after-prod-flush)
+                  "unexpected status code for response for no code change and "
+                  "original etag roundtripped"))
+             (is (= initial-etag (response-etag response))
+                 "etag changed even though code did not")
+             (is (empty? (:body response))
+                 "unexpected body for response")))
+         (testing (str "SERVER-1153 - HTTP 304 (not modified) returned when "
+                       "request roundtrips last etag with '--gzip' suffix and "
+                       "code has not changed")
+           (let [etag-with-gzip-suffix (if (.endsWith initial-etag "--gzip")
+                                         initial-etag
+                                         (str initial-etag "--gzip"))
+                 response (get-env-classes "production"
+                                           etag-with-gzip-suffix)]
+             (is (= 304 (:status response))
                  (str
-                  "etag unexpectedly stayed the same even though "
-                  "the production environment changed"))
+                  "unexpected status code for response for no code change and "
+                  "etag with '--gzip' suffix roundtripped"))
+             (is (= initial-etag (response-etag response))
+                 "etag changed even though code did not")
+             (is (empty? (:body response))
+                 "unexpected body for response")))
+         (testing (str "environment_classes fetch without if-none-match "
+                       "header includes latest info after code update")
+           (testutils/write-pp-file
+            (str "class foo (Hash[String, Integer] $foo_hash = {"
+                 " foo_1 => 1, foo_2 => 2 }){}")
+            "foo")
+           (testutils/write-pp-file "" "bar")
+           (let [baz-file (testutils/write-pp-file
+                           (str "class foo::baz (String $baz_1 = 'the baz',\n"
+                                " Array[String] $baz_arr = ['one', 'two', "
+                                "'three']){}\n"
+                                "class foo::morebaz ($baz) {}")
+                           "baz")
+                 borked-file (testutils/write-pp-file "borked manifest" "borked")
+                 _ (purge-all-env-caches)
+                 response (get-env-classes "production")]
+             (is (= 200 (:status response))
+                 (str
+                  "unexpected status code for response following code change,"
+                  "response: "
+                  (ks/pprint-to-string response)))
+             (is (not= initial-etag (response-etag response))
+                 "etag did not change even though code did")
              (is (= {"name" "production",
-                     "files" [{"path" prod-file
-                               "classes" [{"name" "oneflushprod",
-                                           "params" []}]}]}
-                    (response->class-info-map
-                     production-response-after-prod-flush))
-                 "unexpected body for production response")
-             (is (= 304 (:status test-response-after-prod-flush))
+                     "files" [
+                              {"path" bar-file
+                               "classes" []}
+                              {"path" baz-file
+                               "classes" [{
+                                           "name" "foo::baz"
+                                           "params" [
+                                                     {"name" "baz_1",
+                                                      "type" "String",
+                                                      "default_literal" "the baz",
+                                                      "default_source" "'the baz'"}
+                                                     {"name" "baz_arr"
+                                                      "type" "Array[String]"
+                                                      "default_literal"
+                                                      ["one" "two" "three"]
+                                                      "default_source"
+                                                      "['one', 'two', 'three']"}]}
+                                          {
+                                           "name" "foo::morebaz"
+                                           "params" [
+                                                     {"name" "baz"}]}]}
+                              {"path" borked-file
+                               "error" (str "This Name has no effect. A value "
+                                            "was produced and then forgotten ("
+                                            "one or more preceding expressions "
+                                            "may have the wrong form) at "
+                                            borked-file
+                                            ":1:1")}
+                              {"path" foo-file,
+                               "classes" [{
+                                           "name" "foo"
+                                           "params" [
+                                                     {"name" "foo_hash",
+                                                      "type"
+                                                      "Hash[String, Integer]",
+                                                      "default_literal"
+                                                      {"foo_1" 1
+                                                       "foo_2" 2},
+                                                      "default_source"
+                                                      (str
+                                                       "{ foo_1 => 1, "
+                                                       "foo_2 => 2 }")}]}]}]}
+                    (response->class-info-map response))
+                 "unexpected body following code change")))
+         (testing "environment class cache invalidation for one environment"
+           ;; This test is about ensuring that when the environment-cache
+           ;; endpoint is hit for a single environment that only that the
+           ;; environment class info cached for that environment - but not the
+           ;; info cached for other environments - is invalidated, meaning that
+           ;; the next request for class info for that environment will get fresh
+           ;; data.
+           ;;
+           ;; The test has the following basic steps:
+           ;;
+           ;; 1) Purge the current environment files on disk and hit the
+           ;;    environment-cache endpoint to flush the cache for all
+           ;;    environments, basically to ensure nothing is left around from
+           ;;    other tests.
+           ;; 2) Populate code for the 'test' and 'production' environments and
+           ;;    see that environment_classes queries return the right info for
+           ;;    them.
+           ;; 3) Do one more environment_classes query for each environment,
+           ;;    using the etag from the initial queries, to ensure that a 304
+           ;;    (Not Modified) is returned.
+           ;; 4) Change code on disk for both the 'test' and 'production'
+           ;;    environments.
+           ;; 5) Hit the environment-cache endpoint for the 'production'
+           ;;    environment (but not for the 'test' environment).
+           ;; 6) Do two more environment_classes queries for the 'test' and
+           ;;    'production' environments using the etags from the initial
+           ;;    queries.  Confirm that the information reflects the latest data on
+           ;;    disk for the 'production' environment but still reflects the old
+           ;;    data for the 'test' environment - expected, in this case, because
+           ;;    the 'test' environment was not flushed.
+           (purge-env-dir)
+           (purge-all-env-caches)
+           (let [prod-file (testutils/write-pp-file "class oneprod {}"
+                                                    "somemod"
+                                                    "prod"
+                                                    "production")
+                 test-file (testutils/write-pp-file "class onetest {}"
+                                                    "somemod"
+                                                    "test"
+                                                    "test")
+                 production-response-initial (get-env-classes "production")
+                 production-etag-initial (response-etag production-response-initial)
+                 test-response-initial (get-env-classes "test")
+                 test-etag-initial (response-etag test-response-initial)]
+             (is (= 200 (:status production-response-initial))
                  (str
-                  "unexpected status code for test response after code change "
-                  "but test environment not invalidated"))
-             (is (= test-etag-initial (response-etag
-                                       test-response-after-prod-flush))
-                 "unexpected etag change when test environment not invalidated")
-             (is (empty? (:body test-response-after-prod-flush))
-                 "unexpected body for test response")))))
-     (testing "environment class cache invalidation for all environments"
-       ;; This test is about ensuring that when the environment-cache
-       ;; endpoint is hit with no environment parameter that any previously
-       ;; cached environment class info is invalidated, meaning that
-       ;; the next request for class info for all environments will get fresh
-       ;; data.
-       ;;
-       ;; To eliminate some of the redundancy between tests, this test doesn't
-       ;; repeat the intermediate step of checking to see that the first two
-       ;; environment queries were cached - 304 (Not Modified) returns -
-       ;; between the first set of environment_classes queries and the second
-       ;; set, done after the code on disk for both environments has changed.
-       ;;
-       ;; The test has the following basic steps:
-       ;;
-       ;; 1) Purge the current environment files on disk and hit the
-       ;;    environment-cache endpoint to flush the cache for all
-       ;;    environments, basically to ensure nothing is left around from
-       ;;    other tests.
-       ;; 2) Populate code for the 'test' and 'production' environments and
-       ;;    see that environment_classes queries return the right info for
-       ;;    them.
-       ;; 3) Change code on disk for both the 'test' and 'production'
-       ;;    environments.
-       ;; 4) Hit the environment-cache endpoint with no environment
-       ;;    parameter, expected to have the effect of flushing the cache for
-       ;;    all environments.
-       ;; 5) Do two more environment_classes queries for the 'test' and
-       ;;    'production' environments with the corresponding etags returned
-       ;;    from the first two queries.  Confirm that the information
-       ;;    reflects the latest data on disk for both environments.
-       (purge-env-dir)
-       (purge-all-env-caches)
-       (let [prod-file (testutils/write-pp-file "class allprod {}"
-                                                "somemod"
-                                                "prod"
-                                                "production")
-             test-file (testutils/write-pp-file "class alltest {}"
-                                                "somemod"
-                                                "test"
-                                                "test")
-             production-response-initial (get-env-classes "production")
-             production-etag-initial (response-etag production-response-initial)
-             test-response-initial (get-env-classes "test")
-             test-etag-initial (response-etag test-response-initial)]
-         (is (= 200 (:status production-response-initial))
-             (str
-              "unexpected status code for initial production response"
-              "response: "
-              (ks/pprint-to-string production-response-initial)))
-         (is (not (nil? production-etag-initial))
-             "no etag returned for production response")
-         (is (= {"name" "production",
-                 "files" [ {"path" prod-file,
-                            "classes" [{"name" "allprod",
-                                        "params" []}]}]}
-                (response->class-info-map production-response-initial))
-             "unexpected body for production response")
-         (is (= 200 (:status test-response-initial))
-             (str
-              "unexpected status code for initial test response"
-              "response: "
-              (ks/pprint-to-string test-response-initial)))
-         (is (not (nil? test-etag-initial))
-             "no etag returned for test response")
-         (is (= {"name" "test",
-                 "files" [ {"path" test-file
-                            "classes" [{"name" "alltest"
-                                        "params" []}]}]}
-                (response->class-info-map test-response-initial))
-             "unexpected body for test response")
+                  "unexpected status code for initial production response"
+                  "response: "
+                  (ks/pprint-to-string production-response-initial)))
+             (is (not (nil? production-etag-initial))
+                 "no etag returned for production response")
+             (is (= {"name" "production",
+                     "files" [{"path" prod-file,
+                               "classes" [{"name" "oneprod", "params" []}]}]}
+                    (response->class-info-map production-response-initial))
+                 "unexpected body for production response")
+             (is (= 200 (:status test-response-initial))
+                 (str
+                  "unexpected status code for initial test response"
+                  "response: "
+                  (ks/pprint-to-string test-response-initial)))
+             (is (not (nil? test-etag-initial))
+                 "no etag returned for test response")
+             (is (= {"name" "test",
+                     "files" [{"path" test-file,
+                               "classes" [{"name" "onetest", "params" []}]}]}
+                    (response->class-info-map test-response-initial))
+                 "unexpected body for test response")
 
-         (testutils/write-pp-file "class allflushprod {}"
-                                  "somemod"
-                                  "prod"
-                                  "production")
-         (testutils/write-pp-file "class allflushtest {}"
-                                  "somemod"
-                                  "test"
-                                  "test")
-         (purge-all-env-caches)
+             (testutils/write-pp-file "class oneflushprod {}"
+                                      "somemod"
+                                      "prod"
+                                      "production")
+             (testutils/write-pp-file "class oneflushtest {}"
+                                      "somemod"
+                                      "test"
+                                      "test")
 
-         (let [production-response-after-all-flush (get-env-classes
+             (let [production-response-before-flush (get-env-classes
                                                      "production"
                                                      production-etag-initial)
-               production-etag-after-all-flush (response-etag
-                                                production-response-after-all-flush)]
-           (is (= 200 (:status production-response-after-all-flush))
-               (str
-                "unexpected status code for prod response after code change "
-                "and all environment flush"))
-           (is (not (nil? production-etag-after-all-flush))
-               "no etag returned for production response")
-           (is (not= production-etag-initial production-etag-after-all-flush)
-               (str
-                "etag unexpectedly stayed the same even though "
-                "the production environment changed"))
-           (is (= {"name" "production",
-                   "files" [{"path" prod-file
-                             "classes" [{"name" "allflushprod", "params" []}]}]}
-                  (response->class-info-map
-                   production-response-after-all-flush))
-               "unexpected body for production response"))
+                   test-response-before-flush (get-env-classes
+                                               "test"
+                                               test-etag-initial)]
+               (is (= 304 (:status production-response-before-flush))
+                   (str
+                    "unexpected status code for prod response after code change "
+                    "but before flush"))
+               (is (= production-etag-initial (response-etag
+                                               production-response-before-flush))
+                   "unexpected etag change when no production environment change")
+               (is (empty? (:body production-response-before-flush))
+                   "unexpected body for production response")
+               (is (= 304 (:status test-response-before-flush))
+                   (str
+                    "unexpected status code for test response after code change "
+                    "but before flush"))
+               (is (= test-etag-initial (response-etag
+                                         test-response-before-flush))
+                   "unexpected etag change when no test environment change")
+               (is (empty? (:body test-response-before-flush))
+                   "unexpected body for test response")
 
-         (let [test-response-after-all-flush (get-env-classes
-                                              "test"
-                                              test-etag-initial)
-               test-etag-after-all-flush (response-etag
-                                          test-response-after-all-flush)]
-           (is (= 200 (:status test-response-after-all-flush))
-               (str
-                "unexpected status code for test response after code change "
-                "and all environment flush"))
-           (is (not (nil? test-etag-after-all-flush))
-               "no etag returned for test response")
-           (is (not= test-etag-initial test-etag-after-all-flush)
-               (str
-                "etag unexpectedly stayed the same even though "
-                "the test environment changed"))
-           (is (= {"name" "test",
-                   "files" [{"path" test-file
-                             "classes" [{"name" "allflushtest", "params" []}]}]}
-                  (response->class-info-map
-                   test-response-after-all-flush))
-               "unexpected body for test response")))))))
+               (purge-env-cache "production")
+
+               (let [production-response-after-prod-flush (get-env-classes
+                                                           "production"
+                                                           production-etag-initial)
+                     production-etag-after-prod-flush (response-etag
+                                                       production-response-after-prod-flush)
+                     test-response-after-prod-flush (get-env-classes
+                                                     "test"
+                                                     test-etag-initial)]
+                 (is (= 200 (:status production-response-after-prod-flush))
+                     (str
+                      "unexpected status code for prod response after code change "
+                      "and prod flush"))
+                 (is (not (nil? production-etag-after-prod-flush))
+                     "no etag returned for production response")
+                 (is (not= production-etag-initial
+                           production-etag-after-prod-flush)
+                     (str
+                      "etag unexpectedly stayed the same even though "
+                      "the production environment changed"))
+                 (is (= {"name" "production",
+                         "files" [{"path" prod-file
+                                   "classes" [{"name" "oneflushprod",
+                                               "params" []}]}]}
+                        (response->class-info-map
+                         production-response-after-prod-flush))
+                     "unexpected body for production response")
+                 (is (= 304 (:status test-response-after-prod-flush))
+                     (str
+                      "unexpected status code for test response after code change "
+                      "but test environment not invalidated"))
+                 (is (= test-etag-initial (response-etag
+                                           test-response-after-prod-flush))
+                     "unexpected etag change when test environment not invalidated")
+                 (is (empty? (:body test-response-after-prod-flush))
+                     "unexpected body for test response")))))
+         (testing "environment class cache invalidation for all environments"
+           ;; This test is about ensuring that when the environment-cache
+           ;; endpoint is hit with no environment parameter that any previously
+           ;; cached environment class info is invalidated, meaning that
+           ;; the next request for class info for all environments will get fresh
+           ;; data.
+           ;;
+           ;; To eliminate some of the redundancy between tests, this test doesn't
+           ;; repeat the intermediate step of checking to see that the first two
+           ;; environment queries were cached - 304 (Not Modified) returns -
+           ;; between the first set of environment_classes queries and the second
+           ;; set, done after the code on disk for both environments has changed.
+           ;;
+           ;; The test has the following basic steps:
+           ;;
+           ;; 1) Purge the current environment files on disk and hit the
+           ;;    environment-cache endpoint to flush the cache for all
+           ;;    environments, basically to ensure nothing is left around from
+           ;;    other tests.
+           ;; 2) Populate code for the 'test' and 'production' environments and
+           ;;    see that environment_classes queries return the right info for
+           ;;    them.
+           ;; 3) Change code on disk for both the 'test' and 'production'
+           ;;    environments.
+           ;; 4) Hit the environment-cache endpoint with no environment
+           ;;    parameter, expected to have the effect of flushing the cache for
+           ;;    all environments.
+           ;; 5) Do two more environment_classes queries for the 'test' and
+           ;;    'production' environments with the corresponding etags returned
+           ;;    from the first two queries.  Confirm that the information
+           ;;    reflects the latest data on disk for both environments.
+           (purge-env-dir)
+           (purge-all-env-caches)
+           (let [prod-file (testutils/write-pp-file "class allprod {}"
+                                                    "somemod"
+                                                    "prod"
+                                                    "production")
+                 test-file (testutils/write-pp-file "class alltest {}"
+                                                    "somemod"
+                                                    "test"
+                                                    "test")
+                 production-response-initial (get-env-classes "production")
+                 production-etag-initial (response-etag production-response-initial)
+                 test-response-initial (get-env-classes "test")
+                 test-etag-initial (response-etag test-response-initial)]
+             (is (= 200 (:status production-response-initial))
+                 (str
+                  "unexpected status code for initial production response"
+                  "response: "
+                  (ks/pprint-to-string production-response-initial)))
+             (is (not (nil? production-etag-initial))
+                 "no etag returned for production response")
+             (is (= {"name" "production",
+                     "files" [{"path" prod-file,
+                               "classes" [{"name" "allprod",
+                                           "params" []}]}]}
+                    (response->class-info-map production-response-initial))
+                 "unexpected body for production response")
+             (is (= 200 (:status test-response-initial))
+                 (str
+                  "unexpected status code for initial test response"
+                  "response: "
+                  (ks/pprint-to-string test-response-initial)))
+             (is (not (nil? test-etag-initial))
+                 "no etag returned for test response")
+             (is (= {"name" "test",
+                     "files" [{"path" test-file
+                               "classes" [{"name" "alltest"
+                                           "params" []}]}]}
+                    (response->class-info-map test-response-initial))
+                 "unexpected body for test response")
+
+             (testutils/write-pp-file "class allflushprod {}"
+                                      "somemod"
+                                      "prod"
+                                      "production")
+             (testutils/write-pp-file "class allflushtest {}"
+                                      "somemod"
+                                      "test"
+                                      "test")
+             (purge-all-env-caches)
+
+             (let [production-response-after-all-flush (get-env-classes
+                                                        "production"
+                                                        production-etag-initial)
+                   production-etag-after-all-flush (response-etag
+                                                    production-response-after-all-flush)]
+               (is (= 200 (:status production-response-after-all-flush))
+                   (str
+                    "unexpected status code for prod response after code change "
+                    "and all environment flush"))
+               (is (not (nil? production-etag-after-all-flush))
+                   "no etag returned for production response")
+               (is (not= production-etag-initial production-etag-after-all-flush)
+                   (str
+                    "etag unexpectedly stayed the same even though "
+                    "the production environment changed"))
+               (is (= {"name" "production",
+                       "files" [{"path" prod-file
+                                 "classes" [{"name" "allflushprod", "params" []}]}]}
+                      (response->class-info-map
+                       production-response-after-all-flush))
+                   "unexpected body for production response"))
+
+             (let [test-response-after-all-flush (get-env-classes
+                                                  "test"
+                                                  test-etag-initial)
+                   test-etag-after-all-flush (response-etag
+                                              test-response-after-all-flush)]
+               (is (= 200 (:status test-response-after-all-flush))
+                   (str
+                    "unexpected status code for test response after code change "
+                    "and all environment flush"))
+               (is (not (nil? test-etag-after-all-flush))
+                   "no etag returned for test response")
+               (is (not= test-etag-initial test-etag-after-all-flush)
+                   (str
+                    "etag unexpectedly stayed the same even though "
+                    "the test environment changed"))
+               (is (= {"name" "test",
+                       "files" [{"path" test-file
+                                 "classes" [{"name" "allflushtest", "params" []}]}]}
+                      (response->class-info-map
+                       test-response-after-all-flush))
+                   "unexpected body for test response")))))
+       (catch Exception e
+         (println "dumping puppetserver.log\n" (slurp debug-log))
+         (throw e))))))
 
 (deftest ^:integration
          not-modified-returned-for-environment-class-info-request-with-gzip-tag
@@ -658,7 +671,8 @@
         authorization/authorization-service
         admin/puppet-admin-service
         vcs/versioned-code-service]
-       {:jruby-puppet {:max-active-instances 1}
+       {:jruby-puppet {:max-active-instances 1
+                       :environment-class-cache-enabled true}
         :webserver {:ssl-ca-cert (:localcacert puppet-server-settings)
                     :ssl-cert (:hostcert puppet-server-settings)
                     :ssl-key (:hostprivkey puppet-server-settings)}
@@ -668,7 +682,9 @@
              _ (reset! wait-atom {:continue-promise continue-promise
                                   :wait-promise wait-promise})
              initial-response-future (future (get-env-classes "production"))]
-         @wait-promise
+         (is (true? (deref wait-promise 10000 :timed-out))
+             (str "timed out waiting for get class info call to be reached "
+                  "in mock jrubypuppet instance"))
          (reset! class-info-atom [{"name" "updatedclass"
                                    "params" []}])
          (purge-env-cache "production")

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -91,7 +91,7 @@
                           (get-environment-class-info [_ _ env]
                             (if (= env "production")
                               {}))
-                          (get-environment-class-info-tag-last-updated
+                          (get-environment-class-info-cache-generation-id!
                            [_ _])
                           (set-environment-class-info-tag! [_ _ _ _]))
           handler (fn ([req] {:request req}))
@@ -232,15 +232,19 @@
                      "modules/foo/files/bar"
                      "modules/foo/files/bar/baz.txt"
                      "modules/foo/files/bar/more/path/elements/baz.txt"
-                     "modules/foo/files/bar/%2E%2E/baz.txt"]
+                     "modules/foo/files/bar/%2E%2E/baz.txt"
+                     "environments/production/files/~/.bash_profile"
+                     "dist/foo/files/bar.txt"
+                     "site/foo/files/bar.txt"]
         invalid-paths ["modules/foo/manifests/bar.pp"
+                       "modules/foo/files/"
                        "modules/foo/files/bar/\u002e\u002e/\u002e\u002e/\u002e\u002e/\u002e\u002e"
                        "modules/foo/files/bar/%2E%2E/%2E%2E/%2E%2E/%2E%2E"
                        "manifests/site.pp"
                        "environments/foo/bar/files"
                        "environments/../manifests/files/site.pp"
+                       "environments/files/site.pp"
                        "environments/../modules/foo/lib/puppet/parser/functions/site.rb"
-                       "environments/production/files/~/.bash_profile"
                        "environments/../modules/foo/files/site.pp"
                        "environments/production/modules/foo/files/../../../../../../site.pp"
                        "environments/production/modules/foo/files/bar.txt"


### PR DESCRIPTION
 Merge branch 'stable' at a352065 into master

* stable: (38 commits)
  (SERVER-1196) Add time out to the class-info-cache-flush test
  (SERVER-1196) Add instrumentation to env-class-int-cache-enabled test
  (SERVER-1194) Validate code-id, env for external scripts
  (SERVER-1202) Rename run! in gem and irb namespaces
  (SERVER-1195) Stop serving files directory
  (doc) Add bootstrap.cfg restart details.
  (SERVER-1195) Serve files from any directory
  (SERVER-1160) Add more tests for execution of commands from Ruby
  (SERVER-1160) Update execution.rb for complex commands
  (TK-338) Bump to tk-j9 1.5.4 to handle TimeoutException
  (SERVER-1114) Cosmetic updates to the env-classes API docs
  (SERVER-1114) Add authorization section to env-classes API doc
  (SERVER-1114) Change numbered list items from ) to .
  (SERVER-1114) Moved env_classes docs under puppet-api directory
  (SERVER-1114) Added some error case sections to the env_classes API docs
  (SERVER-1114) Update docs for `environment-class-cache-enabled` setting
  (SERVER-1114) Initial environment_classes API documentation
  (doc) Edit SIGHUP predocs.
  (SERVER-1183) More env-class-info-tag assertion changes
  (doc) Add SIGHUP docs to fallback nav.
  ...

Conflicts:
  documentation/restarting.markdown

  - Just chose the language from the stable branch verbatim to resolve the
    conflict.