### PR TITLE
(SERVER-557) Remove ezbake timeout override

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,6 @@
   :uberjar-name "puppet-server-release.jar"
   :lein-ezbake {:vars {:user "puppet"
                        :group "puppet"
-                       :start-timeout "120"
                        :build-type "foss"
                        :java-args "-Xms2g -Xmx2g -XX:MaxPermSize=256m"
                        :repo-target "PC1"}


### PR DESCRIPTION
The timeout has been raised in ezbake itself, and we can't think
of any great reason not to just use the default from there.