### PR TITLE
(docs) Update Puppet branding and URLs.

### DIFF
--- a/documentation/admin-api/v1/environment-cache.markdown
+++ b/documentation/admin-api/v1/environment-cache.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetserver/latest/admin-api/v1/environment-cache.html"
 ---
 
 When using directory environments, the Puppet master
-[caches](https://docs.puppetlabs.com/puppet/latest/reference/environments_configuring.html)
+[caches](/puppet/latest/reference/environments_configuring.html)
 the data it loads from disk for each environment.  Puppet Server adds a new
 endpoint to the master's HTTP API:
 

--- a/documentation/config_file_auth.md
+++ b/documentation/config_file_auth.md
@@ -11,12 +11,12 @@ canonical: "/puppetserver/latest/config_file_auth.html"
 
 Puppet Server's `auth.conf` file contains rules for authorizing access to Puppet Server's HTTP API endpoints. For an overview, see [Puppet Server Configuration](./configuration.html).
 
-The new Puppet Server authentication configuration and functionality is similar to the legacy method in that you define rules in a file named `auth.conf`, and Puppet Server applies the settings when a request's endpoint matches a rule. 
+The new Puppet Server authentication configuration and functionality is similar to the legacy method in that you define rules in a file named `auth.conf`, and Puppet Server applies the settings when a request's endpoint matches a rule.
 
 However, Puppet Server now has its own `auth.conf` file that uses a new HOCON format with different parameters, syntax, and functionality.
 
 > ### Aside: Changes to Authorization in Puppet Server 2.2.0
-> 
+>
 > Puppet Server 2.2.0 introduces a significant change in how it manages authentication to API endpoints. It uses [`trapperkeeper-authorization`][] for authentication, which is configured by rules and settings in Puppet Server's own `auth.conf`, with a HOCON configuration file format in a different location than the [Puppet `auth.conf`][] file.
 >
 > The older Puppet `auth.conf` file and whitelist-based authorization method are [deprecated][]. Puppet Server's new `auth.conf` file, documented below, also uses a different format for authorization rules.
@@ -27,7 +27,7 @@ However, Puppet Server now has its own `auth.conf` file that uses a new HOCON fo
 > * Requests to certificate status and administration endpoints use the new `auth.conf` rules **only** if the corresponding `client-whitelists` setting is empty or unspecified **and** the `authorization-required` flag is set to `true` (which is its default).
 > * Requests to other certificate administration endpoints --- such as `certificate`, `certificate_request`, and `certificate_revocation_list` --- **always** use the new HOCON `auth.conf` rules in Puppet Server's `auth.conf` file. This happens regardless of the `client-whitelist`, `authorization-required`, or `use-legacy-auth-conf` settings, as versions of Puppet Server before 2.2.0 can't manage those endpoints.
 >
-> **Note:** You can also use the [`puppetlabs-puppet_authorization`](https://forge.puppetlabs.com/puppetlabs/puppet_authorization) module to manage the new `auth.conf` file's authorization rules in the new HOCON format, and the [`puppetlabs-hocon`](https://forge.puppetlabs.com/puppetlabs/hocon) module to use Puppet to manage HOCON-formatted settings in general.
+> **Note:** You can also use the [`puppetlabs-puppet_authorization`](https://forge.puppet.com/puppetlabs/puppet_authorization) module to manage the new `auth.conf` file's authorization rules in the new HOCON format, and the [`puppetlabs-hocon`](https://forge.puppet.com/puppetlabs/hocon) module to use Puppet to manage HOCON-formatted settings in general.
 
 You have two options when configuring how Puppet Server authenticates requests:
 
@@ -48,7 +48,7 @@ The `version` parameter is required. In this initial release, the only supported
 
 This optional `authorization` section parameter determines whether to enable [external SSL termination](./external_ssl_termination.html) on all HTTP endpoints that Puppet Server handles, including those served by the "master" service, the certificate authority API, and the Puppet Admin API. It also controls how Puppet Server derives the user's identity for authorization purposes. The default value is `false`.
 
-If this setting is `true`, Puppet Server ignores any presented certificate and relies completely on header data to authorize requests. 
+If this setting is `true`, Puppet Server ignores any presented certificate and relies completely on header data to authorize requests.
 
 > **Warning!** This is very insecure; **do not enable this parameter** unless you've secured your network to prevent **any** untrusted access to Puppet Server.
 
@@ -128,14 +128,14 @@ query-params: {
 
 #### `allow`, `allow-unauthenticated`, and `deny`
 
-After each rule's `match-request` section, it must also have an `allow`, `allow-unauthenticated`, or `deny` parameter. (You can set both `allow` and `deny` parameters for a rule, though Puppet Server always prioritizes `deny` over `allow` when a request matches both.) 
+After each rule's `match-request` section, it must also have an `allow`, `allow-unauthenticated`, or `deny` parameter. (You can set both `allow` and `deny` parameters for a rule, though Puppet Server always prioritizes `deny` over `allow` when a request matches both.)
 
 If a request matches the rule, Puppet Server checks the request's authenticated "name" (see [`allow-header-cert-info`](#allow-header-cert-info)) against these parameters to determine what to do with the request.
 
 * **`allow-unauthenticated`**: If this Boolean parameter is set to `true`, Puppet Server allows the request --- even if it can't determine an authenticated name. **This is a potentially insecure configuration** --- be careful when enabling it. A rule with this parameter set to `true` can't also contain the `allow` or `deny` parameters.
 * **`allow`**: This parameter can take a single string value or an array of them. The values can be:
     * An exact domain name, such as `www.example.com`.
-    * A glob of names containing a `*` in the first segment, such as `*.example.com` or simply `*`. 
+    * A glob of names containing a `*` in the first segment, such as `*.example.com` or simply `*`.
     * A regular expression surrounded by `/` characters, such as `/example/`.
     * A backreference to a regular expression's capture group in the `path` value, if the rule also contains a `type` value of `regex`. For example, if the path for the rule were `"^/example/([^/]+)$"`, you can make a backreference to the first capture group using a value like `$1.domain.org`.
 

--- a/documentation/dev_debugging.markdown
+++ b/documentation/dev_debugging.markdown
@@ -119,7 +119,7 @@ We are aware that some favorite gems/tools/features for ruby debugging don't cur
 work with JRuby/Puppet Server.  (For example, some things like color syntax highlighting
 in Pry.)  It's important to us to make sure that the Ruby developer experience is not
 degraded for developers working via Puppet Server rather than webrick, so, if you run
-into issues like this, please file an issue on  our [Bug Tracker](https://tickets.puppetlabs.com/browse/SERVER),
+into issues like this, please file an issue on  our [Bug Tracker](https://tickets.puppet.com/browse/SERVER),
 and we will see if it's possible to add support for things that we're missing.  In many
 cases it might be a matter of simply submitting a patch to JRuby, or submitting a
 JRuby-compatibility patch for an existing gem, and we're interested in trying to help

--- a/documentation/external_ca_configuration.markdown
+++ b/documentation/external_ca_configuration.markdown
@@ -7,7 +7,7 @@ canonical: "/puppetserver/latest/external_ca_configuration.html"
 
 Puppet Server supports the ability to configure certificates from an existing
 external CA. This is similar to Ruby Puppet master functionality under a Rack-enabled web server like Apache with Passenger. Much of the existing
-documentation on [External CA Support for the Ruby Puppet Master](https://docs.puppetlabs.com/puppet/latest/reference/config_ssl_external_ca.html)
+documentation on [External CA Support for the Ruby Puppet Master](/puppet/latest/reference/config_ssl_external_ca.html)
 still applies to using an external CA with Puppet Server. However, there are some configuration differences with Puppet Server, which we've detailed on this page.
 
 ## Client DN Authentication

--- a/documentation/external_ssl_termination.markdown
+++ b/documentation/external_ssl_termination.markdown
@@ -41,7 +41,7 @@ on the `puppetserver.conf` and `auth.conf` files.
 
 > **WARNING**: Setting `allow-header-cert-info` to 'true' puts Puppet Server in an incredibly vulnerable state. Take extra caution to ensure it is **absolutely not reachable** by an untrusted network.
 >
-> With `allow-header-cert-info` set to 'true', authorization code will use only the client HTTP header values---not an SSL-layer client certificate---to determine the client subject name, authentication status, and trusted facts. This is true even if the web server is hosting an HTTPS connection. This applies to validation of the client via rules in the [auth.conf](https://docs.puppetlabs.com/guides/rest_auth_conf.html) file and any [trusted facts][trusted] extracted from certificate extensions.
+> With `allow-header-cert-info` set to 'true', authorization code will use only the client HTTP header values---not an SSL-layer client certificate---to determine the client subject name, authentication status, and trusted facts. This is true even if the web server is hosting an HTTPS connection. This applies to validation of the client via rules in the [auth.conf](/guides/rest_auth_conf.html) file and any [trusted facts][trusted] extracted from certificate extensions.
 >
 > If the `client-auth` setting in the `webserver` config block is set to `need` or `want`, the Jetty web server will still validate the client certificate against a certificate authority store, but it will only verify the SSL-layer client certificate---not a certificate in an  `X-Client-Cert` header.
 
@@ -60,7 +60,7 @@ The headers you'll need to set are `X-Client-Verify`, `X-Client-DN`, and `X-Clie
 
 Mandatory. Must be either `SUCCESS` if the certificate was validated, or something else if not. (The convention seems to be to use `NONE` for when a certificate wasn't presented, and `FAILED:reason` for other validation failures.) Puppet Server uses this to authorize requests; only requests with a value of `SUCCESS` will be considered authenticated.
 
-When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_verify_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientverifyheader)
+When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_verify_header` setting.](/puppet/latest/reference/configuration.html#sslclientverifyheader)
 
 This setting (and its twin, `ssl_client_header`) is a bit odd: its value should be the result of transforming the desired HTTP header name into a CGI-style environment variable name. That is, to change the HTTP header to `X-SSL-Client-Verify`, you would set the setting to `HTTP_X_SSL_CLIENT_VERIFY`. (Add `HTTP_` to the front, change hyphens to underscores, and uppercase everything.)
 
@@ -75,19 +75,19 @@ file has no effect on how the client verify header is processed.
 
 Mandatory. Must be the [Subject DN][] of the agent's certificate, if a certificate was presented. Puppet Server uses this to authorize requests.
 
-> **Note:** Currently, when using `master.allow-header-cert-info: true`, the DN must be in RFC-2253 format (comma-delimited). Due to a bug ([SERVER-213](https://tickets.puppetlabs.com/browse/SERVER-213)), Puppet Server can't decode OpenSSL-style DNs (slash-delimited). Note that Apache's `mod_ssl` `SSL_CLIENT_S_DN` variable uses OpenSSL-style DNs.  Note
+> **Note:** Currently, when using `master.allow-header-cert-info: true`, the DN must be in RFC-2253 format (comma-delimited). Due to a bug ([SERVER-213](https://tickets.puppet.com/browse/SERVER-213)), Puppet Server can't decode OpenSSL-style DNs (slash-delimited). Note that Apache's `mod_ssl` `SSL_CLIENT_S_DN` variable uses OpenSSL-style DNs.  Note
  that the bug does not apply when `authorization.allow-header-cert-info` is set
  to true.  `trapperkeeper-authorization` supports decoding both the RFC-2253
  and OpenSSL "slash-delimited" DN formats.
 
-When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_header` setting.](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientheader) See the note above for more info about this setting's expected values.
+When using the `master.allow-header-cert-info: true` setting, you can change this header name with [the `ssl_client_header` setting.](/puppet/latest/reference/configuration.html#sslclientheader) See the note above for more info about this setting's expected values.
 
 Note that if you are using the `authorization.allow-header-cert-info: true`
 setting, the name of the client DN header in the request must be
 `X-Client-DN`; the `ssl_client_header` setting in the `puppet.conf` file has no
 effect on how the client DN header is processed.
 
-[subject dn]: https://docs.puppetlabs.com/background/ssl/cert_anatomy.html#the-subject-dn-cn-certname-etc
+[subject dn]: /background/ssl/cert_anatomy.html#the-subject-dn-cn-certname-etc
 
 ### `X-Client-Cert`
 
@@ -99,6 +99,5 @@ Optional. Should contain the client's [PEM-formatted][pem format] (Base-64) cert
 
 The name of this header is not configurable.
 
-
-[pem format]: https://docs.puppetlabs.com/background/ssl/cert_anatomy.html#pem-file
-[trusted]: https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html#trusted-facts
+[pem format]: /background/ssl/cert_anatomy.html#pem-file
+[trusted]: /puppet/latest/reference/lang_facts_and_builtin_vars.html#trusted-facts

--- a/documentation/gems.markdown
+++ b/documentation/gems.markdown
@@ -111,6 +111,6 @@ page discusses this issue further.
 
 If you're using a gem that won't run on JRuby and you can't find a suitable
 replacement, please open a ticket on our
-[Issue Tracker](https://tickets.puppetlabs.com/browse/SERVER); we're definitely
+[Issue Tracker](https://tickets.puppet.com/browse/SERVER); we're definitely
 interested in helping provide solutions if there are common gems that are
 causing trouble for users!

--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -17,7 +17,7 @@ Puppet Server is configured to use 2 GB of RAM by default. If you'd like to just
 
 ## Quick Start
 
-1. [Enable the Puppet Labs package repositories][repodocs], if you haven't already done so.
+1. [Enable the Puppet package repositories][repodocs], if you haven't already done so.
 2. Stop the existing Puppet master service. The method for doing this varies depending on how your system is set up.
 
     If you're running a WEBrick Puppet master, use: `service puppetmaster stop`.
@@ -71,4 +71,4 @@ By default, Puppet Server will be configured to use 2GB of RAM. However, if you 
 
 ## Reporting Issues
 
-Submit issues to our [bug tracker](https://tickets.puppetlabs.com/browse/SERVER).
+Submit issues to our [bug tracker](https://tickets.puppet.com/browse/SERVER).

--- a/documentation/known_issues.markdown
+++ b/documentation/known_issues.markdown
@@ -5,7 +5,7 @@ canonical: "/puppetserver/latest/known_issues.html"
 ---
 
 
-For a list of all known issues, visit our [Issue Tracker](https://tickets.puppetlabs.com/browse/SERVER).
+For a list of all known issues, visit our [Issue Tracker](https://tickets.puppet.com/browse/SERVER).
 
 Here are a few specific issues that we're aware of that might affect certain users:
 
@@ -17,7 +17,7 @@ Puppet Server on an existing system with Ruby 1.8, the behavior of some extensio
 
 ## Config Reload
 
-[SERVER-15](https://tickets.puppetlabs.com/browse/SERVER-15): In the current
+[SERVER-15](https://tickets.puppet.com/browse/SERVER-15): In the current
 builds of Puppet Server, there is no signal handling mechanism
 that allows you to request a config reload/service refresh. In order to
 clear out the Ruby environments and reload all config, you must restart the
@@ -26,8 +26,8 @@ for reloading rather than restarting.
 
 ## `tmp` directory mounted `noexec`
 
-In some cases (especially for RHEL 7 installations) if the `/tmp` directory is 
-mounted as `noexec`, Puppet Server may fail to run correctly, and you may see an 
+In some cases (especially for RHEL 7 installations) if the `/tmp` directory is
+mounted as `noexec`, Puppet Server may fail to run correctly, and you may see an
 error in the Puppet Server logs similar to the following:
 
 ```
@@ -38,10 +38,10 @@ Nov 12 17:46:12 fqdn.com java[56495]: Puppet::Error: Cannot determine basic syst
 
 This is caused by the fact that JRuby contains some embedded files which need to be
 copied somewhere on the filesystem before they can be executed
-([see this JRuby issue](https://github.com/jruby/jruby/issues/2186)). To work 
-around this  issue, you can either mount the `/tmp` directory without 
-`noexec`, or you can choose a different directory to use as the temporary 
-directory for the Puppet Server process. 
+([see this JRuby issue](https://github.com/jruby/jruby/issues/2186)). To work
+around this  issue, you can either mount the `/tmp` directory without
+`noexec`, or you can choose a different directory to use as the temporary
+directory for the Puppet Server process.
 
 Either way, you'll need to set the permissions of the directory to `1777`. This allows the Puppet Server JRuby process to write a file to `/tmp` and then execute it. If permissions are set incorrectly, you'll get a massive stack trace without much useful information in it.
 
@@ -53,13 +53,13 @@ To use a different temporary directory, you can set the following JVM property:
 
 When Puppet Server is installed from packages, this property should be added
 to the `JAVA_ARGS` variable defined in either `/etc/sysconfig/puppetserver`
-or `/etc/default/puppetserver`, depending on upon your distribution. Note that 
+or `/etc/default/puppetserver`, depending on upon your distribution. Note that
 the service will need to be restarted in order for this change to take effect.
 
 
 ## Diffie-Helman HTTPS Client Issues
 
-[SERVER-17](https://tickets.puppetlabs.com/browse/SERVER-17): When configuring
+[SERVER-17](https://tickets.puppet.com/browse/SERVER-17): When configuring
 Puppet Server to use a report processor that involves HTTPS requests (e.g., to
 Foreman), there can be compatibility issues between the JVM HTTPS client and
 certain server HTTPS implementations (e.g., very recent versions of Apache mod_ssl).
@@ -74,7 +74,7 @@ dependencies in the uberjar, which can cause failures that say
 
 ## OpenBSD JRuby Compatibility Issues
 
-[SERVER-14](https://tickets.puppetlabs.com/browse/SERVER-14): While we don't ship
+[SERVER-14](https://tickets.puppet.com/browse/SERVER-14): While we don't ship
 official packages or provide official support for OpenBSD, we would very much
 like for users to be able to run Puppet Server on it. Current versions of JRuby
 have a bug in their POSIX support on OpenBSD that prevents Puppet Server from
@@ -84,7 +84,7 @@ also be possible to patch the Puppet Ruby code to work around this issue.
 
 ## Puppet Server Master Fails to Connect to Load-Balanced Servers with Different SSL Certificates
 
-[SERVER-207](https://tickets.puppetlabs.com/browse/SERVER-207): Intermittent
+[SERVER-207](https://tickets.puppet.com/browse/SERVER-207): Intermittent
 SSL connection failures have been seen when the Puppet Server master tries to
 make SSL requests to servers via the same virtual ip address.  This has been
 seen when the servers present different certificates during the SSL handshake.

--- a/documentation/puppet-api/v3/static_file_content.md
+++ b/documentation/puppet-api/v3/static_file_content.md
@@ -4,12 +4,12 @@ title: "Puppet Server: Puppet API: Static File Content"
 canonical: "/puppetserver/latest/puppet-api/v3/static_file_content.html"
 ---
 
-[`code-content-command`]: https://docs.puppetlabs.com/puppetserver/latest/config_file_puppetserver.html
-[static catalog]: https://docs.puppetlabs.com/puppet/latest/reference/static_catalogs.html
-[catalog]: https://docs.puppetlabs.com/puppet/latest/reference/subsystem_catalog_compilation.html
-[file resource]: https://docs.puppetlabs.com/puppet/latest/reference/type.html#file
-[environment]: https://docs.puppetlabs.com/puppet/latest/reference/environments.html
-[auth.conf]: https://docs.puppetlabs.com/puppetserver/latest/config_file_auth.html
+[`code-content-command`]: https://docs.puppet.com/puppetserver/latest/config_file_puppetserver.html
+[static catalog]: https://docs.puppet.com/puppet/latest/reference/static_catalogs.html
+[catalog]: https://docs.puppet.com/puppet/latest/reference/subsystem_catalog_compilation.html
+[file resource]: https://docs.puppet.com/puppet/latest/reference/type.html#file
+[environment]: https://docs.puppet.com/puppet/latest/reference/environments.html
+[auth.conf]: https://docs.puppet.com/puppetserver/latest/config_file_auth.html
 
 The `static_file_content` endpoint returns the standard output of a
 [`code-content-command`][] script, which should output the contents of a specific version
@@ -18,7 +18,7 @@ source must be a file from the `files` directory of a module in a specific [envi
 
 Puppet Agent uses this endpoint only when applying a [static catalog][]. This endpoint
 is available only when the Puppet master is running Puppet Server, not Ruby Puppet masters, such as the
-[deprecated WEBrick Puppet master](https://docs.puppetlabs.com/puppet/latest/reference/services_master_webrick.html).
+[deprecated WEBrick Puppet master](https://docs.puppet.com/puppet/latest/reference/services_master_webrick.html).
 
 ## `GET /puppet/v3/static_file_content/<FILE-PATH>`
 

--- a/documentation/puppet_conf_setting_diffs.markdown
+++ b/documentation/puppet_conf_setting_diffs.markdown
@@ -6,34 +6,34 @@ canonical: "/puppetserver/latest/puppet_conf_setting_diffs.html"
 
 
 Puppet Server honors almost all settings in puppet.conf and should pick them
-up automatically. However, some Puppet Server settings differ from a Ruby Puppet master's puppet.conf settings; we've detailed these differences below. For more complete information on puppet.conf settings, see our [Configuration Reference](https://docs.puppetlabs.com/references/latest/configuration.html) page.
+up automatically. However, some Puppet Server settings differ from a Ruby Puppet master's puppet.conf settings; we've detailed these differences below. For more complete information on puppet.conf settings, see our [Configuration Reference](/puppet/latest/reference/configuration.html) page.
 
-### [`autoflush`](https://docs.puppetlabs.com/references/latest/configuration.html#autoflush)
+### [`autoflush`](/puppet/latest/reference/configuration.html#autoflush)
 
 Puppet Server does not use this setting. For more information on the master
 logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
 
-### [`bindaddress`](https://docs.puppetlabs.com/references/latest/configuration.html#bindaddress)
+### [`bindaddress`](/puppet/latest/reference/configuration.html#bindaddress)
 
 Puppet Server does not use this setting. To set the address on which the master
 listens, use either `host` (unencrypted) or `ssl-host` (SSL encrypted) in the
 [webserver.conf](./configuration.markdown#webserverconf) file.
 
-### [`ca`](https://docs.puppetlabs.com/references/latest/configuration.html#ca)
+### [`ca`](/puppet/latest/reference/configuration.html#ca)
 
 Puppet Server does not use this setting. Instead, Puppet Server acts as a
 certificate authority based on the certificate authority service configuration
 in the `bootstrap.cfg` file. See [Service Bootstrapping](./configuration.markdown#service-bootstrapping) for more details.
 
-### [`cacert`](https://docs.puppetlabs.com/references/latest/configuration.html#cacert)
+### [`cacert`](/puppet/latest/reference/configuration.html#cacert)
 
-If you enable Puppet Server's certificate authority service, it uses the `cacert` 
-setting in puppet.conf to determine the location of the CA certificate for such 
-tasks as generating the CA certificate or using the CA to sign client certificates. 
-This is true regardless of the configuration of the `ssl-` settings in 
+If you enable Puppet Server's certificate authority service, it uses the `cacert`
+setting in puppet.conf to determine the location of the CA certificate for such
+tasks as generating the CA certificate or using the CA to sign client certificates.
+This is true regardless of the configuration of the `ssl-` settings in
 [webserver.conf](./configuration.markdown#webserverconf).
 
-### [`cacrl`](https://docs.puppetlabs.com/references/latest/configuration.html#cacrl)
+### [`cacrl`](/puppet/latest/reference/configuration.html#cacrl)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
@@ -52,22 +52,22 @@ revocations performed via the `certificate_status` HTTP endpoint---use the `cacr
 setting in puppet.conf to determine the location of the CRL. This is true
 regardless of the `ssl-` settings in webserver.conf.
 
-### [`capass`](https://docs.puppetlabs.com/references/latest/configuration.html#capass)
+### [`capass`](/puppet/latest/reference/configuration.html#capass)
 
 Puppet Server does not use this setting. Puppet Server's certificate authority
 does not create a `capass` password file when the CA certificate and key are
 generated.
 
-### [`caprivatedir`](https://docs.puppetlabs.com/references/latest/configuration.html#caprivatedir)
+### [`caprivatedir`](/puppet/latest/reference/configuration.html#caprivatedir)
 
 Puppet Server does not use this setting. Puppet Server's certificate authority
 does not create this directory.
 
-### [`daemonize`](https://docs.puppetlabs.com/references/latest/configuration.html#daemonize)
+### [`daemonize`](/puppet/latest/reference/configuration.html#daemonize)
 
 Puppet Server does not use this setting.
 
-### [`hostcert`](https://docs.puppetlabs.com/references/latest/configuration.html#hostcert)
+### [`hostcert`](/puppet/latest/reference/configuration.html#hostcert)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server presents the file at `ssl-cert` to clients as the server certificate via
@@ -83,7 +83,7 @@ Server's certificate authority service, if enabled, uses the `hostcert`
 "puppet.conf" setting, and not the `ssl-cert` setting, to determine the
 location of the server host certificate to generate.
 
-### [`hostcrl`](https://docs.puppetlabs.com/references/latest/configuration.html#hostcrl)
+### [`hostcrl`](/puppet/latest/reference/configuration.html#hostcrl)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
@@ -102,7 +102,7 @@ revocations performed via the `certificate_status` HTTP endpoint---use the `cacr
 setting in puppet.conf to determine the location of the CRL. This is true
 regardless of the `ssl-` settings in webserver.conf.
 
-### [`hostprivkey`](https://docs.puppetlabs.com/references/latest/configuration.html#hostprivkey)
+### [`hostprivkey`](/puppet/latest/reference/configuration.html#hostprivkey)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
 [webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the file at `ssl-key` as the server private key during SSL transactions.
@@ -115,100 +115,100 @@ negotiation.
 
 If you enable the Puppet Server certificate authority service, Puppet Server uses the `hostprivkey` setting in puppet.conf to determine the location of the server host private key to generate. This is true regardless of the configuration of the `ssl-` settings in webserver.conf.
 
-### [`http_debug`](https://docs.puppetlabs.com/references/latest/configuration.html#httpdebug)
+### [`http_debug`](/puppet/latest/reference/configuration.html#httpdebug)
 
 Puppet Server does not use this setting. Debugging for HTTP client code in
 the Puppet Server master is controlled through Puppet Server's common logging
 mechanism. For more information on the master logging implementation for Puppet
 Server, see the [logging configuration section](./configuration.markdown#logging).
 
-### [`keylength`](https://docs.puppetlabs.com/references/latest/configuration.html#keylength)
+### [`keylength`](/puppet/latest/reference/configuration.html#keylength)
 
 Puppet Server does not currently use this setting. Puppet Server's certificate
 authority generates 4096-bit keys in conjunction with any SSL certificates that
 it generates.
 
-### [`localcacert`](https://docs.puppetlabs.com/references/latest/configuration.html#localcacert)
+### [`localcacert`](/puppet/latest/reference/configuration.html#localcacert)
 
 If you define `ssl-cert`, `ssl-key`, `ssl-ca-cert`, and/or `ssl-crl-path` in
-[webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the 
+[webserver.conf](./configuration.markdown#webserverconf), Puppet Server uses the
 file at `ssl-ca-cert` as the CA cert store for authenticating clients via SSL.
 
 If at least one of the `ssl-` settings in webserver.conf
 is set but `ssl-ca-cert` is not set, Puppet Server gives an error
 and shuts down at startup. If none of the `ssl-` settings in webserver.conf is
-set, Puppet Server uses the CA file defined for the `localcacert` setting in 
+set, Puppet Server uses the CA file defined for the `localcacert` setting in
 puppet.conf for SSL authentication.
 
-### [`logdir`](https://docs.puppetlabs.com/references/latest/configuration.html#logdir)
+### [`logdir`](/puppet/latest/reference/configuration.html#logdir)
 
 Puppet Server does not use this setting. For more information on the master
 logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
 
-### [`masterhttplog`](https://docs.puppetlabs.com/references/latest/configuration.html#masterhttplog)
+### [`masterhttplog`](/puppet/latest/reference/configuration.html#masterhttplog)
 
 Puppet Server does not use this setting. You can configure a web server access log via the `access-log-config` setting in the [webserver.conf](./configuration.markdown#webserverconf) file.
 
-### [`masterlog`](https://docs.puppetlabs.com/references/latest/configuration.html#masterlog)
+### [`masterlog`](/puppet/latest/reference/configuration.html#masterlog)
 
 Puppet Server does not use this setting. For more information on the master
 logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
 
-### [`masterport`](https://docs.puppetlabs.com/references/latest/configuration.html#masterport)
+### [`masterport`](/puppet/latest/reference/configuration.html#masterport)
 
 Puppet Server does not use this setting. To set the port on which the master listens, set the `port` (unencrypted) or `ssl-port` (SSL encrypted) setting in the
 [webserver.conf](./configuration.markdown#webserverconf) file.
 
-### [`puppetdlog`](https://docs.puppetlabs.com/references/latest/configuration.html#puppetdlog)
+### [`puppetdlog`](/puppet/latest/reference/configuration.html#puppetdlog)
 
 Puppet Server does not use this setting. For more information on the master
 logging implementation for Puppet Server, see the [logging configuration section](./configuration.markdown#logging).
 
-### [`rails_loglevel`](https://docs.puppetlabs.com/references/latest/configuration.html#railsloglevel)
+### [`rails_loglevel`](/puppet/latest/reference/configuration.html#railsloglevel)
 
 Puppet Server does not use this setting.
 
-### [`railslog`](https://docs.puppetlabs.com/references/latest/configuration.html#railslog)
+### [`railslog`](/puppet/latest/reference/configuration.html#railslog)
 
 Puppet Server does not use this setting.
 
-### [`ssl_client_header`](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientheader)
+### [`ssl_client_header`](/puppet/latest/reference/configuration.html#sslclientheader)
 
 Puppet Server honors this setting only if the `allow-header-cert-info`
 setting in the `master.conf` file is set to 'true'. For more information on
 this setting, see the documentation on [external SSL termination](./external_ssl_termination.markdown).
 
-###  [`ssl_client_verify_header`](https://docs.puppetlabs.com/references/latest/configuration.html#sslclientverifyheader)
+###  [`ssl_client_verify_header`](/puppet/latest/reference/configuration.html#sslclientverifyheader)
 
 Puppet Server honors this setting only if the `allow-header-cert-info`
 setting in the `master.conf` file is set to `true`. For more information on
 this setting, see the documentation on [external SSL termination](./external_ssl_termination.markdown).
 
-### [`ssl_server_ca_auth`](https://docs.puppetlabs.com/references/latest/configuration.html#sslservercaauth)
+### [`ssl_server_ca_auth`](/puppet/latest/reference/configuration.html#sslservercaauth)
 
 Puppet Server does not use this setting. It only considers the `ssl-ca-cert`
 setting from the webserver.conf file and the `cacert` setting from the
 puppet.conf file. See [`cacert`](#cacert) for more information.
 
-### [`syslogfacility`](https://docs.puppetlabs.com/references/latest/configuration.html#syslogfacility)
+### [`syslogfacility`](/puppet/latest/reference/configuration.html#syslogfacility)
 
 Puppet Server does not use this setting.
 
-### [`user`](https://docs.puppetlabs.com/references/latest/configuration.html#user)
+### [`user`](/puppet/latest/reference/configuration.html#user)
 
 Puppet Server does not use this setting.
 
 ## HttpPool-Related Server Settings
 
-### [`configtimeout`](https://docs.puppetlabs.com/references/latest/configuration.html#configtimeout)
+### [`configtimeout`](/puppet/latest/reference/configuration.html#configtimeout)
 
 Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
-### [`http_proxy_host`](https://docs.puppetlabs.com/references/latest/configuration.html#httpproxyhost)
+### [`http_proxy_host`](/puppet/latest/reference/configuration.html#httpproxyhost)
 
 Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 
-### [`http_proxy_port`](https://docs.puppetlabs.com/references/latest/configuration.html#httpproxyport)
+### [`http_proxy_port`](/puppet/latest/reference/configuration.html#httpproxyport)
 
 Puppet Server does not currently consider this setting for any code running on the master and using the `Puppet::Network::HttpPool` module to create an HTTP client connection. This pertains, for example, to any requests that the master would make to the `reporturl` for the `http` report processor. Note that Puppet agents do still honor this setting.
 

--- a/documentation/release_notes.markdown
+++ b/documentation/release_notes.markdown
@@ -21,11 +21,11 @@ This is a bug-fix release that resolves a disruptive logging configuration issue
 
 If its Logback service is configured to log to syslog, Puppet Server 2.3.0 fails to start. Puppet Server 2.3.1 fixes this regression, which did not affect prior versions of Puppet Server.
 
-* [SERVER-1215](https://tickets.puppetlabs.com/browse/SERVER-1215)
+* [SERVER-1215](https://tickets.puppet.com/browse/SERVER-1215)
 
 ### All changes
 
-* [All Puppet Server issues targeted at this release](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.1%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
+* [All Puppet Server issues targeted at this release](https://tickets.puppet.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.1%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
 
 ## Puppet Server 2.3.0
 
@@ -41,25 +41,25 @@ This is a feature release that adds functionality for static catalogs, a new env
 
 Puppet Server 2.3.0 and Puppet 4.4.0 implement [static catalogs][], which inline metadata for [file resources][] into [Puppet catalogs][]. This improves the predictability of Puppet runs in workflows that use cached catalogs and file resources fetched from modules on a Puppet master.
 
-* [SERVER-999](https://tickets.puppetlabs.com/browse/SERVER-999)
+* [SERVER-999](https://tickets.puppet.com/browse/SERVER-999)
 
 ### New feature: `environment_classes` API
 
 The [environment classes API][] in Puppet Server 2.3.0 serves as a replacement for the Puppet [resource type API][] when requesting information about [classes][] available to a Puppet Server.
 
-* [SERVER-1110](https://tickets.puppetlabs.com/browse/SERVER-1110)
+* [SERVER-1110](https://tickets.puppet.com/browse/SERVER-1110)
 
 ### New feature: Faster service restarts with HUP signals
 
 Puppet Server 2.3.0 and newer support being restarted by sending a hangup signal, also known as [HUP or SIGHUP](./restarting.html), to the running Puppet Server process. You can send this signal to the Puppet Server process using the standard `kill` command. The HUP signal stops Puppet Server and reloads it gracefully, without terminating the JVM process. This is generally much faster than completely stopping and restarting the process, and allows you to quickly load changes to your Puppet Server master, including certain configuration changes.
 
-* [SERVER-96](https://tickets.puppetlabs.com/browse/SERVER-96)
+* [SERVER-96](https://tickets.puppet.com/browse/SERVER-96)
 
 ### Bug fix: Puppet Server correctly parses complex script arguments
 
 In versions 1.x and 2.2.x, Puppet Server would incorrectly parse commands executed by Puppet code that had complex string interpolation. For example, calls to the `generate()` function --- such as `generate('/bin/sh', '-c', "/usr/bin/python -c 'print \"foo\"'")` --- would spawn a Python REPL and consume a JRuby instance without returning anything. Puppet Server 2.3.0 fixes this issue.
 
-* [SERVER-1160](https://tickets.puppetlabs.com/browse/SERVER-1160)
+* [SERVER-1160](https://tickets.puppet.com/browse/SERVER-1160)
 
 ### Known issues
 
@@ -80,14 +80,14 @@ puppetlabs.services.versioned-code-service.versioned-code-service/versioned-code
 
 Alternatively, you can merge your changes into the new version of `bootstrap.cfg` (the `bootstrap.cfg.rpmnew` file in the above example) and replace `bootstrap.cfg` with the new file.
 
-* [SERVER-1058](https://tickets.puppetlabs.com/browse/SERVER-1058)
+* [SERVER-1058](https://tickets.puppet.com/browse/SERVER-1058)
 
 #### Puppet Server fails to start when configured to log to syslog
 
 If its Logback service is configured to log to syslog, Puppet Server 2.3.0 fails to start. Puppet Server 2.3.1 fixes this regression, which did not affect prior versions of Puppet Server.
 
-* [SERVER-1215](https://tickets.puppetlabs.com/browse/SERVER-1215)
+* [SERVER-1215](https://tickets.puppet.com/browse/SERVER-1215)
 
 ### All changes
 
-* [All Puppet Server issues targeted at this release](https://tickets.puppetlabs.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.0%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)
+* [All Puppet Server issues targeted at this release](https://tickets.puppet.com/issues/?jql=project%20%3D%20SERVER%20AND%20fixVersion%20%3D%20%22SERVER%202.3.0%22%20ORDER%20BY%20updated%20DESC%2C%20priority%20DESC%2C%20created%20ASC)

--- a/documentation/services_master_puppetserver.markdown
+++ b/documentation/services_master_puppetserver.markdown
@@ -15,13 +15,13 @@ Puppet Server is an application that runs on the Java Virtual Machine (JVM) and 
 
 Puppet Server is one of two recommended ways to run the Puppet master service; the other is [a Rack server][rack]. Today they're mostly equivalent --- Puppet Server is easier to set up and performs better under heavy loads, but they provide the same services. In the future, Puppet Server's features will further surpass the Rack Puppet master, and we plan to eventually disable Rack support.
 
-> Puppet Enterprise 3.7 and later uses Puppet Server by default. You do not need to manually install or configure it.
+> **Note:** Puppet Enterprise 3.7 and later use Puppet Server by default. You do not need to manually install or configure it.
 
 This page describes the generic requirements and run environment for Puppet Server; for practical instructions, see the docs for [installing](./install_from_packages.html) and [configuring](./configuration.html) it. For details about invoking the `puppet master` command, see [the `puppet master` man page](/references/latest/man/master.html).
 
 ## Supported Platforms
 
-Puppet Labs provides Puppet Server packages for Red Hat Enterprise Linux, RHEL-derived distros, Fedora, Debian, and Ubuntu.
+Puppet provides Puppet Server packages for Red Hat Enterprise Linux, RHEL-derived distros, Fedora, Debian, and Ubuntu.
 
 If we don't provide a package for your system, you can run Puppet Server from source on any POSIX server with JDK 1.7 or later. See [Running from Source](./dev_running_from_source.html) for more details.
 
@@ -91,7 +91,7 @@ Additionally, if you need to test or debug code that will be used by Puppet Serv
 
 To handle parallel requests from agent nodes, Puppet Server maintains several separate JRuby interpreters, all independently running Puppet's application code, and distributes agent requests among them. Today, agent requests are distributed more or less randomly, without regard to their environment; this may change in the future.
 
-You can configure the JRuby interpreters in the `jruby-puppet` section of [the `puppetserver.conf` file.](./config_file_puppetserver.html) 
+You can configure the JRuby interpreters in the `jruby-puppet` section of [the `puppetserver.conf` file.](./config_file_puppetserver.html)
 
 #### Tuning Guide
 

--- a/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
+++ b/documentation/ssl_server_certificate_change_and_virtual_ips.markdown
@@ -3,11 +3,12 @@ layout: default
 title: "Puppet Server: Known Issues: SSL Server Certificate Change and Virtual IP Addresses"
 canonical: "/puppetserver/latest/ssl_server_certificate_change_and_virtual_ips.html"
 ---
-[pe_db_instructions]: https://docs.puppetlabs.com/pe/latest/release_notes_known_issues.html#puppetdb-behind-a-load-balancer-causes-puppet-server-errors
+
+[pe_db_instructions]: /pe/latest/release_notes_known_issues.html#puppetdb-behind-a-load-balancer-causes-puppet-server-errors
 
 Puppet Server can often encounter `server certificate change is restricted` errors when it makes HTTPS requests to a group of load-balanced servers behind a virtual IP address. This page describes the issue, workarounds for the issue, and our future plans for handling the issue.
 
-The behavior described in this page was identified in [SERVER-207](https://tickets.puppetlabs.com/browse/SERVER-207).
+The behavior described in this page was identified in [SERVER-207](https://tickets.puppet.com/browse/SERVER-207).
 
 ## Summary of the Problem
 
@@ -51,12 +52,12 @@ The use of the `allowUnsafeServerCertChange` property is documented in
 
 We're considering optional settings to turn off SSL session caching for Puppet Server's client requests or for the Jetty server when hosting Puppet Server or PuppetDB. Several JIRA tickets have been filed to cover this work:
 
-* [TK-124](https://tickets.puppetlabs.com/browse/TK-124): Disable SSL session
+* [TK-124](https://tickets.puppet.com/browse/TK-124): Disable SSL session
   caching in the Jetty server
-* [TK-125](https://tickets.puppetlabs.com/browse/TK-125): Disable SSL session
+* [TK-125](https://tickets.puppet.com/browse/TK-125): Disable SSL session
   caching in the clj-http-client library that Puppet Server uses to make its
   client requests
-* [SERVER-216](https://tickets.puppetlabs.com/browse/SERVER-216): Utilize work
+* [SERVER-216](https://tickets.puppet.com/browse/SERVER-216): Utilize work
   in TK-125 to allow SSL session caching to be disabled for Puppet Server client
   requests.
 


### PR DESCRIPTION
Updates links in documentation and references to Puppet Labs.