### PR TITLE
(MAINT) Add restarting the server link to index markdown doc

### DIFF
--- a/documentation/index.markdown
+++ b/documentation/index.markdown
@@ -20,6 +20,7 @@ Puppet Server is the next-generation application for managing Puppet agents.
 * [Using an External CA](./external_ca_configuration.markdown)
 * [External SSL Termination](./external_ssl_termination.markdown)
 * [Tuning Guide](./tuning_guide.markdown)
+* [Restarting the Server](./restarting.markdown)
 * **Known Issues and Workarounds**
     * [Known Issues](./known_issues.markdown)
     * [SSL Problems With Load-Balanced PuppetDB Servers ("Server Certificate Change" error)](./ssl_server_certificate_change_and_virtual_ips.markdown)


### PR DESCRIPTION
This commit adds a "Restarting the Server" link to the index.markdown
doc.  That link had somehow been present on the master branch but absent
from the current stable branch.