### PR TITLE
(SERVER-977) DELETE handler for certificate_request endpoint

### DIFF
--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1013,7 +1013,7 @@
       (let [msg (format
                   "No certificate request for %s at expected path %s"
                   subject csr-path)]
-        (log/info msg)
+        (log/warn msg)
         {:outcome :not-found
          :message msg }))))
 

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -991,11 +991,11 @@
         (autosign-certificate-request! subject csr settings)
         (fs/delete (path-to-cert-request csrdir subject))))))
 
-(schema/defn ^:always-validate process-csr-deletion!
+(schema/defn ^:always-validate delete-certificate-request!
   :- {:outcome (schema/enum :success :not-found :error) :message schema/Str}
   "Delete pending certificate requests for subject"
-  [subject :- schema/Str
-   {:keys [csrdir]} :- CaSettings]
+  [{:keys [csrdir]} :- CaSettings
+   subject :- schema/Str]
   (let [csr-path (path-to-cert-request csrdir subject)]
     (if (fs/exists? csr-path)
       (if (fs/delete csr-path)
@@ -1008,8 +1008,8 @@
           {:outcome :error
            :message msg}))
       (let [msg (format
-                   "No certificate request for %s at expected path %s"
-                   subject csr-path)]
+                  "No certificate request for %s at expected path %s"
+                  subject csr-path)]
         (log/info msg)
         {:outcome :not-found
          :message msg }))))
@@ -1206,15 +1206,11 @@
         message))))
 
 (schema/defn ^:always-validate delete-certificate!
-  "Delete the certificate and/or CSR for the given subject.
+  "Delete the certificate for the given subject.
    Note this does not revoke the certificate."
   [{:keys [csrdir signeddir]} :- CaSettings
    subject :- schema/Str]
-  (let [cert (path-to-cert signeddir subject)
-        csr  (path-to-cert-request csrdir subject)]
+  (let [cert (path-to-cert signeddir subject)]
     (when (fs/exists? cert)
       (fs/delete cert)
-      (log/debug "Deleted certificate for" subject))
-    (when (fs/exists? csr)
-      (fs/delete csr)
-      (log/debug "Deleted certificate request for" subject))))
+      (log/debug "Deleted certificate for" subject))))

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -995,7 +995,7 @@
   :- {:outcome (schema/enum :success :not-found :error) :message schema/Str}
   "Delete pending certificate requests for subject"
   [subject :- schema/Str
-   {:keys [csrdir] :as settings} :- CaSettings]
+   {:keys [csrdir]} :- CaSettings]
   (let [csr-path (path-to-cert-request csrdir subject)]
     (if (fs/exists? csr-path)
       (if (fs/delete csr-path)

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -97,6 +97,10 @@
 (def CertificateRevocationList
   (schema/pred utils/certificate-revocation-list?))
 
+(def OutcomeInfo
+  "Generic map of outcome & message for API consumers"
+  {:outcome (schema/enum :success :not-found :error) :message schema/Str})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions
 
@@ -991,8 +995,7 @@
         (autosign-certificate-request! subject csr settings)
         (fs/delete (path-to-cert-request csrdir subject))))))
 
