### PR TITLE
(docs) Update file-path glob details.

### DIFF
--- a/documentation/puppet-api/v3/static_file_content.md
+++ b/documentation/puppet-api/v3/static_file_content.md
@@ -26,9 +26,14 @@ exist on Ruby Puppet masters, such as the
 (Introduced in Puppet Server 2.3.0)
 
 To retrieve a specific version of a file at a given environment and path, make an HTTP
-request to this endpoint with the required parameters. The `<FILE-PATH>` segment of the
-endpoint corresponds to the requested file's path, relative to the given environment's
-root directory, and is required.
+request to this endpoint with the required parameters.
+
+The `<FILE-PATH>` segment of the endpoint is required. The path corresponds to the
+requested file's path on the Server relative to the given environment's root directory,
+and must point to a file in the `*/*/files/**` glob. For example, Puppet Server will
+inline metadata into static catalogs for file resources sourcing module files located by
+default in
+`/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.
 
 ### Query parameters
 


### PR DESCRIPTION
Per @joshcooper in `puppet-docs` PR 622 and SERVER-1195, update the `static_file_content` API docs to specify the paths for files that can have inlined file resource metadata.