### PR TITLE
(SERVER-1204) Update execution stub to correctly handle empty args

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -24,6 +24,12 @@ describe Puppet::Server::Execution do
       expect(result).to eq "hi\n"
     end
 
+    it "returns an instance of ProcessOutput for a command with an empty array of args" do
+      result = Puppet::Server::Execution.execute("echo hi", [])
+      expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+      expect(result).to eq "hi\n"
+    end
+
     it "should return the exit code of the process" do
       result = Puppet::Server::Execution.execute("echo hi")
       expect(result.exitstatus).to eq 0

--- a/src/ruby/puppet-server-lib/puppet/server/execution.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/execution.rb
@@ -26,7 +26,7 @@ class Puppet::Server::Execution
   end
 
   def self.execute(command, args = nil)
-    if args
+    if args && !args.empty?
       result = ShellUtils.executeCommand(command, args.to_java(:string))
     else
       result = ShellUtils.executeCommand(command)

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -34,7 +34,7 @@
   {(schema/required-key "name") schema/Str
    (schema/required-key "classes") [schema/Str]
    (schema/required-key "environment") schema/Str
-   (schema/required-key "version") schema/Int
+   (schema/required-key "version") schema/Any
    (schema/required-key "resources") [PuppetResource]
    (schema/required-key "edges") [{schema/Str schema/Str}]
    (schema/optional-key "code_id") (schema/maybe schema/Str)

--- a/test/integration/puppetlabs/puppetserver/testutils.clj
+++ b/test/integration/puppetlabs/puppetserver/testutils.clj
@@ -2,7 +2,8 @@
   (:require [me.raynes.fs :as fs]
             [schema.core :as schema]
             [cheshire.core :as json]
-            [puppetlabs.http.client.sync :as http-client])
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.kitchensink.core :as ks])
   (:import (java.io File)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -112,6 +113,11 @@
   (http-client/get
    (str "https://localhost:8140/" path) catalog-request-options))
 
+(defn create-file
+  [file content]
+  (ks/mkdirs! (fs/parent file))
+  (spit file content))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Interacting with puppet code and catalogs
 
@@ -141,6 +147,12 @@
 (schema/defn ^:always-validate write-foo-pp-file :- schema/Str
   [foo-pp-contents]
   (write-pp-file foo-pp-contents "foo"))
+
+(defn create-env-conf
+  [env-dir content]
+  (create-file (fs/file env-dir "environment.conf")
+               (str "environment_timeout = unlimited\n"
+                    content)))
 
 (schema/defn ^:always-validate get-static-file-content
   ([url-end :- schema/Str]


### PR DESCRIPTION
Previously, puppet server's execution stub assumed that if it was handed
an array, that the first element would be the command. This turns out
not to be true for all of puppet's uses of the execute method.
Specifically, config_version is often a script with arguments that is
handed as a single string in an array to Puppet::Util::Execution.execute
and then on to puppet server's execution stub.
This is a problem because something like '/bin/echo a b c' is not a valid
command. This commit addresses the problem by using the correct call to
ShellUtils in the case where there is a single element array. The
ShellUtils call will in that case correctly parse '/bin/echo a b c' into
a call to /bin/echo with a b and c as arguments.