### PR TITLE
(maint) Conditionally set always_cache_features

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -2,14 +2,11 @@ require 'puppet/server/puppet_config'
 
 describe 'Puppet::Server::PuppetConfig' do
   context "When puppet has had settings initialized" do
-    before :each do
-      mock_puppet_config = {}
-      Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
-    end
-
     describe "the puppet log level (Puppet[:log_level])" do
       subject { Puppet[:log_level] }
       it 'is set to debug (the highest) so messages make it to logback' do
+        mock_puppet_config = {}
+        Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
         expect(subject).to eq('debug')
       end
     end
@@ -17,6 +14,8 @@ describe 'Puppet::Server::PuppetConfig' do
     describe "the puppet log level (Puppet::Util::Log.level)" do
       subject { Puppet::Util::Log.level }
       it 'is set to debug (the highest) so messages make it to logback' do
+        mock_puppet_config = {}
+        Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
         expect(subject).to eq(:debug)
       end
     end
@@ -24,6 +23,9 @@ describe 'Puppet::Server::PuppetConfig' do
     describe '(SERVER-410) Puppet[:always_cache_features]' do
       subject { Puppet[:always_cache_features] }
       it 'is true for increased performance in puppet-server' do
+        mock_puppet_config = {}
+        Puppet.settings.expects(:setting).with('always_retry_plugins').returns(nil)
+        Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
         expect(subject).to eq(true)
       end
     end
@@ -31,6 +33,8 @@ describe 'Puppet::Server::PuppetConfig' do
     describe '(PUP-5482) Puppet[:always_retry_plugins]' do
       subject { Puppet[:always_retry_plugins] }
       it 'is false for increased performance in puppet-server' do
+        mock_puppet_config = {}
+        Puppet::Server::PuppetConfig.initialize_puppet(mock_puppet_config)
         expect(subject).to eq(false)
       end
     end

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -21,6 +21,9 @@ class Puppet::Server::PuppetConfig
     )
     Puppet[:trace] = true
 
+    # This conditional can be replaced with just setting always_retry_plugins
+    # once puppetserver depends on a version of puppet that has that setting
+    # available.
     if Puppet.settings.setting('always_retry_plugins')
       Puppet[:always_retry_plugins] = false
     else

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -21,12 +21,12 @@ class Puppet::Server::PuppetConfig
     )
     Puppet[:trace] = true
 
-    # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
-    # the cache is intended for agents to reload features mid-catalog-run.
-    Puppet[:always_cache_features] = true
-
     if Puppet.settings.setting('always_retry_plugins')
       Puppet[:always_retry_plugins] = false
+    else
+      # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
+      # the cache is intended for agents to reload features mid-catalog-run.
+      Puppet[:always_cache_features] = true
     end
 
     # Crank Puppet's log level all the way up and just control it via logback.


### PR DESCRIPTION
The new always_retry_plugins replaces always_cache_features, which will
be deprecated in the next minor release of puppet. To avoid deprecation
warnings, this commit updates Puppet::Server::PuppetConfig to only set
always_cache_features if always_retry_plugins is unavailable.