### PR TITLE
(maint) Update puppet-agent version

### DIFF
--- a/acceptance/lib/helper.rb
+++ b/acceptance/lib/helper.rb
@@ -30,7 +30,7 @@ module PuppetServerExtensions
     puppet_build_version = get_option_value(options[:puppet_build_version],
                          nil, "Puppet Agent Development Build Version",
                          "PUPPET_BUILD_VERSION",
-                         "4d2719050bc69451bc18652add734bf63db94062", :string)
+                         "192cd8fa98c5458d00b189787920a6f526cc736d", :string)
 
     # puppetdb version corresponds to packaged development version located at:
     # http://builds.delivery.puppetlabs.net/puppetdb/


### PR DESCRIPTION
This commit updates the puppet-agent version used for acceptance testing
to include the OID work that was recently merged into puppet.