### PR TITLE
(SERVER-864) Allow special characters in certificate_statuses key

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -262,7 +262,7 @@
     (comidi/context ["/v1"]
       (ANY ["/certificate_status/" :subject] [subject]
         (certificate-status subject ca-settings))
-      (ANY ["/certificate_statuses/" :ignored-but-required] []
+      (ANY ["/certificate_statuses/" [#"[^/]+" :ignored-but-required]] []
         (certificate-statuses ca-settings))
       (GET ["/certificate/" :subject] [subject]
         (handle-get-certificate subject ca-settings))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -305,6 +305,20 @@
           (is (= #{localhost-status test-agent-status revoked-agent-status}
                  (set (json/parse-string (:body response) true)))))
 
+        (testing "requires ignored path segment"
+          (let [response (test-app
+                          {:uri "/v1/certificate_statuses/"
+                           :request-method :get})]
+            (is (= 404 (:status response)))))
+
+        (testing "allows special characters in ignored path segment"
+          (let [response (test-app
+                          {:uri "/v1/certificate_statuses/*"
+                           :request-method :get})]
+            (is (= 200 (:status response)))
+            (is (= #{localhost-status test-agent-status revoked-agent-status}
+                 (set (json/parse-string (:body response) true))))))
+
         (testing "with 'Accept: pson'"
           (let [response (test-app
                           {:uri "/v1/certificate_statuses/thisisirrelevant"


### PR DESCRIPTION
Prior to this the certificate_statuses endpoint would not match calls
when the required key path segment contained anyting that wasn't an
alphanum, hyphen, underscore, or period. eg.
  `puppet-ca/v1/certificate_statuses/*`
would fail to match the specification of:
  `:ca-mount-endpoint/:version/certificate_statuses/:key`
even though there is no further requirements on the key path segment.

This behavior is determined by how we describe our path segment captures
to a third party library (bidi).

This patch updates our route description to allow the key path segment
to match any single path segment of one or more characters in length.