### PR TITLE
(maint) Don't set always_cache_features in puppet_config

### DIFF
--- a/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
+++ b/spec/puppet-server-lib/puppet/jvm/puppet_config_spec.rb
@@ -21,13 +21,6 @@ describe 'Puppet::Server::PuppetConfig' do
       end
     end
 
-    describe '(SERVER-410) Puppet[:always_cache_features]' do
-      subject { Puppet[:always_cache_features] }
-      it 'is true for increased performance in puppet-server' do
-        expect(subject).to eq(true)
-      end
-    end
-
     describe '(PUP-5482) Puppet[:always_retry_plugins]' do
       subject { Puppet[:always_retry_plugins] }
       it 'is false for increased performance in puppet-server' do

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -23,7 +23,8 @@ class Puppet::Server::PuppetConfig
 
     # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
     # the cache is intended for agents to reload features mid-catalog-run.
-    # As of (PUP-5482) always_retry_plugins includes always_cache_features.
+    # As of (PUP-5482) setting always_retry_plugins to false implies that
+    # features will always be cached.
     if Puppet.settings.setting('always_retry_plugins')
       Puppet[:always_retry_plugins] = false
     end

--- a/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
+++ b/src/ruby/puppet-server-lib/puppet/server/puppet_config.rb
@@ -23,8 +23,7 @@ class Puppet::Server::PuppetConfig
 
     # (SERVER-410) Cache features in puppetserver for performance.  Avoiding
     # the cache is intended for agents to reload features mid-catalog-run.
-    Puppet[:always_cache_features] = true
-
+    # As of (PUP-5482) always_retry_plugins includes always_cache_features.
     if Puppet.settings.setting('always_retry_plugins')
       Puppet[:always_retry_plugins] = false
     end


### PR DESCRIPTION
The new always_retry_plugins setting includes always_cache_features, and
setting always_cache_features now generates an unsightly deprecation
warning, so this commit removes that setting from puppet_config.