### PR TITLE
(ORCH-1235) Add code_id to environment catalog requests

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "878f7e7c2084716a483544aeb5ebffb4ec48d9d6", :string)
+                         "2c492d8f1ff5018c171b9f4cef7671f14d92c215", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/puppet.conf
+++ b/dev-resources/puppetlabs/general_puppet/general_puppet_int_test/puppet.conf
@@ -3,3 +3,4 @@
 certname = localhost
 environmentpath = $confdir/environments
 environment_timeout = unlimited
+app_management = true

--- a/src/clj/puppetlabs/puppetserver/jruby_request.clj
+++ b/src/clj/puppetlabs/puppetserver/jruby_request.clj
@@ -67,10 +67,13 @@
      (handler (assoc request :jruby-instance jruby-instance)))))
 
 (defn get-environment-from-request
-  "Gets the environment from a request."
+  "Gets the environment from the URL or query string of a request."
   [req]
-  (-> req
-      (get-in [:params "environment"])))
+  ;; If environment is derived from the path, favor that over a query/form
+  ;; param named environment, since it doesn't make sense to ask about
+  ;; environment production in environment development.
+  (or (get-in req [:route-params :environment])
+      (get-in req [:params "environment"])))
 
 (defn wrap-with-environment-validation
   "Middleware function which validates the presence and syntactical content

--- a/src/clj/puppetlabs/services/master/master_core.clj
+++ b/src/clj/puppetlabs/services/master/master_core.clj
@@ -437,8 +437,8 @@
                (request-handler request))
    (comidi/GET ["/resource_types/" [#".*" :rest]] request
                (request-handler request))
-   (comidi/GET ["/environment/" [#".*" :rest]] request
-               (request-handler request))
+   (comidi/GET ["/environment/" [#".*" :environment]] request
+               (request-handler (assoc request :include-code-id? true)))
    (comidi/GET "/environments" request
                (request-handler request))
    (comidi/GET ["/status/" [#".*" :rest]] request

--- a/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
+++ b/test/integration/puppetlabs/general_puppet/general_puppet_int_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.puppetserver.bootstrap-testutils :as bootstrap]
             [me.raynes.fs :as fs]
+            [cheshire.core :as json]
             [puppetlabs.http.client.sync :as http-client]
             [puppetlabs.puppetserver.testutils :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
@@ -120,6 +121,25 @@
             (is (= 400 (:status response)))
             (is (= (ps-common/environment-validation-error-msg "production;cat")
                    (:body response)))))))))
+
+(deftest ^:integration code-id-request-test-get-environment
+  (bootstrap/with-puppetserver-running
+    app {:jruby-puppet
+         {:max-active-instances num-jrubies}
+         :versioned-code
+         {:code-id-command (script-path "echo")
+          :code-content-command (script-path "echo")}}
+    (testutils/write-site-pp-file "site { }")
+    (testing "code id is added to the request body for environment requests"
+      (let [env-catalog (-> (http-client/get "https://localhost:8140/puppet/v3/environment/production" (assoc testutils/ssl-request-options :as :text))
+                            :body
+                            json/parse-string)]
+        (is (= "production" (get env-catalog "code_id")))))
+    (testing "code id is set based on the environment in the URL, not a query param"
+      (let [env-catalog (-> (http-client/get "https://localhost:8140/puppet/v3/environment/production?environment=development" (assoc testutils/ssl-request-options :as :text))
+                            :body
+                            json/parse-string)]
+        (is (= "production" (get env-catalog "code_id")))))))
 
 (deftest ^:integration code-id-request-test-non-zero-exit
     (testing "catalog request fails if code-id-command returns a non-zero exit code"

--- a/test/unit/puppetlabs/services/master/master_core_test.clj
+++ b/test/unit/puppetlabs/services/master/master_core_test.clj
@@ -287,7 +287,6 @@
           request (partial app-request app)]
       (doseq [[method paths]
               {:get ["node"
-                     "environment"
                      "file_content"
                      "file_metadatas"
                      "file_metadata"


### PR DESCRIPTION
Similar to agent catalog requests, we now add code id for the given
environment to environment catalog requests.

This extends the logic for determining the request environment to now check
both the :environment URL segment as well as the "environment" query param.
If environment is part of the URL, we favor that over a conflicting query
param.