### PR TITLE
(PUP-5482) Toggle always_retry_plugins when available

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/master_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/master_spec.rb
@@ -24,7 +24,7 @@ describe 'Puppet::Server::Master' do
     end
 
     it "returns the correct puppet version number" do
-      expect(subject).to eq('4.4.1')
+      expect(subject).to eq('4.4.2')
     end
   end
 

--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -27,5 +27,12 @@ describe 'Puppet::Server::PuppetConfig' do
         expect(subject).to eq(true)
       end
     end
+
+    describe '(PUP-5482) Puppet[:always_retry_plugins]' do
+      subject { Puppet[:always_retry_plugins] }
+      it 'is false for increased performance in puppet-server' do
+        expect(subject).to eq(false)
+      end
+    end
   end
 end

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -25,6 +25,10 @@ class Puppet::Server::PuppetConfig
     # the cache is intended for agents to reload features mid-catalog-run.
     Puppet[:always_cache_features] = true
 
+    if Puppet.settings.setting('always_retry_plugins')
+      Puppet[:always_retry_plugins] = false
+    end
+
     # Crank Puppet's log level all the way up and just control it via logback.
     Puppet[:log_level] = "debug"
 


### PR DESCRIPTION
A performance improvement was just merged into puppet. It is guarded by
a setting called `always_retry_plugins`, which defaults to true. To take
advantage of this improvement, we should set it to false. This commit
makes that change, but checks to see if the setting is available yet by
calling into `Puppet.settings.setting`.