-(schema/defn ^:always-validate delete-certificate-request!
-  :- {:outcome (schema/enum :success :not-found :error) :message schema/Str}
+(schema/defn ^:always-validate delete-certificate-request! :- OutcomeInfo
   "Delete pending certificate requests for subject"
   [{:keys [csrdir]} :- CaSettings
    subject :- schema/Str]

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -99,7 +99,8 @@
 
 (def OutcomeInfo
   "Generic map of outcome & message for API consumers"
-  {:outcome (schema/enum :success :not-found :error) :message schema/Str})
+  {:outcome (schema/enum :success :not-found :error)
+   :message schema/Str})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Definitions

--- a/src/clj/puppetlabs/puppetserver/certificate_authority.clj
+++ b/src/clj/puppetlabs/puppetserver/certificate_authority.clj
@@ -1212,7 +1212,7 @@
 (schema/defn ^:always-validate delete-certificate!
   "Delete the certificate for the given subject.
    Note this does not revoke the certificate."
-  [{:keys [csrdir signeddir]} :- CaSettings
+  [{signeddir :signeddir} :- CaSettings
    subject :- schema/Str]
   (let [cert (path-to-cert signeddir subject)]
     (when (fs/exists? cert)

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -64,7 +64,7 @@
 (schema/defn handle-delete-certificate-request!
   [subject :- String
    ca-settings :- ca/CaSettings]
-  (let [response (ca/process-csr-deletion! subject ca-settings)
+  (let [response (ca/delete-certificate-request! ca-settings subject)
         outcomes->codes {:success 204 :not-found 404 :error 500}]
     (-> (rr/response (:message response))
         (rr/status ((response :outcome) outcomes->codes))
@@ -176,7 +176,8 @@
 
   :delete!
   (fn [context]
-    (ca/delete-certificate! settings subject))
+    (ca/delete-certificate! settings subject)
+    (ca/delete-certificate-request! settings subject))
 
   :exists?
   (fn [context]

--- a/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
+++ b/src/clj/puppetlabs/services/ca/certificate_authority_core.clj
@@ -4,7 +4,7 @@
   (:require [puppetlabs.puppetserver.certificate-authority :as ca]
             [puppetlabs.puppetserver.ringutils :as ringutils]
             [puppetlabs.puppetserver.liberator-utils :as liberator-utils]
-            [puppetlabs.comidi :as comidi :refer [GET ANY PUT]]
+            [puppetlabs.comidi :as comidi :refer [GET ANY PUT DELETE]]
             [bidi.schema :as bidi-schema]
             [slingshot.slingshot :as sling]
             [clojure.tools.logging :as log]
@@ -60,6 +60,15 @@
   (-> (ca/get-certificate-revocation-list cacrl)
       (rr/response)
       (rr/content-type "text/plain")))
+
+(schema/defn handle-delete-certificate-request!
+  [subject :- String
+   ca-settings :- ca/CaSettings]
+  (let [response (ca/process-csr-deletion! subject ca-settings)
+        outcomes->codes {:success 204 :not-found 404 :error 500}]
+    (-> (rr/response (:message response))
+        (rr/status ((response :outcome) outcomes->codes))
+        (rr/content-type "text/plain"))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Web app
@@ -271,6 +280,8 @@
           (handle-get-certificate-request subject ca-settings))
         (PUT [""] [subject :as {body :body}]
           (handle-put-certificate-request! subject body ca-settings)))
+        (DELETE [""] [subject]
+          (handle-delete-certificate-request! subject ca-settings))
       (GET ["/certificate_revocation_list/" :ignored-node-name] []
         (handle-get-certificate-revocation-list ca-settings)))
     (comidi/not-found "Not Found")))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -142,7 +142,8 @@
             (fs/delete expected-path))))
       (testing "Attempted deletion of a non-existant CSR"
         (let [response (handle-delete-certificate-request! subject settings)
-              msg-matcher (re-pattern (str "No cert.* " subject " at .*"))]
+              msg-matcher (re-pattern
+                            (str "No cert.*request for " subject " at.*" expected-path))]
           (is (false? (fs/exists? expected-path)))
           (is (= 404 (:status response)))
           (is (re-matches msg-matcher (:body response)))

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -148,35 +148,35 @@
               (is (logged? msg-matcher :debug)))
             (finally
               (fs/delete expected-path))))))
