### PR TITLE
(SERVER-532) Change = to : in webserver settings

### DIFF
--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,6 +1,6 @@
 webserver: {
-    access-log-config = /etc/puppetlabs/puppetserver/request-logging.xml
-    client-auth = want
-    ssl-host = 0.0.0.0
-    ssl-port = 8140
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
+    client-auth: want
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
 }


### PR DESCRIPTION
This commit changes the delimiter for settings in the webserver conf
file from = signs to colons.  This is done for consistency with our
configuration elsewhere, where we should delimit these settings as JSON
would require even though HOCON allows either format.