### PR TITLE
(doc) Fix environment cache api link

### DIFF
--- a/documentation/puppet-api/v3/environment_classes.md
+++ b/documentation/puppet-api/v3/environment_classes.md
@@ -376,7 +376,7 @@ the class information in later queries to the environment classes endpoint. To c
 entries on the server, do one of the following:
 
 1.  Call the
-    [`environment-cache` API endpoint](/puppet-server/latest/admin-api/v1/environment-cache.html).
+    [environment cache API][].
 
     For best performance, call this endpoint with a query parameter that specifies the
     environment whose cache should be flushed.

--- a/documentation/puppet-api/v3/environment_classes.md
+++ b/documentation/puppet-api/v3/environment_classes.md
@@ -376,7 +376,7 @@ the class information in later queries to the environment classes endpoint. To c
 entries on the server, do one of the following:
 
 1.  Call the
-    [environment cache API][].
+    [`environment-cache` API endpoint][environment cache API].
 
     For best performance, call this endpoint with a query parameter that specifies the
     environment whose cache should be flushed.


### PR DESCRIPTION
This fixes a link to the environment cache API docs from the environment
classes endpoint docs, by using the already-defined `environment cache API`
markdown link reference.