-      (testing "Attempted deletion of a non-existant CSR"
-        (logutils/with-test-logging
-          (let [subject "not-found-agent"
-                response (handle-delete-certificate-request! subject settings)
-                expected-path (ca/path-to-cert-request (:csrdir settings) subject)
-                msg-matcher (re-pattern
-                              (str "No cert.*request for " subject " at.*" expected-path))]
-            (is (false? (fs/exists? expected-path)))
-            (is (= 404 (:status response)))
-            (is (re-matches msg-matcher (:body response)))
-            (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-            (is (logged? msg-matcher :warn)))))
-      (testing "Error during deletion of a CSR"
-        (logutils/with-test-logging
-          (let [subject "err-agent"
-                csr-stream (gen-csr-input-stream! subject)
-                expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
-            (try
-              (handle-put-certificate-request! subject csr-stream settings)
-              (is (true? (fs/exists? expected-path)))
-              (fs/chmod "-w" (fs/parent expected-path))
-              (let [response (handle-delete-certificate-request! subject settings)
-                     msg-matcher (re-pattern (str "Path " expected-path " exists but.*"))]
-                 (is (= 500 (:status response)))
-                 (is (re-matches msg-matcher (:body response)))
-                 (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-                 (is (logged? msg-matcher :error)))
-              (finally
-                (fs/chmod "+w" (fs/parent expected-path)))))))))
+    (testing "Attempted deletion of a non-existant CSR"
+      (logutils/with-test-logging
+        (let [subject "not-found-agent"
+              response (handle-delete-certificate-request! subject settings)
+              expected-path (ca/path-to-cert-request (:csrdir settings) subject)
+              msg-matcher (re-pattern
+                            (str "No cert.*request for " subject " at.*" expected-path))]
+          (is (false? (fs/exists? expected-path)))
+          (is (= 404 (:status response)))
+          (is (re-matches msg-matcher (:body response)))
+          (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+          (is (logged? msg-matcher :warn)))))
+    (testing "Error during deletion of a CSR"
+      (logutils/with-test-logging
+        (let [subject "err-agent"
+              csr-stream (gen-csr-input-stream! subject)
+              expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
+          (try
+            (handle-put-certificate-request! subject csr-stream settings)
+            (is (true? (fs/exists? expected-path)))
+            (fs/chmod "-w" (fs/parent expected-path))
+            (let [response (handle-delete-certificate-request! subject settings)
+                   msg-matcher (re-pattern (str "Path " expected-path " exists but.*"))]
+               (is (= 500 (:status response)))
+               (is (re-matches msg-matcher (:body response)))
+               (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+               (is (logged? msg-matcher :error)))
+            (finally
+              (fs/chmod "+w" (fs/parent expected-path)))))))))
 
 (deftest handle-put-certificate-request!-test
   (let [settings   (assoc (testutils/ca-sandbox! cadir)

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -119,6 +119,44 @@
           response (ring-app request)]
       (is (= version-number (get-in response [:headers "X-Puppet-Version"]))))))
 
+(deftest handle-delete-certificate-request!-test
+  (let [settings      (assoc (testutils/ca-sandbox! cadir)
+                             :allow-duplicate-certs true
+                             :autosign false)
+        subject       "foo-agent"
+        csr-stream    (io/input-stream (test-pem-file "foo-agent-csr.pem"))
+        expected-path (ca/path-to-cert-request (:csrdir settings) subject)
+        assert-proper
+          (fn
+            [response code matcher log-level]
+            (do
+             (is (= code (:status response)))
+             (is (re-matches matcher (:body response)))
+             (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+             (is (logged? matcher log-level))))]
+    (logutils/with-test-logging
+      (testing "Successful CSR deletion"
+        (try
+          (handle-put-certificate-request! subject csr-stream settings)
+          (is (true? (fs/exists? expected-path)))
+          (let [response (handle-delete-certificate-request! subject settings)
+                msg-matcher (re-pattern (str "Deleted .* for " subject ".*"))]
+            (is (false? (fs/exists? expected-path)))
+            (assert-proper response 204 msg-matcher :debug))
+          (finally
+            (fs/delete expected-path))))
+      (testing "Attempted deletion of a non-existant CSR"
+        (let [response (handle-delete-certificate-request! subject settings)
+              msg-matcher (re-pattern (str "No cert.* " subject " at .*"))]
+          (is (false? (fs/exists? expected-path)))
+          (assert-proper response 404 msg-matcher :info)))
+      (testing "Error during deletion of a CSR"
+        (let [response
+              (with-redefs [me.raynes.fs/exists? (constantly true)]
+                (handle-delete-certificate-request! subject settings))
+              msg-matcher (re-pattern (str "Path " expected-path " exists but.*"))]
+          (assert-proper response 500 msg-matcher :error))))))
+
 (deftest handle-put-certificate-request!-test
   (let [settings   (assoc (testutils/ca-sandbox! cadir)
                      :allow-duplicate-certs true)

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -147,7 +147,7 @@
           (is (= 404 (:status response)))
           (is (re-matches msg-matcher (:body response)))
           (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-          (is (logged? msg-matcher :info))))
+          (is (logged? msg-matcher :warn))))
       (testing "Error during deletion of a CSR"
         (let [response
               (with-redefs [me.raynes.fs/exists? (constantly true)]

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -120,11 +120,11 @@
       (is (= version-number (get-in response [:headers "X-Puppet-Version"]))))))
 
 (deftest handle-delete-certificate-request!-test
-  (let [settings      (assoc (testutils/ca-sandbox! cadir)
-                             :allow-duplicate-certs true
-                             :autosign false)
-        subject       "foo-agent"
-        csr-stream    (io/input-stream (test-pem-file "foo-agent-csr.pem"))
+  (let [settings (assoc (testutils/ca-sandbox! cadir)
+                        :allow-duplicate-certs true
+                        :autosign false)
+        subject "foo-agent"
+        csr-stream (io/input-stream (test-pem-file "foo-agent-csr.pem"))
         expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
     (logutils/with-test-logging
       (testing "successful csr deletion"

--- a/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
+++ b/test/unit/puppetlabs/services/ca/certificate_authority_core_test.clj
@@ -47,6 +47,14 @@
         (handler request)))
     puppet-version))
 
+(defn gen-csr-input-stream!
+  [subject]
+  (let [key-pair (utils/generate-key-pair 512)
+        csr (utils/generate-certificate-request key-pair (utils/cn subject))
+        pem (java.io.ByteArrayOutputStream.)
+        _ (utils/obj->pem! csr pem)]
+    (io/input-stream (.getBytes (.toString pem)))))
+
 (defn wrap-with-ssl-client-cert
   "Wrap a compojure app so all requests will include the
    localhost certificate to allow access to the certificate
@@ -122,27 +130,29 @@
 (deftest handle-delete-certificate-request!-test
   (let [settings (assoc (testutils/ca-sandbox! cadir)
                         :allow-duplicate-certs true
-                        :autosign false)
-        subject "foo-agent"
-        csr-stream (io/input-stream (test-pem-file "foo-agent-csr.pem"))
-        expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
+                        :autosign false)]
     (testing "successful csr deletion"
       (logutils/with-test-logging
-        (try
-          (handle-put-certificate-request! subject csr-stream settings)
-          (is (true? (fs/exists? expected-path)))
-          (let [response (handle-delete-certificate-request! subject settings)
-                msg-matcher (re-pattern (str "Deleted .* for " subject ".*"))]
-            (is (false? (fs/exists? expected-path)))
-            (is (= 204 (:status response)))
-            (is (re-matches msg-matcher (:body response)))
-            (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-            (is (logged? msg-matcher :debug)))
-          (finally
-            (fs/delete expected-path))))
+        (let [subject "happy-agent"
+              csr-stream (gen-csr-input-stream! subject)
+              expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
+          (try
+            (handle-put-certificate-request! subject csr-stream settings)
+            (is (true? (fs/exists? expected-path)))
+            (let [response (handle-delete-certificate-request! subject settings)
+                  msg-matcher (re-pattern (str "Deleted .* for " subject ".*"))]
+              (is (false? (fs/exists? expected-path)))
+              (is (= 204 (:status response)))
+              (is (re-matches msg-matcher (:body response)))
+              (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+              (is (logged? msg-matcher :debug)))
+            (finally
+              (fs/delete expected-path))))))
       (testing "Attempted deletion of a non-existant CSR"
         (logutils/with-test-logging
-          (let [response (handle-delete-certificate-request! subject settings)
+          (let [subject "not-found-agent"
+                response (handle-delete-certificate-request! subject settings)
+                expected-path (ca/path-to-cert-request (:csrdir settings) subject)
                 msg-matcher (re-pattern
                               (str "No cert.*request for " subject " at.*" expected-path))]
             (is (false? (fs/exists? expected-path)))
@@ -152,14 +162,21 @@
             (is (logged? msg-matcher :warn)))))
       (testing "Error during deletion of a CSR"
         (logutils/with-test-logging
-          (let [response
-                (with-redefs [me.raynes.fs/exists? (constantly true)]
-                  (handle-delete-certificate-request! subject settings))
-                msg-matcher (re-pattern (str "Path " expected-path " exists but.*"))]
-            (is (= 500 (:status response)))
-            (is (re-matches msg-matcher (:body response)))
-            (is (= "text/plain" (get-in response [:headers "Content-Type"])))
-            (is (logged? msg-matcher :error))))))))
+          (let [subject "err-agent"
+                csr-stream (gen-csr-input-stream! subject)
+                expected-path (ca/path-to-cert-request (:csrdir settings) subject)]
+            (try
+              (handle-put-certificate-request! subject csr-stream settings)
+              (is (true? (fs/exists? expected-path)))
+              (fs/chmod "-w" (fs/parent expected-path))
+              (let [response (handle-delete-certificate-request! subject settings)
+                     msg-matcher (re-pattern (str "Path " expected-path " exists but.*"))]
+                 (is (= 500 (:status response)))
+                 (is (re-matches msg-matcher (:body response)))
+                 (is (= "text/plain" (get-in response [:headers "Content-Type"])))
+                 (is (logged? msg-matcher :error)))
+              (finally
+                (fs/chmod "+w" (fs/parent expected-path)))))))))
 
 (deftest handle-put-certificate-request!-test
   (let [settings   (assoc (testutils/ca-sandbox! cadir)


### PR DESCRIPTION
Prior to this there was no handler for the DELETE method of
certificate_request endpoint.

This adds a basic handler for deleting a pending certificate request.