### PR TITLE
Merge branch 'stable' at 9df228f into master

### DIFF
--- a/documentation/puppet-api/v3/static_file_content.md
+++ b/documentation/puppet-api/v3/static_file_content.md
@@ -26,9 +26,14 @@ exist on Ruby Puppet masters, such as the
 (Introduced in Puppet Server 2.3.0)
 
 To retrieve a specific version of a file at a given environment and path, make an HTTP
-request to this endpoint with the required parameters. The `<FILE-PATH>` segment of the
-endpoint corresponds to the requested file's path, relative to the given environment's
-root directory, and is required.
+request to this endpoint with the required parameters.
+
+The `<FILE-PATH>` segment of the endpoint is required. The path corresponds to the
+requested file's path on the Server relative to the given environment's root directory,
+and must point to a file in the `*/*/files/**` glob. For example, Puppet Server will
+inline metadata into static catalogs for file resources sourcing module files located by
+default in
+`/etc/puppetlabs/code/environments/<ENVIRONMENT>/modules/<MODULE NAME>/files/**`.
 
 ### Query parameters
 

--- a/ezbake/config/conf.d/webserver.conf
+++ b/ezbake/config/conf.d/webserver.conf
@@ -1,6 +1,6 @@
 webserver: {
-    access-log-config = /etc/puppetlabs/puppetserver/request-logging.xml
-    client-auth = want
-    ssl-host = 0.0.0.0
-    ssl-port = 8140
+    access-log-config: /etc/puppetlabs/puppetserver/request-logging.xml
+    client-auth: want
+    ssl-host: 0.0.0.0
+    ssl-port: 8140
 }

--- a/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/execution_spec.rb
@@ -24,6 +24,12 @@ describe Puppet::Server::Execution do
       expect(result).to eq "hi\n"
     end
 
+    it "returns an instance of ProcessOutput for a command with an empty array of args" do
+      result = Puppet::Server::Execution.execute("echo hi", [])
+      expect(result).to be_a Puppet::Util::Execution::ProcessOutput
+      expect(result).to eq "hi\n"
+    end
+
     it "should return the exit code of the process" do
       result = Puppet::Server::Execution.execute("echo hi")
       expect(result.exitstatus).to eq 0

--- a/src/ruby/puppet-server-lib/puppet/server/execution.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/execution.rb
@@ -26,7 +26,7 @@ class Puppet::Server::Execution
   end
 
   def self.execute(command, args = nil)
-    if args
+    if args && !args.empty?
       result = ShellUtils.executeCommand(command, args.to_java(:string))
     else
       result = ShellUtils.executeCommand(command)

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -11,6 +11,9 @@
 (def test-resources-dir
   (ks/absolute-path "./dev-resources/puppetlabs/general_puppet/general_puppet_int_test"))
 
+(def environment-dir
+  (ks/absolute-path (str testutils/conf-dir "/environments/production")))
+
 (defn script-path
   [script-name]
   (str test-resources-dir "/" script-name))
@@ -240,3 +243,14 @@
         (is (= 500 (:status response)))
         (is (re-matches #".*Cannot retrieve code content because the \"versioned-code\.code-content-command\" setting is not present in configuration.*"
                         (:body response))))))))
+
+(deftest ^:integration test-config-version-execution
+  (testing "config_version is executed correctly"
+    (testutils/create-env-conf
+     environment-dir
+     (format "config_version = \"%s $environment\"" (script-path "echo")))
+    (bootstrap/with-puppetserver-running
+     app {:jruby-puppet
+          {:max-active-instances num-jrubies}}
+     (let [catalog (testutils/get-catalog)]
+       (is (= "production" (get catalog "version")))))))


### PR DESCRIPTION
 * stable:
      (doc) Update environment classes predocs.
      (SERVER-1204) Add integration test for config_version
      (SERVER-1204) Update catalog schema for version field
      (maint) Move create-file and create-env-conf into testutils
      (docs) Update file-path glob details.
      (SERVER-532) Change = to : in webserver settings
      (maint) Update puppet-agent version for testing
      (SERVER-1204) Update execution stub to correctly handle empty args
      (maint) Bump puppet submodule to stable latest
      (MAINT) Add restarting the server link to index markdown doc

    Conflicts:
    acceptance/lib/helper.rb

      - Only conflict was the PUPPET_BUILD_VERSION.  Preserved the version
        being selected on master since it is pinned to a puppet-agent#master
        version rather than the one that the stable branch is pinned to,
        from puppet-agent#stable.