### PR TITLE
(maint) Return 400 for incomplete URL to certificate_statuses

### DIFF
--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -28,10 +28,10 @@
 ;;; 'handler' functions for HTTP endpoints
 
 (defn handle-server-error
-  ([message]
-    (-> (rr/response message)
-        (rr/status 400)
-        (rr/content-type "text/plain"))))
+  [message]
+  (-> (rr/response message)
+      (rr/status 400)
+      (rr/content-type "text/plain")))
 
 (defn handle-get-certificate
   [subject {:keys [cacert signeddir]}]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -27,6 +27,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; 'handler' functions for HTTP endpoints
 
+(defn handle-server-error
+  ([message]
+    (-> (rr/response message)
+        (rr/status 400)
+        (rr/content-type "text/plain"))))
+
 (defn handle-get-certificate
   [subject {:keys [cacert signeddir]}]
   (-> (if-let [certificate (ca/get-certificate subject cacert signeddir)]
@@ -51,9 +57,7 @@
     (catch ca/csr-validation-failure? {:keys [message]}
       (log/error message)
       ;; Respond to all CSR validation failures with a 400
-      (-> (rr/response message)
-          (rr/status 400)
-          (rr/content-type "text/plain")))))
+      (handle-server-error message))))
 
 (defn handle-get-certificate-revocation-list
   [{:keys [cacrl]}]
@@ -262,8 +266,10 @@
     (comidi/context ["/v1"]
       (ANY ["/certificate_status/" :subject] [subject]
         (certificate-status subject ca-settings))
-      (ANY ["/certificate_statuses/" [#"[^/]+" :ignored-but-required]] []
-        (certificate-statuses ca-settings))
+      (comidi/context ["/certificate_statuses/"]
+        (ANY [[#"[^/]+" :ignored-but-required]] []
+          (certificate-statuses ca-settings))
+        (ANY [""] [] (handle-server-error "Missing URL Segment")))
       (GET ["/certificate/" :subject] [subject]
         (handle-get-certificate subject ca-settings))
       (comidi/context ["/certificate_request/" :subject]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -309,7 +309,9 @@
           (let [response (test-app
                           {:uri "/v1/certificate_statuses/"
                            :request-method :get})]
-            (is (= 400 (:status response)))))
+            (is (= 400 (:status response)))
+            (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+            (is (= "Missing URL Segment" (:body response)))))
 
         (testing "allows special characters in ignored path segment"
           (let [response (test-app

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -309,7 +309,7 @@
           (let [response (test-app
                           {:uri "/v1/certificate_statuses/"
                            :request-method :get})]
-            (is (= 404 (:status response)))))
+            (is (= 400 (:status response)))))
 
         (testing "allows special characters in ignored path segment"
           (let [response (test-app


### PR DESCRIPTION
Previously, we were falling through to the default handler of our
`web-routes` if the `certificate_statuses` endpoint did not include its
required -- but ignored -- trailing key segment.  The default handler
returns a 404.

This provides a default handler for the `certificate_statuses` endpoint
that will catch malformed URLs and return a 400 instead of a 404.

It also extracts providing a generic 400 response into a method that
is reused where appropriate.