### PR TITLE
(maint) Bump project.clj version to 2.3.2-master-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def tk-version "1.3.0")
 (def tk-jetty-version "1.5.4")
 (def ks-version "1.3.0")
-(def ps-version "2.3.0-master-SNAPSHOT")
+(def ps-version "2.3.2-master-SNAPSHOT")
 
 (defn deploy-info
   [url]


### PR DESCRIPTION
2.3.0 has already been released, so the previous version did not make sense anymore.