### PR TITLE
Revert "updates beaker to 2.38.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jira-ruby', :group => :development
 
 group :test do
   gem 'rspec'
-  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.38.1')
+  gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.24.0')
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
   gem 'uuidtools'
   gem 'httparty'


### PR DESCRIPTION
This reverts commit 528db99d531aa2364935629d865e8cef115e5307, because BKR-650 is still a problem.