### PR TITLE
(maint) Fix pedantic errors and puppet agent version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "2c492d8f1ff5018c171b9f4cef7671f14d92c215", :string)
+                         "adf3cd46f5904ba119567bd4bd9784cc255f1a90", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def clj-version "1.7.0")
 (def tk-version "1.3.1")
-(def tk-jetty-version "1.5.4")
+(def tk-jetty-version "1.5.5")
 (def ks-version "1.3.0")
 (def ps-version "2.4.0-master-SNAPSHOT")
 

--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.4.0')
+      expect(subject).to eq('4.4.1')
     end
   end
 


### PR DESCRIPTION
Previously, puppet server packages were failing to be built because `lein
with-profile ezbake` had version conflicts and pedantic errors. This updates to a new tk-ws-j9 that removes these version conflicts.

The previous PUPPET_BUILD_VERSION was set to a puppet-agent build that was
1.3.5, which didn't work with puppet server's current requirement on
puppet-agent >= 1.4.0. This updates the PUPPET_BUILD_VERSION to the latest passing
puppet-agent version off puppet master, and the puppet submodule to the commit
that is in that puppet-agent version.