### PR TITLE
(TK-344) Update to TK 1.3.1 and remove logback version hack

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def clj-version "1.7.0")
-(def tk-version "1.3.0")
+(def tk-version "1.3.1")
 (def tk-jetty-version "1.5.4")
 (def ks-version "1.3.0")
 (def ps-version "2.4.0-master-SNAPSHOT")
@@ -17,21 +17,11 @@
   :dependencies [[org.clojure/clojure ~clj-version]
 
                  ;; begin version conflict resolution dependencies
-                 [puppetlabs/typesafe-config "0.1.4"]
+                 [puppetlabs/typesafe-config "0.1.5"]
                  [org.clojure/tools.macro "0.1.5"]
                  [com.fasterxml.jackson.core/jackson-core "2.5.4"]
                  [org.clojure/tools.reader "1.0.0-alpha1"]
                  ;; end version conflict resolution dependencies
-
-                 ;; This is a temporary hack to work around
-                 ;; https://tickets.puppetlabs.com/browse/SERVER-1215
-                 ;; these lines should be removed once we have
-                 ;; a better fix in place
-                 [ch.qos.logback/logback-classic "1.1.3"]
-                 [ch.qos.logback/logback-access "1.1.3"]
-                 [ch.qos.logback/logback-core "1.1.3"]
-                 [org.slf4j/slf4j-api "1.7.13"]
-                 ;; end SERVER-1215 hack
 
                  [cheshire "5.3.1"]
                  [slingshot "0.10.3"]


### PR DESCRIPTION
This commit bumps us to the latest release of TK, which includes
explicit versioning for all of our logback artifacts to ensure
that we don't end up shipping incompatible versions of the various
logback components.  The commit also removes the previous hack
that we'd put in to temporarily fix the logback versioning issue.